### PR TITLE
chore: remove checks files

### DIFF
--- a/community-adder-template/src/config/checks.js
+++ b/community-adder-template/src/config/checks.js
@@ -1,6 +1,0 @@
-import { defineAdderChecks } from '@svelte-cli/core';
-import { options } from './options.js';
-
-export const checks = defineAdderChecks({
-	options
-});

--- a/community-adder-template/src/index.js
+++ b/community-adder-template/src/index.js
@@ -1,6 +1,5 @@
 import { defineAdder } from '@svelte-cli/core';
 import { adder } from './config/adder.js';
-import { checks } from './config/checks.js';
 import { tests } from './config/tests.js';
 
-export default defineAdder(adder, checks, tests);
+export default defineAdder(adder, tests);

--- a/packages/adders/drizzle/config/checks.ts
+++ b/packages/adders/drizzle/config/checks.ts
@@ -1,6 +1,0 @@
-import { defineAdderChecks } from '@svelte-cli/core';
-import { options } from './options.ts';
-
-export const checks = defineAdderChecks({
-	options
-});

--- a/packages/adders/drizzle/index.ts
+++ b/packages/adders/drizzle/index.ts
@@ -1,6 +1,5 @@
 import { defineAdder } from '@svelte-cli/core';
 import { adder } from './config/adder.ts';
-import { checks } from './config/checks.ts';
 import { tests } from './config/tests.ts';
 
-export default defineAdder(adder, checks, tests);
+export default defineAdder(adder, tests);

--- a/packages/adders/eslint/config/checks.ts
+++ b/packages/adders/eslint/config/checks.ts
@@ -1,6 +1,0 @@
-import { defineAdderChecks } from '@svelte-cli/core';
-import { options } from './options.ts';
-
-export const checks = defineAdderChecks({
-	options
-});

--- a/packages/adders/eslint/index.ts
+++ b/packages/adders/eslint/index.ts
@@ -1,6 +1,5 @@
 import { defineAdder } from '@svelte-cli/core';
 import { adder } from './config/adder.ts';
-import { checks } from './config/checks.ts';
 import { tests } from './config/tests.ts';
 
-export default defineAdder(adder, checks, tests);
+export default defineAdder(adder, tests);

--- a/packages/adders/lucia/config/checks.ts
+++ b/packages/adders/lucia/config/checks.ts
@@ -1,4 +1,0 @@
-import { defineAdderChecks } from '@svelte-cli/core';
-import { options } from './options.ts';
-
-export const checks = defineAdderChecks({ options });

--- a/packages/adders/lucia/index.ts
+++ b/packages/adders/lucia/index.ts
@@ -1,6 +1,5 @@
 import { defineAdder } from '@svelte-cli/core';
 import { adder } from './config/adder.ts';
-import { checks } from './config/checks.ts';
 import { tests } from './config/tests.ts';
 
-export default defineAdder(adder, checks, tests);
+export default defineAdder(adder, tests);

--- a/packages/adders/mdsvex/config/checks.ts
+++ b/packages/adders/mdsvex/config/checks.ts
@@ -1,6 +1,0 @@
-import { defineAdderChecks } from '@svelte-cli/core';
-import { options } from './options.ts';
-
-export const checks = defineAdderChecks({
-	options
-});

--- a/packages/adders/mdsvex/index.ts
+++ b/packages/adders/mdsvex/index.ts
@@ -1,6 +1,5 @@
 import { defineAdder } from '@svelte-cli/core';
 import { adder } from './config/adder.ts';
 import { tests } from './config/tests.ts';
-import { checks } from './config/checks.ts';
 
-export default defineAdder(adder, checks, tests);
+export default defineAdder(adder, tests);

--- a/packages/adders/playwright/config/checks.ts
+++ b/packages/adders/playwright/config/checks.ts
@@ -1,6 +1,0 @@
-import { defineAdderChecks } from '@svelte-cli/core';
-import { options } from './options.ts';
-
-export const checks = defineAdderChecks({
-	options
-});

--- a/packages/adders/playwright/index.ts
+++ b/packages/adders/playwright/index.ts
@@ -1,6 +1,5 @@
 import { defineAdder } from '@svelte-cli/core';
 import { adder } from './config/adder.ts';
-import { checks } from './config/checks.ts';
 import { tests } from './config/tests.ts';
 
-export default defineAdder(adder, checks, tests);
+export default defineAdder(adder, tests);

--- a/packages/adders/prettier/config/checks.ts
+++ b/packages/adders/prettier/config/checks.ts
@@ -1,6 +1,0 @@
-import { defineAdderChecks } from '@svelte-cli/core';
-import { options } from './options.ts';
-
-export const checks = defineAdderChecks({
-	options
-});

--- a/packages/adders/prettier/index.ts
+++ b/packages/adders/prettier/index.ts
@@ -1,6 +1,5 @@
 import { defineAdder } from '@svelte-cli/core';
 import { adder } from './config/adder.ts';
-import { checks } from './config/checks.ts';
 import { tests } from './config/tests.ts';
 
-export default defineAdder(adder, checks, tests);
+export default defineAdder(adder, tests);

--- a/packages/adders/routify/config/checks.ts
+++ b/packages/adders/routify/config/checks.ts
@@ -1,6 +1,0 @@
-import { defineAdderChecks } from '@svelte-cli/core';
-import { options } from './options.ts';
-
-export const checks = defineAdderChecks({
-	options
-});

--- a/packages/adders/routify/index.ts
+++ b/packages/adders/routify/index.ts
@@ -1,6 +1,5 @@
 import { defineAdder } from '@svelte-cli/core';
 import { adder } from './config/adder.ts';
 import { tests } from './config/tests.ts';
-import { checks } from './config/checks.ts';
 
-export default defineAdder(adder, checks, tests);
+export default defineAdder(adder, tests);

--- a/packages/adders/storybook/config/checks.ts
+++ b/packages/adders/storybook/config/checks.ts
@@ -1,6 +1,0 @@
-import { defineAdderChecks } from '@svelte-cli/core';
-import { options } from './options.ts';
-
-export const checks = defineAdderChecks({
-	options
-});

--- a/packages/adders/storybook/index.ts
+++ b/packages/adders/storybook/index.ts
@@ -1,6 +1,5 @@
 import { defineAdder } from '@svelte-cli/core';
 import { adder } from './config/adder.ts';
 import { tests } from './config/tests.ts';
-import { checks } from './config/checks.ts';
 
-export default defineAdder(adder, checks, tests);
+export default defineAdder(adder, tests);

--- a/packages/adders/tailwindcss/config/checks.ts
+++ b/packages/adders/tailwindcss/config/checks.ts
@@ -1,6 +1,0 @@
-import { defineAdderChecks } from '@svelte-cli/core';
-import { options } from './options.ts';
-
-export const checks = defineAdderChecks({
-	options
-});

--- a/packages/adders/tailwindcss/index.ts
+++ b/packages/adders/tailwindcss/index.ts
@@ -1,6 +1,5 @@
 import { defineAdder } from '@svelte-cli/core';
 import { adder } from './config/adder.ts';
-import { checks } from './config/checks.ts';
 import { tests } from './config/tests.ts';
 
-export default defineAdder(adder, checks, tests);
+export default defineAdder(adder, tests);

--- a/packages/adders/vitest/config/checks.ts
+++ b/packages/adders/vitest/config/checks.ts
@@ -1,6 +1,0 @@
-import { defineAdderChecks } from '@svelte-cli/core';
-import { options } from './options.ts';
-
-export const checks = defineAdderChecks({
-	options
-});

--- a/packages/adders/vitest/index.ts
+++ b/packages/adders/vitest/index.ts
@@ -1,6 +1,5 @@
 import { defineAdder } from '@svelte-cli/core';
 import { adder } from './config/adder.ts';
-import { checks } from './config/checks.ts';
 import { tests } from './config/tests.ts';
 
-export default defineAdder(adder, checks, tests);
+export default defineAdder(adder, tests);

--- a/packages/cli/commands/add.ts
+++ b/packages/cli/commands/add.ts
@@ -360,7 +360,7 @@ export async function runAddCommand(options: Options, adders: string[]): Promise
 	// run precondition checks
 	if (options.preconditions) {
 		const preconditions = selectedAdders
-			.flatMap(({ adder }) => adder.checks.preconditions)
+			.flatMap(({ adder }) => adder.config.preconditions)
 			.filter((p) => p !== undefined);
 
 		// add global checks

--- a/packages/core/adder/config.ts
+++ b/packages/core/adder/config.ts
@@ -48,6 +48,7 @@ export type AdderConfig<Args extends OptionDefinition> = {
 	packages: Array<PackageDefinition<Args>>;
 	scripts?: Array<Scripts<Args>>;
 	files: Array<FileType<Args>>;
+	preconditions?: Precondition[];
 	nextSteps?: (
 		data: {
 			highlighter: Highlighter;
@@ -71,7 +72,6 @@ export function defineAdderConfig<Args extends OptionDefinition>(
 
 export type Adder<Args extends OptionDefinition> = {
 	config: AdderConfig<Args>;
-	checks: AdderCheckConfig<Args>;
 	tests?: AdderTestConfig<Args>;
 };
 
@@ -80,10 +80,9 @@ export type AdderConfigWithoutExplicitArgs = AdderConfig<Record<string, Question
 
 export function defineAdder<Args extends OptionDefinition>(
 	config: AdderConfig<Args>,
-	checks: AdderCheckConfig<Args>,
 	tests?: AdderTestConfig<Args>
 ): Adder<Args> {
-	const adder: Adder<Args> = { config, checks, tests };
+	const adder: Adder<Args> = { config, tests };
 	return adder;
 }
 
@@ -125,14 +124,3 @@ export type Precondition = {
 	name: string;
 	run: () => MaybePromise<{ success: boolean; message: string | undefined }>;
 };
-
-export type AdderCheckConfig<Args extends OptionDefinition> = {
-	options: Args;
-	preconditions?: Precondition[];
-};
-
-export function defineAdderChecks<Args extends OptionDefinition>(
-	checks: AdderCheckConfig<Args>
-): AdderCheckConfig<Args> {
-	return checks;
-}

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -2,8 +2,7 @@ export {
 	defineAdderConfig,
 	defineAdderTests,
 	defineAdder,
-	defineAdderOptions,
-	defineAdderChecks
+	defineAdderOptions
 } from './adder/config.ts';
 export { log } from '@svelte-cli/clack-prompts';
 export { default as colors } from 'picocolors';


### PR DESCRIPTION
Moved `preconditions` into the `config`, which simplifies the amount of code needed to create an adder