### PR TITLE
fix: update prettier plugin to latest

### DIFF
--- a/packages/adders/prettier/config/adder.ts
+++ b/packages/adders/prettier/config/adder.ts
@@ -18,7 +18,7 @@ export const adder = defineAdderConfig({
 	integrationType: 'inline',
 	packages: [
 		{ name: 'prettier', version: '^3.3.2', dev: true },
-		{ name: 'prettier-plugin-svelte', version: '^3.2.5', dev: true },
+		{ name: 'prettier-plugin-svelte', version: '^3.2.6', dev: true },
 		{
 			name: 'eslint-config-prettier',
 			version: '^9.1.0',


### PR DESCRIPTION
The Svelte 5 migration tool will bump users to this version, so I'm assuming there's something in it that's necessary for Svelte 5 support

Mostly I just want to test pkg.pr.new :wink: 