### PR TITLE
chore: use sync `fs` api instead of async `fs/promises`

### DIFF
--- a/packages/core/adder/postconditions.ts
+++ b/packages/core/adder/postconditions.ts
@@ -1,3 +1,4 @@
+import dedent from 'dedent';
 import * as pc from 'picocolors';
 import { messagePrompt } from '../utils/prompts';
 import { fileExistsWorkspace, readFile } from '../files/utils';
@@ -7,12 +8,12 @@ import type { OptionDefinition } from './options';
 
 export type PreconditionParameters<Args extends OptionDefinition> = {
 	workspace: Workspace<Args>;
-	fileExists: (path: string) => Promise<void>;
-	fileContains: (path: string, expectedContent: string) => Promise<void>;
+	fileExists: (path: string) => void;
+	fileContains: (path: string, expectedContent: string) => void;
 };
 export type Postcondition<Args extends OptionDefinition> = {
 	name: string;
-	run: (params: PreconditionParameters<Args>) => Promise<void>;
+	run: (params: PreconditionParameters<Args>) => Promise<void> | void;
 };
 
 export async function checkPostconditions<Args extends OptionDefinition>(
@@ -41,20 +42,20 @@ export async function checkPostconditions<Args extends OptionDefinition>(
 	return unmetPostconditions;
 }
 
-async function fileExists<Args extends OptionDefinition>(path: string, workspace: Workspace<Args>) {
-	if (await fileExistsWorkspace(workspace, path)) return;
+function fileExists<Args extends OptionDefinition>(path: string, workspace: Workspace<Args>) {
+	if (fileExistsWorkspace(workspace, path)) return;
 
 	throw new Error(`File "${path}" does not exists`);
 }
 
-async function fileContains<Args extends OptionDefinition>(
+function fileContains<Args extends OptionDefinition>(
 	path: string,
 	workspace: Workspace<Args>,
 	expectedContent: string
-): Promise<void> {
-	await fileExists(path, workspace);
+): void {
+	fileExists(path, workspace);
 
-	const content = await readFile(workspace, path);
+	const content = readFile(workspace, path);
 	if (content && content.includes(expectedContent)) return;
 
 	throw new Error(`File "${path}" does not contain "${expectedContent}"`);
@@ -62,8 +63,11 @@ async function fileContains<Args extends OptionDefinition>(
 
 export function printUnmetPostconditions(unmetPostconditions: string[]): void {
 	const postconditionList = unmetPostconditions.map((x) => pc.yellow(`- ${x}`)).join('\n');
-	const additionalText = `Postconditions are not supposed to fail.
-Please open an issue providing the full console output:
-https://github.com/sveltejs/cli/issues/new/choose`;
+	const additionalText = dedent`
+		Postconditions are not supposed to fail.
+		Please open an issue providing the full console output:
+		https://github.com/sveltejs/cli/issues/new/choose
+	`;
+
 	messagePrompt('Postconditions not met', `${postconditionList}\n\n${additionalText}`);
 }

--- a/packages/core/adder/preconditions.ts
+++ b/packages/core/adder/preconditions.ts
@@ -1,10 +1,9 @@
 import * as pc from 'picocolors';
 import { booleanPrompt, endPrompts, messagePrompt } from '../utils/prompts';
 import { executeCli } from '../utils/cli';
-import type { AdderDetails } from './execute';
+import type { AdderDetails, ProjectType } from './execute';
 import type { Precondition } from './config';
 import type { OptionDefinition } from './options';
-import type { ProjectType } from '../utils/create-project';
 
 function getGlobalPreconditions<Args extends OptionDefinition>(
 	executingCli: string,

--- a/packages/core/files/processors.ts
+++ b/packages/core/files/processors.ts
@@ -86,10 +86,10 @@ export type FileTypes<Args extends OptionDefinition> =
  * @param workspace
  * @returns a list of paths of changed or created files
  */
-export async function createOrUpdateFiles<Args extends OptionDefinition>(
+export function createOrUpdateFiles<Args extends OptionDefinition>(
 	files: Array<FileTypes<Args>>,
 	workspace: Workspace<Args>
-): Promise<string[]> {
+): string[] {
 	const changedFiles = [];
 	for (const fileDetails of files) {
 		try {
@@ -97,13 +97,13 @@ export async function createOrUpdateFiles<Args extends OptionDefinition>(
 				continue;
 			}
 
-			const exists = await fileExistsWorkspace(workspace, fileDetails.name(workspace));
+			const exists = fileExistsWorkspace(workspace, fileDetails.name(workspace));
 
 			let content = '';
 			if (!exists) {
 				content = '';
 			} else {
-				content = await readFile(workspace, fileDetails.name(workspace));
+				content = readFile(workspace, fileDetails.name(workspace));
 			}
 
 			if (fileDetails.contentType == 'script') {
@@ -120,7 +120,7 @@ export async function createOrUpdateFiles<Args extends OptionDefinition>(
 				content = handleHtmlFile(content, fileDetails, workspace);
 			}
 
-			await writeFile(workspace, fileDetails.name(workspace), content);
+			writeFile(workspace, fileDetails.name(workspace), content);
 			changedFiles.push(fileDetails.name(workspace));
 		} catch (e) {
 			if (e instanceof Error)

--- a/packages/core/utils/common.ts
+++ b/packages/core/utils/common.ts
@@ -12,11 +12,11 @@ export type Package = {
 	keywords?: string[];
 };
 
-export async function getPackageJson(workspace: WorkspaceWithoutExplicitArgs): Promise<{
+export function getPackageJson(workspace: WorkspaceWithoutExplicitArgs): {
 	text: string;
 	data: Package;
-}> {
-	const packageText = await readFile(workspace, commonFilePaths.packageJsonFilePath);
+} {
+	const packageText = readFile(workspace, commonFilePaths.packageJsonFilePath);
 	if (!packageText) {
 		return {
 			text: '',

--- a/packages/core/utils/create-project.ts
+++ b/packages/core/utils/create-project.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import * as p from './prompts';
-import { commonFilePaths, directoryExists, fileExists } from '../files/utils';
+import { commonFilePaths } from '../files/utils';
 import { getPackageJson } from './common';
 import { createEmptyWorkspace } from './workspace';
 import { spinner } from '@svelte-cli/clack-prompts';
@@ -14,21 +14,21 @@ export async function detectSvelteDirectory(directoryPath: string): Promise<stri
 	const parentDirectoryPath = path.normalize(path.join(directoryPath, '..'));
 	const isRoot = parentDirectoryPath == directoryPath;
 
-	if (!isRoot && !(await directoryExists(directoryPath))) {
+	if (!isRoot && !fs.existsSync(directoryPath)) {
 		return await detectSvelteDirectory(parentDirectoryPath);
 	}
 
-	if (!isRoot && !(await fileExists(packageJsonPath))) {
+	if (!isRoot && !fs.existsSync(packageJsonPath)) {
 		return await detectSvelteDirectory(parentDirectoryPath);
 	}
 
-	if (isRoot && !(await fileExists(packageJsonPath))) {
+	if (isRoot && !fs.existsSync(packageJsonPath)) {
 		return null;
 	}
 
 	const emptyWorkspace = createEmptyWorkspace();
 	emptyWorkspace.cwd = directoryPath;
-	const { data: packageJson } = await getPackageJson(emptyWorkspace);
+	const { data: packageJson } = getPackageJson(emptyWorkspace);
 
 	if (packageJson.devDependencies && 'svelte' in packageJson.devDependencies) {
 		return directoryPath;


### PR DESCRIPTION
This one scratches an itch that i've had for a while. 

We're using `fs/promises` for nearly all `fs` operations when we're not even using them in such a way that takes advantage of their non-blocking nature. Instead, we're just blocking on every fs operation anyway (which is completely fine for our purposes). In reality, using the async variant of this api is just needlessly forcing us to color every parent function

this pr switches all of them to their sync variant