### PR TITLE
chore: publish all packages for previews

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -39,5 +39,6 @@ jobs:
         if: ${{ steps.changed-files.outputs.all_changed_files_count > 0 }}
         env:
           CHANGED_DIRS: ${{ steps.changed-files.outputs.all_changed_files }}
-        run: |
-          node scripts/get-deps-to-publish.js
+        # run: |
+        #   node scripts/get-deps-to-publish.js
+        run: pnpm dlx pkg-pr-new@0.0 publish --pnpm './packages/*'


### PR DESCRIPTION
we use [a script](https://github.com/sveltejs/cli/blob/main/scripts/get-deps-to-publish.js) to only publish package previews for modified packages and their dependents. this would normally be fine if our packages were already published to the npm registry as they would have access to their fallbacks, but since that's not the case, we're often met with this error if we wanted to test out the cli via `pkg.pr.new`:
```
$ npx https://pkg.pr.new/sveltejs/cli/sv@11 add
Need to install the following packages:
https://pkg.pr.new/sveltejs/cli/sv@11
Ok to proceed? (y) 

npm error code E404
npm error 404 Not Found - GET https://registry.npmjs.org/@svelte-cli%2fast-manipulation - Not found
```

as a temporary fix, (until we either [switch to rolldown](https://github.com/sveltejs/cli/pull/11) where we'll start bundling everything into a single package, or begin publishing our packages to npm), we'll just have `pkg.pr.new` publish all of our non-privated packages on every run.