### PR TITLE
chore: remove runsAfter

### DIFF
--- a/packages/adders/lucia/config/adder.ts
+++ b/packages/adders/lucia/config/adder.ts
@@ -47,7 +47,6 @@ export const adder = defineAdder({
 			dev: false
 		}
 	],
-	runsAfter: ['drizzle'],
 	dependsOn: ['drizzle'],
 	files: [
 		{

--- a/packages/cli/commands/add/index.ts
+++ b/packages/cli/commands/add/index.ts
@@ -530,10 +530,10 @@ export async function installAdders({
 	// and adders with dependencies runs later on, based on the adders they depend on.
 	// based on https://stackoverflow.com/a/72030336/16075084
 	details.sort((a, b) => {
-		if (!a.runsAfter) return -1;
-		if (!b.runsAfter) return 1;
+		if (!a.dependsOn) return -1;
+		if (!b.dependsOn) return 1;
 
-		return a.runsAfter.includes(b.metadata.id) ? 1 : b.runsAfter.includes(a.metadata.id) ? -1 : 0;
+		return a.dependsOn.includes(b.metadata.id) ? 1 : b.dependsOn.includes(a.metadata.id) ? -1 : 0;
 	});
 
 	// apply adders

--- a/packages/core/adder/config.ts
+++ b/packages/core/adder/config.ts
@@ -43,7 +43,6 @@ export type Scripts<Args extends OptionDefinition> = {
 export type Adder<Args extends OptionDefinition> = {
 	metadata: AdderConfigMetadata;
 	options: Args;
-	runsAfter?: string[];
 	dependsOn?: string[];
 	packages: Array<PackageDefinition<Args>>;
 	scripts?: Array<Scripts<Args>>;


### PR DESCRIPTION
continuing to incrementally tackle https://github.com/sveltejs/cli/issues/85

`runsAfter` seems like it's a duplicate of `dependsOn` and we can just use one of the two