### PR TITLE
fix: find up

### DIFF
--- a/packages/core/files/utils.ts
+++ b/packages/core/files/utils.ts
@@ -130,6 +130,8 @@ export const commonFilePaths = {
 } as const;
 
 export function findUp(searchPath: string, fileName: string, maxDepth = -1): string | undefined {
+	searchPath = path.join(process.cwd(), searchPath);
+
 	// partially sourced from https://github.com/privatenumber/get-tsconfig/blob/9e78ec52d450d58743439358dd88e2066109743f/src/utils/find-up.ts#L5
 	let depth = 0;
 	while (maxDepth < 0 || depth < maxDepth) {


### PR DESCRIPTION
Let's face this:
`findUp('../svelte-cli', 'tsconfig.json')`

This will search currently search the following paths'
```
../svelte-cli/tsconfig.json
../tsconfig.json
tsconfig.json
```

which is absolutely not what we want. After this change it will look like this:
```
D:/dev/web/svelte-cli-temp/tsconfig.json
D:/dev/web/tsconfig.json
D:/dev/tsconfig.json
D:/tsconfig.json
```