### PR TITLE
chore: unpin storybook

### DIFF
--- a/packages/adders/storybook/config/adder.ts
+++ b/packages/adders/storybook/config/adder.ts
@@ -23,5 +23,5 @@ export const adder = defineAdderConfig({
 
 	options,
 	integrationType: 'external',
-	command: 'storybook@8.3.0-alpha.3 init --skip-install --no-dev'
+	command: 'storybook@latest init --skip-install --no-dev'
 });


### PR DESCRIPTION
Storybook fixed `--skip-install` and it works on the official releases now! https://github.com/storybookjs/storybook/releases/tag/v8.3.2