### PR TITLE
chore: remove adder preconditions

### DIFF
--- a/packages/cli/commands/add/index.ts
+++ b/packages/cli/commands/add/index.ts
@@ -355,16 +355,11 @@ export async function runAddCommand(options: Options, adders: string[]): Promise
 
 	// run precondition checks
 	if (options.preconditions) {
-		const preconditions = selectedAdders
-			.flatMap(({ adder }) => adder.preconditions)
-			.filter((p) => p !== undefined);
-
 		// add global checks
 		const { kit } = createWorkspace(options.cwd);
 		const projectType = kit ? 'kit' : 'svelte';
 		const adders = selectedAdders.map(({ adder }) => adder);
-		const globalPreconditions = common.getGlobalPreconditions(options.cwd, projectType, adders);
-		preconditions.unshift(...globalPreconditions.preconditions);
+		const { preconditions } = common.getGlobalPreconditions(options.cwd, projectType, adders);
 
 		const fails: Array<{ name: string; message?: string }> = [];
 		for (const condition of preconditions) {

--- a/packages/core/adder/config.ts
+++ b/packages/core/adder/config.ts
@@ -48,7 +48,6 @@ export type Adder<Args extends OptionDefinition> = {
 	packages: Array<PackageDefinition<Args>>;
 	scripts?: Array<Scripts<Args>>;
 	files: Array<FileType<Args>>;
-	preconditions?: Precondition[];
 	nextSteps?: (
 		data: {
 			highlighter: Highlighter;


### PR DESCRIPTION
continuing on with https://github.com/sveltejs/cli/issues/85

`preconditions` is unused. We only have the global preconditions. Let's remove it for now to give ourselves more freedom. We can always add new APIs as they are needed in the future, but removing them is very difficult