### PR TITLE
chore(DRAFT): use `acorn`, `estree` and `esrap`

### DIFF
--- a/packages/adders/drizzle/index.ts
+++ b/packages/adders/drizzle/index.ts
@@ -229,8 +229,8 @@ export default defineAdder({
 						url: common.expressionFromString('process.env.DATABASE_URL'),
 						authToken
 					}),
-					verbose: { type: 'BooleanLiteral', value: true },
-					strict: { type: 'BooleanLiteral', value: true },
+					verbose: { type: 'Literal', value: true },
+					strict: { type: 'Literal', value: true },
 					driver
 				});
 

--- a/packages/adders/eslint/index.ts
+++ b/packages/adders/eslint/index.ts
@@ -9,7 +9,6 @@ import {
 	functions,
 	imports,
 	object,
-	type AstKinds,
 	type AstTypes
 } from '@sveltejs/cli-core/js';
 import { parseJson, parseScript } from '@sveltejs/cli-core/parsers';
@@ -71,7 +70,7 @@ export default defineAdder({
 				const { ast, generateCode } = parseScript(content);
 
 				const eslintConfigs: Array<
-					AstKinds.ExpressionKind | AstTypes.SpreadElement | AstTypes.ObjectExpression
+					AstTypes.Expression | AstTypes.SpreadElement | AstTypes.ObjectExpression
 				> = [];
 
 				const jsConfig = common.expressionFromString('js.configs.recommended');

--- a/packages/adders/lucia/index.ts
+++ b/packages/adders/lucia/index.ts
@@ -61,17 +61,17 @@ export default defineAdder({
 			name: ({ typescript }) => `drizzle.config.${typescript ? 'ts' : 'js'}`,
 			content: ({ content }) => {
 				const { ast, generateCode } = parseScript(content);
-				const isProp = (name: string, node: AstTypes.ObjectProperty) =>
+				const isProp = (name: string, node: AstTypes.Property) =>
 					node.key.type === 'Identifier' && node.key.name === name;
 
 				// prettier-ignore
-				Walker.walk(ast as AstTypes.ASTNode, {}, {
-					ObjectProperty(node) {
-						if (isProp('dialect', node) && node.value.type === 'StringLiteral') {
+				Walker.walk(ast as AstTypes.Node, {}, {
+					Property(node) {
+						if (isProp('dialect', node) && node.value.type === 'Literal') {
 							drizzleDialect = node.value.value as Dialect;
 						}
-						if (isProp('schema', node) && node.value.type === 'StringLiteral') {
-							schemaPath = node.value.value;
+						if (isProp('schema', node) && node.value.type === 'Literal') {
+							schemaPath = node.value.value as string;
 						}
 					}
 				})
@@ -549,6 +549,7 @@ function createLuciaType(name: string): AstTypes.TSInterfaceBody['body'][number]
 			type: 'Identifier',
 			name
 		},
+		computed: false,
 		typeAnnotation: {
 			type: 'TSTypeAnnotation',
 			typeAnnotation: {
@@ -556,7 +557,7 @@ function createLuciaType(name: string): AstTypes.TSInterfaceBody['body'][number]
 				types: [
 					{
 						type: 'TSImportType',
-						argument: { type: 'StringLiteral', value: 'lucia' },
+						argument: { type: 'Literal', value: 'lucia' },
 						qualifier: {
 							type: 'Identifier',
 							// capitalize first letter
@@ -603,7 +604,7 @@ function getAuthHandleContent() {
 		};`;
 }
 
-function getCallExpression(ast: AstTypes.ASTNode): AstTypes.CallExpression | undefined {
+function getCallExpression(ast: AstTypes.Node): AstTypes.CallExpression | undefined {
 	let callExpression;
 
 	// prettier-ignore

--- a/packages/adders/vitest/index.ts
+++ b/packages/adders/vitest/index.ts
@@ -55,7 +55,9 @@ export default defineAdder({
 						importDecl.importKind === 'value' &&
 						importDecl.specifiers?.some(
 							(specifier) =>
-								specifier.type === 'ImportSpecifier' && specifier.imported.name === 'defineConfig'
+								specifier.type === 'ImportSpecifier' &&
+								specifier.imported.type == 'Identifier' &&
+								specifier.imported.name === 'defineConfig'
 						)
 				);
 
@@ -67,7 +69,10 @@ export default defineAdder({
 				} else {
 					// otherwise, just remove the `defineConfig` specifier
 					const idxToRemove = defineConfigImportDecl?.specifiers?.findIndex(
-						(s) => s.type === 'ImportSpecifier' && s.imported.name === 'defineConfig'
+						(specifier) =>
+							specifier.type === 'ImportSpecifier' &&
+							specifier.imported.type == 'Identifier' &&
+							specifier.imported.name === 'defineConfig'
 					);
 					if (idxToRemove) defineConfigImportDecl?.specifiers?.splice(idxToRemove, 1);
 				}
@@ -86,7 +91,10 @@ export default defineAdder({
 				) {
 					// if the previous `defineConfig` was aliased, reuse the alias for the "vitest/config" import
 					const importSpecifier = defineConfigImportDecl?.specifiers?.find(
-						(sp) => sp.type === 'ImportSpecifier' && sp.imported.name === 'defineConfig'
+						(specifier) =>
+							specifier.type === 'ImportSpecifier' &&
+							specifier.imported.type == 'Identifier' &&
+							specifier.imported.name === 'defineConfig'
 					);
 					const defineConfigAlias = importSpecifier?.local?.name ?? 'defineConfig';
 					imports.addNamed(ast, 'vitest/config', { defineConfig: defineConfigAlias });

--- a/packages/ast-tooling/index.ts
+++ b/packages/ast-tooling/index.ts
@@ -15,8 +15,7 @@ import * as fleece from 'silver-fleece';
 import * as Walker from 'zimmerframe';
 import * as acorn from 'acorn';
 import { tsPlugin } from 'acorn-typescript';
-// @ts-expect-error
-import { print as esrapPrint } from 'esrap';
+import { print as esrapPrint } from 'esrap-typescript-temp';
 // todo: why is this file only generated during `dev` startup, if it's prefixed with type?
 import { TsEstree } from './ts-estree.ts';
 

--- a/packages/ast-tooling/package.json
+++ b/packages/ast-tooling/package.json
@@ -25,7 +25,7 @@
 		"dom-serializer": "^2.0.0",
 		"domhandler": "^5.0.3",
 		"domutils": "^3.1.0",
-		"esrap": "^1.2.2",
+		"esrap-typescript-temp": "^0.0.1",
 		"htmlparser2": "^9.1.0",
 		"postcss": "^8.4.38",
 		"silver-fleece": "^1.1.0",
@@ -36,5 +36,5 @@
 		"type": "git",
 		"url": "https://github.com/sveltejs/cli/tree/main/packages/ast-tooling"
 	},
-	"keywords": []
+	"keywords": [ ]
 }

--- a/packages/ast-tooling/package.json
+++ b/packages/ast-tooling/package.json
@@ -36,5 +36,5 @@
 		"type": "git",
 		"url": "https://github.com/sveltejs/cli/tree/main/packages/ast-tooling"
 	},
-	"keywords": [ ]
+	"keywords": []
 }

--- a/packages/ast-tooling/package.json
+++ b/packages/ast-tooling/package.json
@@ -19,14 +19,15 @@
 		"dist"
 	],
 	"devDependencies": {
-		"@babel/parser": "^7.24.7",
-		"ast-types": "^0.14.2",
+		"@types/estree": "^1.0.6",
+		"acorn": "^8.12.1",
+		"acorn-typescript": "^1.4.13",
 		"dom-serializer": "^2.0.0",
 		"domhandler": "^5.0.3",
 		"domutils": "^3.1.0",
+		"esrap": "^1.2.2",
 		"htmlparser2": "^9.1.0",
 		"postcss": "^8.4.38",
-		"recast": "^0.23.7",
 		"silver-fleece": "^1.1.0",
 		"zimmerframe": "^1.1.2"
 	},

--- a/packages/ast-tooling/ts-estree.ts
+++ b/packages/ast-tooling/ts-estree.ts
@@ -1,0 +1,79 @@
+import type * as estree from 'estree';
+
+declare module 'estree' {
+	// new types
+	interface TSTypeAnnotation {
+		type: 'TSTypeAnnotation';
+		typeAnnotation: TSStringKeyword | TSTypeReference | TSUnionType;
+	}
+	interface TSStringKeyword {
+		type: 'TSStringKeyword';
+	}
+	interface TSNullKeyword {
+		type: 'TSNullKeyword';
+	}
+	interface TSTypeReference {
+		type: 'TSTypeReference';
+		typeName: Identifier;
+	}
+	interface TSAsExpression extends BaseNode {
+		type: 'TSAsExpression';
+		expression: Expression;
+		typeAnnotation: TSTypeAnnotation['typeAnnotation'];
+	}
+	interface TSModuleDeclaration extends BaseNode {
+		type: 'TSModuleDeclaration';
+		global: boolean;
+		declare: boolean;
+		id: Identifier;
+		body: TSModuleBlock;
+	}
+	interface TSModuleBlock extends BaseNode {
+		type: 'TSModuleBlock';
+		body: Array<TSModuleDeclaration | TSInterfaceDeclaration>;
+	}
+	interface TSInterfaceDeclaration extends BaseNode {
+		type: 'TSInterfaceDeclaration';
+		id: Identifier;
+		body: TSInterfaceBody;
+	}
+	interface TSInterfaceBody extends BaseNode {
+		type: 'TSInterfaceBody';
+		body: TSPropertySignature[];
+	}
+	interface TSPropertySignature extends BaseNode {
+		type: 'TSPropertySignature';
+		computed: boolean;
+		key: Identifier;
+		typeAnnotation: TSTypeAnnotation;
+	}
+	interface TSProgram extends Omit<Program, 'body'> {
+		body: Array<Directive | Statement | ModuleDeclaration | TSModuleDeclaration>;
+	}
+	interface TSUnionType {
+		type: 'TSUnionType';
+		types: Array<TSNullKeyword | TSTypeReference | TSImportType>;
+	}
+	interface TSImportType {
+		type: 'TSImportType';
+		argument: Literal;
+		qualifier: Identifier;
+	}
+
+	// enhanced types
+	interface Identifier {
+		typeAnnotation?: TSTypeAnnotation;
+	}
+	interface ExpressionMap {
+		TSAsExpression: TSAsExpression;
+	}
+	interface NodeMap {
+		TSModuleDeclaration: TSModuleDeclaration;
+		TSInterfaceDeclaration: TSInterfaceDeclaration;
+	}
+	interface ImportDeclaration {
+		importKind: 'type' | 'value';
+	}
+}
+
+export type { estree as TsEstree };

--- a/packages/core/tests/css/common/add-at-rule/run.ts
+++ b/packages/core/tests/css/common/add-at-rule/run.ts
@@ -1,7 +1,7 @@
 import { addAtRule } from '@sveltejs/cli-core/css';
-import type { CssFileEditor } from '@sveltejs/cli-core';
+import type { CssAst } from '@sveltejs/ast-tooling';
 
-export function run({ ast }: CssFileEditor<any>): void {
+export function run(ast: CssAst): void {
 	addAtRule(ast, 'tailwind', "'lib/path/file.ext'", false);
 	addAtRule(ast, 'tailwind', "'lib/path/file1.ext'", true);
 }

--- a/packages/core/tests/css/common/add-comment/run.ts
+++ b/packages/core/tests/css/common/add-comment/run.ts
@@ -1,6 +1,6 @@
 import { addComment } from '@sveltejs/cli-core/css';
-import type { CssFileEditor } from '@sveltejs/cli-core';
+import type { CssAst } from '@sveltejs/ast-tooling';
 
-export function run({ ast }: CssFileEditor<any>): void {
+export function run(ast: CssAst): void {
 	addComment(ast, 'foo comment');
 }

--- a/packages/core/tests/css/common/add-imports/run.ts
+++ b/packages/core/tests/css/common/add-imports/run.ts
@@ -1,6 +1,6 @@
 import { addImports } from '@sveltejs/cli-core/css';
-import type { CssFileEditor } from '@sveltejs/cli-core';
+import type { CssAst } from '@sveltejs/ast-tooling';
 
-export function run({ ast }: CssFileEditor<any>): void {
+export function run(ast: CssAst): void {
 	addImports(ast, ["'lib/path/file.css'"]);
 }

--- a/packages/core/tests/css/common/add-rule/run.ts
+++ b/packages/core/tests/css/common/add-rule/run.ts
@@ -1,7 +1,7 @@
 import { addDeclaration, addRule } from '@sveltejs/cli-core/css';
-import type { CssFileEditor } from '@sveltejs/cli-core';
+import type { CssAst } from '@sveltejs/ast-tooling';
 
-export function run({ ast }: CssFileEditor<any>): void {
+export function run(ast: CssAst): void {
 	const barSelectorRule = addRule(ast, '.bar');
 	addDeclaration(barSelectorRule, 'color', 'blue');
 }

--- a/packages/core/tests/css/index.ts
+++ b/packages/core/tests/css/index.ts
@@ -20,7 +20,7 @@ for (const categoryDirectory of categoryDirectories) {
 
 				// dynamic imports always need to provide the path inline for static analysis
 				const module = await import(`./${categoryDirectory}/${testName}/run.ts`);
-				module.run({ ast });
+				module.run(ast);
 
 				const output = serializeCss(ast);
 				await expect(output).toMatchFileSnapshot(`${testDirectoryPath}/output.css`);

--- a/packages/core/tests/html/common/create-div/run.ts
+++ b/packages/core/tests/html/common/create-div/run.ts
@@ -1,7 +1,6 @@
-import { div, appendElement, insertElement } from '@sveltejs/cli-core/html';
-import type { HtmlFileEditor } from '@sveltejs/cli-core';
+import { div, appendElement, insertElement, type HtmlDocument } from '@sveltejs/cli-core/html';
 
-export function run({ ast }: HtmlFileEditor<any>): void {
+export function run(ast: HtmlDocument): void {
 	const emptyDiv = div();
 	insertElement(ast.childNodes, emptyDiv);
 	appendElement(ast.childNodes, emptyDiv);

--- a/packages/core/tests/html/common/create-element/run.ts
+++ b/packages/core/tests/html/common/create-element/run.ts
@@ -1,7 +1,6 @@
-import { element, appendElement, insertElement } from '@sveltejs/cli-core/html';
-import type { HtmlFileEditor } from '@sveltejs/cli-core';
+import { element, appendElement, insertElement, type HtmlDocument } from '@sveltejs/cli-core/html';
 
-export function run({ ast }: HtmlFileEditor<any>): void {
+export function run(ast: HtmlDocument): void {
 	const emptySpan = element('span');
 	insertElement(ast.childNodes, emptySpan);
 	appendElement(ast.childNodes, emptySpan);

--- a/packages/core/tests/html/common/from-raw/run.ts
+++ b/packages/core/tests/html/common/from-raw/run.ts
@@ -1,6 +1,5 @@
-import { addFromRawHtml } from '@sveltejs/cli-core/html';
-import type { HtmlFileEditor } from '@sveltejs/cli-core';
+import { addFromRawHtml, type HtmlDocument } from '@sveltejs/cli-core/html';
 
-export function run({ ast }: HtmlFileEditor<any>): void {
+export function run(ast: HtmlDocument): void {
 	addFromRawHtml(ast.childNodes, '<div style="display: flex" data-foo="bar">foo</div>');
 }

--- a/packages/core/tests/html/index.ts
+++ b/packages/core/tests/html/index.ts
@@ -20,7 +20,7 @@ for (const categoryDirectory of categoryDirectories) {
 
 				// dynamic imports always need to provide the path inline for static analysis
 				const module = await import(`./${categoryDirectory}/${testName}/run.ts`);
-				module.run({ ast });
+				module.run(ast);
 
 				const output = serializeHtml(ast);
 				await expect(output).toMatchFileSnapshot(`${testDirectoryPath}/output.html`);

--- a/packages/core/tests/js/arrays/empty-array/run.ts
+++ b/packages/core/tests/js/arrays/empty-array/run.ts
@@ -1,7 +1,6 @@
-import { array, variables } from '@sveltejs/cli-core/js';
-import type { ScriptFileEditor } from '@sveltejs/cli-core';
+import { array, variables, type AstTypes } from '@sveltejs/cli-core/js';
 
-export function run({ ast }: ScriptFileEditor<any>): void {
+export function run(ast: AstTypes.Program): void {
 	const emptyArray = array.createEmpty();
 
 	// create declaration so that we serialize everything

--- a/packages/core/tests/js/arrays/object-array/output.ts
+++ b/packages/core/tests/js/arrays/object-array/output.ts
@@ -1,5 +1,1 @@
-const array = [{
-  test: true
-}, {
-  test2: "string"
-}];
+const array = [{ test: true }, { test2: "string" }];

--- a/packages/core/tests/js/arrays/object-array/run.ts
+++ b/packages/core/tests/js/arrays/object-array/run.ts
@@ -1,7 +1,6 @@
-import { array, object, common, variables } from '@sveltejs/cli-core/js';
-import type { ScriptFileEditor } from '@sveltejs/cli-core';
+import { array, object, common, variables, type AstTypes } from '@sveltejs/cli-core/js';
 
-export function run({ ast }: ScriptFileEditor<any>): void {
+export function run(ast: AstTypes.Program): void {
 	const array1 = array.createEmpty();
 
 	const object1 = object.create({ test: common.expressionFromString('true') });

--- a/packages/core/tests/js/arrays/string-array/run.ts
+++ b/packages/core/tests/js/arrays/string-array/run.ts
@@ -1,7 +1,6 @@
-import { array, variables } from '@sveltejs/cli-core/js';
-import type { ScriptFileEditor } from '@sveltejs/cli-core';
+import { array, variables, type AstTypes } from '@sveltejs/cli-core/js';
 
-export function run({ ast }: ScriptFileEditor<any>): void {
+export function run(ast: AstTypes.Program): void {
 	const array1 = array.createEmpty();
 	array.push(array1, 'test');
 	array.push(array1, 'test2');

--- a/packages/core/tests/js/exports/default-export-with-variable/output.ts
+++ b/packages/core/tests/js/exports/default-export-with-variable/output.ts
@@ -1,5 +1,3 @@
-const object = {
-  test: "string"
-};
+const object = { test: "string" };
 
 export default object;

--- a/packages/core/tests/js/exports/default-export-with-variable/run.ts
+++ b/packages/core/tests/js/exports/default-export-with-variable/run.ts
@@ -1,7 +1,6 @@
-import { object, common, variables, exports } from '@sveltejs/cli-core/js';
-import type { ScriptFileEditor } from '@sveltejs/cli-core';
+import { object, common, variables, exports, type AstTypes } from '@sveltejs/cli-core/js';
 
-export function run({ ast }: ScriptFileEditor<any>): void {
+export function run(ast: AstTypes.Program): void {
 	const object1 = object.create({
 		test: common.createLiteral('string')
 	});

--- a/packages/core/tests/js/exports/default-export/output.ts
+++ b/packages/core/tests/js/exports/default-export/output.ts
@@ -1,3 +1,1 @@
-export default {
-  test: "string"
-};
+export default { test: "string" };

--- a/packages/core/tests/js/exports/default-export/run.ts
+++ b/packages/core/tests/js/exports/default-export/run.ts
@@ -1,7 +1,6 @@
-import { object, common, exports } from '@sveltejs/cli-core/js';
-import type { ScriptFileEditor } from '@sveltejs/cli-core';
+import { object, common, exports, type AstTypes } from '@sveltejs/cli-core/js';
 
-export function run({ ast }: ScriptFileEditor<any>): void {
+export function run(ast: AstTypes.Program): void {
 	const object1 = object.create({
 		test: common.createLiteral('string')
 	});

--- a/packages/core/tests/js/exports/named-export-with-existing/output.ts
+++ b/packages/core/tests/js/exports/named-export-with-existing/output.ts
@@ -1,4 +1,1 @@
-export const named = {
-    test: 'string',
-    test2: "string2"
-};
+export const named = { test: 'string', test2: "string2" };

--- a/packages/core/tests/js/exports/named-export-with-existing/run.ts
+++ b/packages/core/tests/js/exports/named-export-with-existing/run.ts
@@ -1,7 +1,6 @@
 import { common, variables, object, exports, type AstTypes } from '@sveltejs/cli-core/js';
-import type { ScriptFileEditor } from '@sveltejs/cli-core';
 
-export function run({ ast }: ScriptFileEditor<any>): void {
+export function run(ast: AstTypes.Program): void {
 	const variableFallback = variables.declaration(ast, 'const', 'variable', object.createEmpty());
 
 	const existingExport = exports.namedExport(ast, 'named', variableFallback);

--- a/packages/core/tests/js/exports/named-export/output.ts
+++ b/packages/core/tests/js/exports/named-export/output.ts
@@ -1,7 +1,2 @@
-export const variable = {
-  test: "string"
-};
-
-export const variable2 = {
-  test2: "string2"
-};
+export const variable = { test: "string" };
+export const variable2 = { test2: "string2" };

--- a/packages/core/tests/js/exports/named-export/run.ts
+++ b/packages/core/tests/js/exports/named-export/run.ts
@@ -1,7 +1,6 @@
-import { common, variables, object, exports } from '@sveltejs/cli-core/js';
-import type { ScriptFileEditor } from '@sveltejs/cli-core';
+import { common, variables, object, exports, type AstTypes } from '@sveltejs/cli-core/js';
 
-export function run({ ast }: ScriptFileEditor<any>): void {
+export function run(ast: AstTypes.Program): void {
 	const object1 = object.create({
 		test: common.createLiteral('string')
 	});

--- a/packages/core/tests/js/functions/arrow-function/output.ts
+++ b/packages/core/tests/js/functions/arrow-function/output.ts
@@ -1,6 +1,6 @@
 () => console.log('foo');
 
 () => {
-  console.log('foo');
-  console.log('bar');
+	console.log('foo');
+	console.log('bar');
 };

--- a/packages/core/tests/js/functions/arrow-function/run.ts
+++ b/packages/core/tests/js/functions/arrow-function/run.ts
@@ -1,7 +1,6 @@
-import { functions, common } from '@sveltejs/cli-core/js';
-import type { ScriptFileEditor } from '@sveltejs/cli-core';
+import { functions, common, type AstTypes } from '@sveltejs/cli-core/js';
 
-export function run({ ast }: ScriptFileEditor<any>): void {
+export function run(ast: AstTypes.Program): void {
 	const insideExpression = common.expressionFromString("console.log('foo')");
 	const functionCall = functions.arrowFunction(false, insideExpression);
 	const expression = common.expressionStatement(functionCall);

--- a/packages/core/tests/js/functions/function-call-by-identifier/output.ts
+++ b/packages/core/tests/js/functions/function-call-by-identifier/output.ts
@@ -3,4 +3,5 @@ function foo(bar: string) {
 }
 
 const a = 'bar';
+
 foo(a);

--- a/packages/core/tests/js/functions/function-call-by-identifier/run.ts
+++ b/packages/core/tests/js/functions/function-call-by-identifier/run.ts
@@ -1,7 +1,6 @@
-import { functions, common } from '@sveltejs/cli-core/js';
-import type { ScriptFileEditor } from '@sveltejs/cli-core';
+import { functions, common, type AstTypes } from '@sveltejs/cli-core/js';
 
-export function run({ ast }: ScriptFileEditor<any>): void {
+export function run(ast: AstTypes.Program): void {
 	const functionCall = functions.callByIdentifier('foo', ['a']);
 	const expression = common.expressionStatement(functionCall);
 	ast.body.push(expression);

--- a/packages/core/tests/js/functions/function-call/output.ts
+++ b/packages/core/tests/js/functions/function-call/output.ts
@@ -1,4 +1,5 @@
 function foo(bar: string) {
 	console.log(bar);
 }
+
 foo("bar");

--- a/packages/core/tests/js/functions/function-call/run.ts
+++ b/packages/core/tests/js/functions/function-call/run.ts
@@ -1,7 +1,6 @@
-import { functions, common } from '@sveltejs/cli-core/js';
-import type { ScriptFileEditor } from '@sveltejs/cli-core';
+import { functions, common, type AstTypes } from '@sveltejs/cli-core/js';
 
-export function run({ ast }: ScriptFileEditor<any>): void {
+export function run(ast: AstTypes.Program): void {
 	const functionCall = functions.call('foo', ['bar']);
 	const expression = common.expressionStatement(functionCall);
 	ast.body.push(expression);

--- a/packages/core/tests/js/imports/avoid-duplicating-imports/run.ts
+++ b/packages/core/tests/js/imports/avoid-duplicating-imports/run.ts
@@ -1,7 +1,6 @@
-import { imports } from '@sveltejs/cli-core/js';
-import type { ScriptFileEditor } from '@sveltejs/cli-core';
+import { imports, type AstTypes } from '@sveltejs/cli-core/js';
 
-export function run({ ast }: ScriptFileEditor<any>): void {
+export function run(ast: AstTypes.Program): void {
 	imports.addEmpty(ast, 'package/file.js');
 	imports.addDefault(ast, 'package', 'MyPackage');
 	imports.addNamed(ast, 'package2', { Named: 'Named' });

--- a/packages/core/tests/js/imports/default-import/run.ts
+++ b/packages/core/tests/js/imports/default-import/run.ts
@@ -1,6 +1,5 @@
-import { imports } from '@sveltejs/cli-core/js';
-import type { ScriptFileEditor } from '@sveltejs/cli-core';
+import { imports, type AstTypes } from '@sveltejs/cli-core/js';
 
-export function run({ ast }: ScriptFileEditor<any>): void {
+export function run(ast: AstTypes.Program): void {
 	imports.addDefault(ast, 'package', 'MyPackage');
 }

--- a/packages/core/tests/js/imports/empty-import/run.ts
+++ b/packages/core/tests/js/imports/empty-import/run.ts
@@ -1,7 +1,6 @@
-import { imports } from '@sveltejs/cli-core/js';
-import type { ScriptFileEditor } from '@sveltejs/cli-core';
+import { imports, type AstTypes } from '@sveltejs/cli-core/js';
 
-export function run({ ast }: ScriptFileEditor<any>): void {
+export function run(ast: AstTypes.Program): void {
 	imports.addEmpty(ast, './relativ/file.css');
 
 	// allow importing from npm packages

--- a/packages/core/tests/js/imports/named-import-merging/run.ts
+++ b/packages/core/tests/js/imports/named-import-merging/run.ts
@@ -1,6 +1,5 @@
-import { imports } from '@sveltejs/cli-core/js';
-import type { ScriptFileEditor } from '@sveltejs/cli-core';
+import { imports, type AstTypes } from '@sveltejs/cli-core/js';
 
-export function run({ ast }: ScriptFileEditor<any>): void {
+export function run(ast: AstTypes.Program): void {
 	imports.addNamed(ast, 'package', { namedTwo: 'namedTwo' }, false);
 }

--- a/packages/core/tests/js/imports/named-import/run.ts
+++ b/packages/core/tests/js/imports/named-import/run.ts
@@ -1,7 +1,6 @@
-import { imports } from '@sveltejs/cli-core/js';
-import type { ScriptFileEditor } from '@sveltejs/cli-core';
+import { imports, type AstTypes } from '@sveltejs/cli-core/js';
 
-export function run({ ast }: ScriptFileEditor<any>): void {
+export function run(ast: AstTypes.Program): void {
 	imports.addNamed(ast, 'package', { namedOne: 'namedOne' }, false);
 
 	imports.addNamed(ast, '@sveltejs/kit', { Handle: 'Handle' }, false);

--- a/packages/core/tests/js/index.ts
+++ b/packages/core/tests/js/index.ts
@@ -20,7 +20,7 @@ for (const categoryDirectory of categoryDirectories) {
 
 				// dynamic imports always need to provide the path inline for static analysis
 				const module = await import(`./${categoryDirectory}/${testName}/run.ts`);
-				module.run({ ast });
+				module.run(ast);
 
 				const output = serializeScript(ast);
 				await expect(output).toMatchFileSnapshot(`${testDirectoryPath}/output.ts`);

--- a/packages/core/tests/js/object/create/output.ts
+++ b/packages/core/tests/js/object/create/output.ts
@@ -1,6 +1,2 @@
 const empty = {};
-
-const created = {
-  foo: 1,
-  bar: "string"
-};
+const created = { foo: 1, bar: "string" };

--- a/packages/core/tests/js/object/create/run.ts
+++ b/packages/core/tests/js/object/create/run.ts
@@ -1,7 +1,6 @@
-import { variables, object, common } from '@sveltejs/cli-core/js';
-import type { ScriptFileEditor } from '@sveltejs/cli-core';
+import { variables, object, common, type AstTypes } from '@sveltejs/cli-core/js';
 
-export function run({ ast }: ScriptFileEditor<any>): void {
+export function run(ast: AstTypes.Program): void {
 	const emptyObject = object.createEmpty();
 	const emptyVariable = variables.declaration(ast, 'const', 'empty', emptyObject);
 	ast.body.push(emptyVariable);

--- a/packages/core/tests/js/object/override-property/output.ts
+++ b/packages/core/tests/js/object/override-property/output.ts
@@ -1,5 +1,1 @@
-const test = {
-    foo: 2,
-    bar: "string2",
-    lorem: false
-}
+const test = { foo: 2, bar: "string2", lorem: false };

--- a/packages/core/tests/js/object/override-property/run.ts
+++ b/packages/core/tests/js/object/override-property/run.ts
@@ -1,7 +1,6 @@
 import { variables, object, common, type AstTypes } from '@sveltejs/cli-core/js';
-import type { ScriptFileEditor } from '@sveltejs/cli-core';
 
-export function run({ ast }: ScriptFileEditor<any>): void {
+export function run(ast: AstTypes.Program): void {
 	const variable = variables.declaration(ast, 'const', 'test', object.createEmpty());
 	const objectDeclarator = variable.declarations[0] as AstTypes.VariableDeclarator;
 	const objectExpression = objectDeclarator.init as AstTypes.ObjectExpression;

--- a/packages/core/tests/js/object/property/output.ts
+++ b/packages/core/tests/js/object/property/output.ts
@@ -1,4 +1,1 @@
-const test = {
-    foo: 1,
-    bar: "string"
-}
+const test = { foo: 1, bar: "string" };

--- a/packages/core/tests/js/object/property/run.ts
+++ b/packages/core/tests/js/object/property/run.ts
@@ -1,7 +1,6 @@
 import { variables, object, common, type AstTypes } from '@sveltejs/cli-core/js';
-import type { ScriptFileEditor } from '@sveltejs/cli-core';
 
-export function run({ ast }: ScriptFileEditor<any>): void {
+export function run(ast: AstTypes.Program): void {
 	const variable = variables.declaration(ast, 'const', 'test', object.createEmpty());
 	const objectDeclarator = variable.declarations[0] as AstTypes.VariableDeclarator;
 	const objectExpression = objectDeclarator.init as AstTypes.ObjectExpression;

--- a/packages/core/tests/js/object/remove-property/output.ts
+++ b/packages/core/tests/js/object/remove-property/output.ts
@@ -1,1 +1,1 @@
-const test = {}
+const test = {};

--- a/packages/core/tests/js/object/remove-property/run.ts
+++ b/packages/core/tests/js/object/remove-property/run.ts
@@ -1,7 +1,6 @@
 import { variables, object, type AstTypes } from '@sveltejs/cli-core/js';
-import type { ScriptFileEditor } from '@sveltejs/cli-core';
 
-export function run({ ast }: ScriptFileEditor<any>): void {
+export function run(ast: AstTypes.Program): void {
 	const variable = variables.declaration(ast, 'const', 'test', object.createEmpty());
 	const objectDeclarator = variable.declarations[0] as AstTypes.VariableDeclarator;
 	const objectExpression = objectDeclarator.init as AstTypes.ObjectExpression;

--- a/packages/core/tests/js/variables/declaration/output.ts
+++ b/packages/core/tests/js/variables/declaration/output.ts
@@ -1,5 +1,2 @@
 const testNumber = 2;
-
-const testObject = {
-  foo: "bar"
-};
+const testObject = { foo: "bar" };

--- a/packages/core/tests/js/variables/declaration/run.ts
+++ b/packages/core/tests/js/variables/declaration/run.ts
@@ -1,7 +1,6 @@
-import { variables, common, object } from '@sveltejs/cli-core/js';
-import type { ScriptFileEditor } from '@sveltejs/cli-core';
+import { variables, common, object, type AstTypes } from '@sveltejs/cli-core/js';
 
-export function run({ ast }: ScriptFileEditor<any>): void {
+export function run(ast: AstTypes.Program): void {
 	const testNumberVariable = variables.declaration(
 		ast,
 		'const',

--- a/packages/core/tests/js/variables/identifier/run.ts
+++ b/packages/core/tests/js/variables/identifier/run.ts
@@ -1,7 +1,6 @@
-import { variables } from '@sveltejs/cli-core/js';
-import type { ScriptFileEditor } from '@sveltejs/cli-core';
+import { variables, type AstTypes } from '@sveltejs/cli-core/js';
 
-export function run({ ast }: ScriptFileEditor<any>): void {
+export function run(ast: AstTypes.Program): void {
 	const barVariable = variables.declaration(ast, 'const', 'bar', variables.identifier('foo'));
 	ast.body.push(barVariable);
 }

--- a/packages/core/tests/js/variables/type-annotate-declarator/run.ts
+++ b/packages/core/tests/js/variables/type-annotate-declarator/run.ts
@@ -1,7 +1,6 @@
-import { variables } from '@sveltejs/cli-core/js';
-import type { ScriptFileEditor } from '@sveltejs/cli-core';
+import { variables, type AstTypes } from '@sveltejs/cli-core/js';
 
-export function run({ ast }: ScriptFileEditor<any>): void {
+export function run(ast: AstTypes.Program): void {
 	const decl = ast.body[0] as any;
 	const annotatedDecl = variables.typeAnnotateDeclarator(decl.declarations[0], 'string');
 	decl.declarations[0] = annotatedDecl;

--- a/packages/core/tooling/js/array.ts
+++ b/packages/core/tooling/js/array.ts
@@ -1,5 +1,5 @@
 import { areNodesEqual } from './common.ts';
-import type { AstKinds, AstTypes } from '@sveltejs/ast-tooling';
+import type { AstTypes } from '@sveltejs/ast-tooling';
 
 export function createEmpty(): AstTypes.ArrayExpression {
 	const arrayExpression: AstTypes.ArrayExpression = {
@@ -11,24 +11,24 @@ export function createEmpty(): AstTypes.ArrayExpression {
 
 export function push(
 	ast: AstTypes.ArrayExpression,
-	data: string | AstKinds.ExpressionKind | AstKinds.SpreadElementKind
+	data: string | AstTypes.Expression | AstTypes.SpreadElement
 ): void {
 	if (typeof data === 'string') {
 		const existingLiterals = ast.elements.filter(
-			(x): x is AstTypes.StringLiteral => x?.type == 'StringLiteral'
+			(x): x is AstTypes.Literal => x?.type == 'Literal'
 		);
 		let literal = existingLiterals.find((x) => x.value == data);
 
 		if (!literal) {
 			literal = {
-				type: 'StringLiteral',
+				type: 'Literal',
 				value: data
 			};
 			ast.elements.push(literal);
 		}
 	} else {
 		let anyNodeEquals = false;
-		const elements = ast.elements as AstTypes.ASTNode[];
+		const elements = ast.elements as AstTypes.Node[];
 		for (const node of elements) {
 			if (areNodesEqual(data, node)) {
 				anyNodeEquals = true;

--- a/packages/core/tooling/js/common.ts
+++ b/packages/core/tooling/js/common.ts
@@ -1,5 +1,4 @@
 import {
-	type AstKinds,
 	type AstTypes,
 	Walker,
 	parseScript,
@@ -9,21 +8,20 @@ import {
 import decircular from 'decircular';
 import dedent from 'dedent';
 
-export function addJsDocTypeComment(node: AstTypes.Node, type: string): void {
-	const comment: AstTypes.CommentBlock = {
-		type: 'CommentBlock',
-		value: `* @type {${type}} `,
-		leading: true
+export function addJsDocTypeComment(node: AstTypes.BaseNode, type: string): void {
+	const comment: AstTypes.Comment = {
+		type: 'Line',
+		value: `* @type {${type}} `
 	};
 
-	node.comments ??= [];
+	node.leadingComments ??= [];
 
-	const found = node.comments.find((n) => n.type === 'CommentBlock' && n.value === comment.value);
-	if (!found) node.comments.push(comment);
+	const found = node.leadingComments.find((n) => n.type === 'Line' && n.value === comment.value);
+	if (!found) node.leadingComments.push(comment);
 }
 
 export function typeAnnotateExpression(
-	node: AstKinds.ExpressionKind,
+	node: AstTypes.Expression,
 	type: string
 ): AstTypes.TSAsExpression {
 	const expression: AstTypes.TSAsExpression = {
@@ -35,7 +33,7 @@ export function typeAnnotateExpression(
 	return expression;
 }
 
-export function createSpreadElement(expression: AstKinds.ExpressionKind): AstTypes.SpreadElement {
+export function createSpreadElement(expression: AstTypes.Expression): AstTypes.SpreadElement {
 	return {
 		type: 'SpreadElement',
 		argument: expression
@@ -51,13 +49,15 @@ export function createLiteral(value: string | number | boolean | null = null): A
 	return literal;
 }
 
-export function areNodesEqual(ast1: AstTypes.ASTNode, ast2: AstTypes.ASTNode): boolean {
+export function areNodesEqual(ast1: AstTypes.Node, ast2: AstTypes.Node): boolean {
 	// We're deep cloning these trees so that we can strip the locations off of them for comparisons.
 	// Without this, we'd be getting false negatives due to slight differences in formatting style.
 	// These ASTs are also filled to the brim with circular references, which prevents
 	// us from using `structuredCloned` directly
-	const ast1Clone = stripAst(decircular(ast1), 'loc');
-	const ast2Clone = stripAst(decircular(ast2), 'loc');
+
+	// todo: can we simplify this duplicated call?
+	const ast1Clone = stripAst(stripAst(decircular(ast1), 'loc'), 'raw');
+	const ast2Clone = stripAst(stripAst(decircular(ast2), 'loc'), 'raw');
 	return serializeScript(ast1Clone) === serializeScript(ast2Clone);
 }
 
@@ -69,9 +69,7 @@ export function blockStatement(): AstTypes.BlockStatement {
 	return statement;
 }
 
-export function expressionStatement(
-	expression: AstKinds.ExpressionKind
-): AstTypes.ExpressionStatement {
+export function expressionStatement(expression: AstTypes.Expression): AstTypes.ExpressionStatement {
 	const statement: AstTypes.ExpressionStatement = {
 		type: 'ExpressionStatement',
 		expression
@@ -86,11 +84,12 @@ export function addFromString(
 	const program = parseScript(dedent(value));
 
 	for (const childNode of program.body) {
+		// @ts-expect-error
 		ast.body.push(childNode);
 	}
 }
 
-export function expressionFromString(value: string): AstKinds.ExpressionKind {
+export function expressionFromString(value: string): AstTypes.Expression {
 	const program = parseScript(dedent(value));
 	const statement = program.body[0]!;
 	if (statement.type !== 'ExpressionStatement') {
@@ -100,23 +99,27 @@ export function expressionFromString(value: string): AstKinds.ExpressionKind {
 	return statement.expression;
 }
 
-export function statementFromString(value: string): AstKinds.StatementKind {
+export function statementFromString(value: string): AstTypes.Statement {
+	return fromString<AstTypes.Statement>(value);
+}
+
+export function fromString<T extends AstTypes.Node>(value: string): T {
 	const program = parseScript(dedent(value));
 	const statement = program.body[0]!;
 
-	return statement;
+	return statement as T;
 }
 
 /** Appends the statement to body of the block if it doesn't already exist */
 export function addStatement(
 	ast: AstTypes.BlockStatement | AstTypes.Program,
-	statement: AstKinds.StatementKind
+	statement: AstTypes.Statement
 ): void {
 	if (!hasNode(ast, statement)) ast.body.push(statement);
 }
 
 /** Returns `true` if the provided node exists in the AST */
-export function hasNode(ast: AstTypes.ASTNode, nodeToMatch: AstTypes.ASTNode): boolean {
+export function hasNode(ast: AstTypes.Node, nodeToMatch: AstTypes.Node): boolean {
 	let found = false;
 	// prettier-ignore
 	// this gets needlessly butchered by prettier

--- a/packages/core/tooling/js/exports.ts
+++ b/packages/core/tooling/js/exports.ts
@@ -1,11 +1,11 @@
-import type { AstKinds, AstTypes } from '@sveltejs/ast-tooling';
+import type { AstTypes } from '@sveltejs/ast-tooling';
 
 export type ExportDefaultReturn<T> = {
 	astNode: AstTypes.ExportDefaultDeclaration;
 	value: T;
 };
 
-export function defaultExport<T extends AstKinds.ExpressionKind>(
+export function defaultExport<T extends AstTypes.Expression>(
 	ast: AstTypes.Program,
 	fallbackDeclaration: T
 ): ExportDefaultReturn<T> {
@@ -72,7 +72,8 @@ export function namedExport(
 
 	namedExport = {
 		type: 'ExportNamedDeclaration',
-		declaration: fallback
+		declaration: fallback,
+		specifiers: []
 	};
 	ast.body.push(namedExport);
 	return namedExport;

--- a/packages/core/tooling/js/function.ts
+++ b/packages/core/tooling/js/function.ts
@@ -1,4 +1,4 @@
-import type { AstKinds, AstTypes } from '@sveltejs/ast-tooling';
+import type { AstTypes } from '@sveltejs/ast-tooling';
 
 export function call(name: string, args: string[]): AstTypes.CallExpression {
 	const callExpression: AstTypes.CallExpression = {
@@ -7,7 +7,8 @@ export function call(name: string, args: string[]): AstTypes.CallExpression {
 			type: 'Identifier',
 			name
 		},
-		arguments: []
+		arguments: [],
+		optional: false
 	};
 
 	for (const argument of args) {
@@ -27,7 +28,8 @@ export function callByIdentifier(name: string, args: string[]): AstTypes.CallExp
 			type: 'Identifier',
 			name
 		},
-		arguments: []
+		arguments: [],
+		optional: false
 	};
 
 	for (const argument of args) {
@@ -43,19 +45,20 @@ export function callByIdentifier(name: string, args: string[]): AstTypes.CallExp
 
 export function arrowFunction(
 	async: boolean,
-	body: AstKinds.ExpressionKind | AstTypes.BlockStatement
+	body: AstTypes.Expression | AstTypes.BlockStatement
 ): AstTypes.ArrowFunctionExpression {
 	const arrowFunction: AstTypes.ArrowFunctionExpression = {
 		type: 'ArrowFunctionExpression',
 		async,
 		body,
-		params: []
+		params: [],
+		expression: true
 	};
 
 	return arrowFunction;
 }
 
-export function argumentByIndex<T extends AstKinds.ExpressionKind>(
+export function argumentByIndex<T extends AstTypes.Expression>(
 	ast: AstTypes.CallExpression,
 	i: number,
 	fallback: T

--- a/packages/core/tooling/js/imports.ts
+++ b/packages/core/tooling/js/imports.ts
@@ -8,7 +8,8 @@ export function addEmpty(ast: AstTypes.Program, importFrom: string): void {
 			type: 'Literal',
 			value: importFrom
 		},
-		specifiers: []
+		specifiers: [],
+		importKind: 'value'
 	};
 
 	addImportIfNecessary(ast, expectedImportDeclaration);
@@ -29,7 +30,8 @@ export function addDefault(ast: AstTypes.Program, importFrom: string, importAs: 
 					name: importAs
 				}
 			}
-		]
+		],
+		importKind: 'value'
 	};
 
 	addImportIfNecessary(ast, expectedImportDeclaration);
@@ -58,7 +60,7 @@ export function addNamed(
 
 	let importDecl: AstTypes.ImportDeclaration | undefined;
 	// prettier-ignore
-	Walker.walk(ast as AstTypes.ASTNode, {}, {
+	Walker.walk(ast as AstTypes.Node, {}, {
 		ImportDeclaration(node) {
 			if (node.source.value === importFrom && node.specifiers) {
 				importDecl = node;
@@ -74,6 +76,8 @@ export function addNamed(
 					(existingSpecifier) =>
 						existingSpecifier.type === 'ImportSpecifier' &&
 						existingSpecifier.local?.name !== specifierToAdd.local?.name &&
+						existingSpecifier.imported.type == 'Identifier' &&
+						specifierToAdd.imported.type == 'Identifier' &&
 						existingSpecifier.imported.name !== specifierToAdd.imported.name
 				)
 			) {
@@ -90,7 +94,7 @@ export function addNamed(
 			value: importFrom
 		},
 		specifiers,
-		importKind: isType ? 'type' : undefined
+		importKind: isType ? 'type' : 'value'
 	};
 
 	ast.body.unshift(expectedImportDeclaration);

--- a/packages/core/tooling/js/index.ts
+++ b/packages/core/tooling/js/index.ts
@@ -6,4 +6,4 @@ export * as imports from './imports.ts';
 export * as variables from './variables.ts';
 export * as exports from './exports.ts';
 export * as kit from './kit.ts';
-export type { AstTypes, AstKinds } from '@sveltejs/ast-tooling';
+export type { AstTypes } from '@sveltejs/ast-tooling';

--- a/packages/core/tooling/js/kit.ts
+++ b/packages/core/tooling/js/kit.ts
@@ -1,8 +1,8 @@
-import { Walker, type AstKinds } from '@sveltejs/ast-tooling';
-import { common, functions, imports, variables, exports, type AstTypes } from '../js/index.ts';
+import { Walker } from '@sveltejs/ast-tooling';
+import { type AstTypes, common, functions, imports, variables, exports } from '../js/index.ts';
 
 export function addGlobalAppInterface(
-	ast: AstTypes.Program,
+	ast: AstTypes.TSProgram,
 	name: 'Error' | 'Locals' | 'PageData' | 'PageState' | 'Platform'
 ): AstTypes.TSInterfaceDeclaration {
 	let globalDecl = ast.body
@@ -10,7 +10,7 @@ export function addGlobalAppInterface(
 		.find((m) => m.global && m.declare);
 
 	if (!globalDecl) {
-		globalDecl = common.statementFromString('declare global {}') as AstTypes.TSModuleDeclaration;
+		globalDecl = common.fromString<AstTypes.TSModuleDeclaration>('declare global {}');
 		ast.body.push(globalDecl);
 	}
 
@@ -22,7 +22,7 @@ export function addGlobalAppInterface(
 	let interfaceNode: AstTypes.TSInterfaceDeclaration | undefined;
 
 	// prettier-ignore
-	Walker.walk(globalDecl as AstTypes.ASTNode, {}, {
+	Walker.walk(globalDecl as AstTypes.Node, {}, {
 		TSModuleDeclaration(node, { next }) {
 			if (node.id.type === 'Identifier' && node.id.name === 'App') {
 				app = node;
@@ -37,7 +37,7 @@ export function addGlobalAppInterface(
 	});
 
 	if (!app) {
-		app = common.statementFromString('namespace App {}') as AstTypes.TSModuleDeclaration;
+		app = common.fromString<AstTypes.TSModuleDeclaration>('namespace App {}');
 		globalDecl.body.body.push(app);
 	}
 
@@ -47,9 +47,7 @@ export function addGlobalAppInterface(
 
 	if (!interfaceNode) {
 		// add the interface if it's missing
-		interfaceNode = common.statementFromString(
-			`interface ${name} {}`
-		) as AstTypes.TSInterfaceDeclaration;
+		interfaceNode = common.fromString<AstTypes.TSInterfaceDeclaration>(`interface ${name} {}`);
 		app.body.body.push(interfaceNode);
 	}
 
@@ -70,20 +68,20 @@ export function addHooksHandle(
 	let isSpecifier: boolean = false;
 	let handleName = 'handle';
 	let exportDecl: AstTypes.ExportNamedDeclaration | undefined;
-	let originalHandleDecl: AstKinds.DeclarationKind | undefined;
+	let originalHandleDecl: AstTypes.Declaration | undefined;
 
 	// We'll first visit all of the named exports and grab their references if they export `handle`.
 	// This will grab export references for:
 	// `export { handle }` & `export { foo as handle }`
 	// `export const handle = ...`, & `export function handle() {...}`
 	// prettier-ignore
-	Walker.walk(ast as AstTypes.ASTNode, {}, {
+	Walker.walk(ast as AstTypes.Node, {}, {
 		ExportNamedDeclaration(node) {
-			let maybeHandleDecl: AstKinds.DeclarationKind | undefined;
+			let maybeHandleDecl: AstTypes.Declaration | undefined;
 
 			// `export { handle }` & `export { foo as handle }`
-			const handleSpecifier = node.specifiers?.find((s) => s.exported.name === 'handle');
-			if (handleSpecifier) {
+			const handleSpecifier = node.specifiers?.find((s) => s.exported.type == 'Identifier' && s.exported.name === 'handle');
+			if (handleSpecifier && handleSpecifier.local.type == 'Identifier' && handleSpecifier.exported.type == 'Identifier') {
 				isSpecifier = true;
 				// we'll search for the local name in case it's aliased (e.g. `export { foo as handle }`)
 				handleName = handleSpecifier.local?.name ?? handleSpecifier.exported.name;
@@ -257,7 +255,7 @@ function usingSequence(node: AstTypes.VariableDeclarator, handleName: string) {
 }
 
 function isVariableDeclaration(
-	node: AstTypes.ASTNode,
+	node: AstTypes.Node,
 	variableName: string
 ): node is AstTypes.VariableDeclaration {
 	return (
@@ -275,7 +273,7 @@ function getVariableDeclarator(
 }
 
 function isFunctionDeclaration(
-	node: AstTypes.ASTNode,
+	node: AstTypes.Node,
 	funcName: string
 ): node is AstTypes.FunctionDeclaration {
 	return node.type === 'FunctionDeclaration' && node.id?.name === funcName;

--- a/packages/core/tooling/js/object.ts
+++ b/packages/core/tooling/js/object.ts
@@ -1,13 +1,13 @@
-import type { AstKinds, AstTypes } from '@sveltejs/ast-tooling';
+import type { AstTypes } from '@sveltejs/ast-tooling';
 
-export function property<T extends AstKinds.ExpressionKind | AstTypes.Identifier>(
+export function property<T extends AstTypes.Expression | AstTypes.Identifier>(
 	ast: AstTypes.ObjectExpression,
 	name: string,
 	fallback: T
 ): T {
 	const objectExpression = ast;
 	const properties = objectExpression.properties.filter(
-		(x): x is AstTypes.ObjectProperty => x.type == 'ObjectProperty'
+		(x): x is AstTypes.Property => x.type == 'Property'
 	);
 	let property = properties.find((x) => (x.key as AstTypes.Identifier).name == name);
 	let propertyValue: T;
@@ -23,13 +23,16 @@ export function property<T extends AstKinds.ExpressionKind | AstTypes.Identifier
 
 		propertyValue = fallback;
 		property = {
-			type: 'ObjectProperty',
+			type: 'Property',
 			shorthand: isShorthand,
 			key: {
 				type: 'Identifier',
 				name
 			},
-			value: propertyValue
+			value: propertyValue,
+			kind: 'init',
+			computed: false,
+			method: false
 		};
 
 		objectExpression.properties.push(property);
@@ -38,14 +41,14 @@ export function property<T extends AstKinds.ExpressionKind | AstTypes.Identifier
 	return propertyValue;
 }
 
-export function overrideProperty<T extends AstKinds.ExpressionKind>(
+export function overrideProperty<T extends AstTypes.Expression>(
 	ast: AstTypes.ObjectExpression,
 	name: string,
 	value: T
 ): T {
 	const objectExpression = ast;
 	const properties = objectExpression.properties.filter(
-		(x): x is AstTypes.ObjectProperty => x.type == 'ObjectProperty'
+		(x): x is AstTypes.Property => x.type == 'Property'
 	);
 	const prop = properties.find((x) => (x.key as AstTypes.Identifier).name == name);
 
@@ -58,7 +61,7 @@ export function overrideProperty<T extends AstKinds.ExpressionKind>(
 	return value;
 }
 
-export function overrideProperties<T extends AstKinds.ExpressionKind>(
+export function overrideProperties<T extends AstTypes.Expression>(
 	ast: AstTypes.ObjectExpression,
 	obj: Record<string, T | undefined>
 ): void {
@@ -68,7 +71,7 @@ export function overrideProperties<T extends AstKinds.ExpressionKind>(
 	}
 }
 
-export function properties<T extends AstKinds.ExpressionKind>(
+export function properties<T extends AstTypes.Expression>(
 	ast: AstTypes.ObjectExpression,
 	obj: Record<string, T | undefined>
 ): void {
@@ -79,9 +82,7 @@ export function properties<T extends AstKinds.ExpressionKind>(
 }
 
 export function removeProperty(ast: AstTypes.ObjectExpression, property: string): void {
-	const properties = ast.properties.filter(
-		(x): x is AstTypes.ObjectProperty => x.type === 'ObjectProperty'
-	);
+	const properties = ast.properties.filter((x): x is AstTypes.Property => x.type === 'Property');
 	const propIdx = properties.findIndex((x) => (x.key as AstTypes.Identifier).name === property);
 
 	if (propIdx !== -1) {
@@ -89,7 +90,7 @@ export function removeProperty(ast: AstTypes.ObjectExpression, property: string)
 	}
 }
 
-export function create<T extends AstKinds.ExpressionKind>(
+export function create<T extends AstTypes.Expression>(
 	obj: Record<string, T | undefined>
 ): AstTypes.ObjectExpression {
 	const objExpression = createEmpty();

--- a/packages/core/tooling/js/variables.ts
+++ b/packages/core/tooling/js/variables.ts
@@ -1,10 +1,10 @@
-import type { AstKinds, AstTypes } from '@sveltejs/ast-tooling';
+import type { AstTypes } from '@sveltejs/ast-tooling';
 
 export function declaration(
-	ast: AstTypes.Program | AstKinds.DeclarationKind,
+	ast: AstTypes.Program | AstTypes.Declaration,
 	kind: 'const' | 'let' | 'var',
 	name: string,
-	value: AstKinds.ExpressionKind
+	value: AstTypes.Expression
 ): AstTypes.VariableDeclaration {
 	const declarations =
 		ast.type == 'Program'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,9 +114,9 @@ importers:
       domutils:
         specifier: ^3.1.0
         version: 3.1.0
-      esrap:
-        specifier: ^1.2.2
-        version: link:../../../esrap
+      esrap-typescript-temp:
+        specifier: ^0.0.1
+        version: 0.0.1
       htmlparser2:
         specifier: ^9.1.0
         version: 9.1.0
@@ -1159,6 +1159,9 @@ packages:
   esquery@1.6.0:
     resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
     engines: {node: '>=0.10'}
+
+  esrap-typescript-temp@0.0.1:
+    resolution: {integrity: sha512-7CtMLBfcpwqzI42svwz3CYEujMUzWqqv/s1ezaWXdFZlFnMaAQoxh1BYo5emZeeP+fNmqGRc/9cvazg5N5zlLg==}
 
   esrap@1.2.2:
     resolution: {integrity: sha512-F2pSJklxx1BlQIQgooczXCPHmcWpn6EsP5oo73LQfonG9fIlIENQ8vMmfGXeojP9MrkzUNAfyU5vdFlR9shHAw==}
@@ -3108,6 +3111,11 @@ snapshots:
   esquery@1.6.0:
     dependencies:
       estraverse: 5.3.0
+
+  esrap-typescript-temp@0.0.1:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.0
+      '@typescript-eslint/types': 8.5.0
 
   esrap@1.2.2:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,12 +96,15 @@ importers:
 
   packages/ast-tooling:
     devDependencies:
-      '@babel/parser':
-        specifier: ^7.24.7
-        version: 7.25.3
-      ast-types:
-        specifier: ^0.14.2
-        version: 0.14.2
+      '@types/estree':
+        specifier: ^1.0.6
+        version: 1.0.6
+      acorn:
+        specifier: ^8.12.1
+        version: 8.12.1
+      acorn-typescript:
+        specifier: ^1.4.13
+        version: 1.4.13(acorn@8.12.1)
       dom-serializer:
         specifier: ^2.0.0
         version: 2.0.0
@@ -111,15 +114,15 @@ importers:
       domutils:
         specifier: ^3.1.0
         version: 3.1.0
+      esrap:
+        specifier: ^1.2.2
+        version: link:../../../esrap
       htmlparser2:
         specifier: ^9.1.0
         version: 9.1.0
       postcss:
         specifier: ^8.4.38
         version: 8.4.45
-      recast:
-        specifier: ^0.23.7
-        version: 0.23.9
       silver-fleece:
         specifier: ^1.1.0
         version: 1.1.0
@@ -236,25 +239,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@babel/helper-string-parser@7.24.8':
-    resolution: {integrity: sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.24.7':
-    resolution: {integrity: sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/parser@7.25.3':
-    resolution: {integrity: sha512-iLTJKDbJ4hMvFPgQwwsVoxtHyWpKKPBrxkANrSYewDPaPpT5py5yeVkgPIJ7XYXhndxJpaA3PyALSXQ7u8e/Dw==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   '@babel/runtime@7.25.0':
     resolution: {integrity: sha512-7dRy4DwXwtzBrPbZflqxnvfxLF8kdZXPkhymtDeFoFqE6ldzjQFgYTtYIFARcLEYDrqfBfYcZt1WqFxRoyC9Rw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.25.2':
-    resolution: {integrity: sha512-YTnYtra7W9e6/oAZEHj0bJehPRUlLH9/fbpT5LfB0NhQXyALCRkRs3zH9v07IYhkgpqX6Z78FnuccZr/l4Fs4Q==}
     engines: {node: '>=6.9.0'}
 
   '@changesets/apply-release-plan@7.0.5':
@@ -727,6 +713,9 @@ packages:
   '@types/estree@1.0.5':
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
 
+  '@types/estree@1.0.6':
+    resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
+
   '@types/gitignore-parser@0.0.3':
     resolution: {integrity: sha512-sbdu1sG2pQcwjEYWTsX78OqJo5pKnonwC4FV3m2JeQRE2xYb3q0icHHopCHEvpn4uIBuvWBTpJUCJ76ISK24CA==}
 
@@ -883,14 +872,6 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
-
-  ast-types@0.14.2:
-    resolution: {integrity: sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==}
-    engines: {node: '>=4'}
-
-  ast-types@0.16.1:
-    resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
-    engines: {node: '>=4'}
 
   astring@1.8.6:
     resolution: {integrity: sha512-ISvCdHdlTDlH5IpxQJIex7BWBywFWgjJSVdwst+/iQCoEYnyOaQ95+X1JGshuBjGp6nxKUy1jMgE3zPqN7fQdg==}
@@ -1729,10 +1710,6 @@ packages:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
 
-  recast@0.23.9:
-    resolution: {integrity: sha512-Hx/BGIbwj+Des3+xy5uAtAbdCyqK9y9wbBcDFDYanLS9JnMqf7OeF87HQwUimE87OEc72mr6tkKUKMBBL+hF9Q==}
-    engines: {node: '>= 4'}
-
   regenerator-runtime@0.14.1:
     resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
 
@@ -1825,10 +1802,6 @@ packages:
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
-    engines: {node: '>=0.10.0'}
-
-  source-map@0.6.1:
-    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
   sourcemap-codec@1.4.8:
@@ -1934,9 +1907,6 @@ packages:
   tiny-glob@0.2.9:
     resolution: {integrity: sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==}
 
-  tiny-invariant@1.3.3:
-    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
-
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -1959,10 +1929,6 @@ packages:
     resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
     engines: {node: '>=0.6.0'}
 
-  to-fast-properties@2.0.0:
-    resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
-    engines: {node: '>=4'}
-
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -1982,9 +1948,6 @@ packages:
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
-
-  tslib@2.6.3:
-    resolution: {integrity: sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -2173,23 +2136,9 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@babel/helper-string-parser@7.24.8': {}
-
-  '@babel/helper-validator-identifier@7.24.7': {}
-
-  '@babel/parser@7.25.3':
-    dependencies:
-      '@babel/types': 7.25.2
-
   '@babel/runtime@7.25.0':
     dependencies:
       regenerator-runtime: 0.14.1
-
-  '@babel/types@7.25.2':
-    dependencies:
-      '@babel/helper-string-parser': 7.24.8
-      '@babel/helper-validator-identifier': 7.24.7
-      to-fast-properties: 2.0.0
 
   '@changesets/apply-release-plan@7.0.5':
     dependencies:
@@ -2653,6 +2602,8 @@ snapshots:
 
   '@types/estree@1.0.5': {}
 
+  '@types/estree@1.0.6': {}
+
   '@types/gitignore-parser@0.0.3': {}
 
   '@types/node@12.20.55': {}
@@ -2839,14 +2790,6 @@ snapshots:
   array-union@2.1.0: {}
 
   assertion-error@2.0.1: {}
-
-  ast-types@0.14.2:
-    dependencies:
-      tslib: 2.6.3
-
-  ast-types@0.16.1:
-    dependencies:
-      tslib: 2.6.3
 
   astring@1.8.6: {}
 
@@ -3169,7 +3112,7 @@ snapshots:
   esrap@1.2.2:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
 
   esrecurse@4.3.0:
     dependencies:
@@ -3181,7 +3124,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
 
   esutils@2.0.3: {}
 
@@ -3662,14 +3605,6 @@ snapshots:
       pify: 4.0.1
       strip-bom: 3.0.0
 
-  recast@0.23.9:
-    dependencies:
-      ast-types: 0.16.1
-      esprima: 4.0.1
-      source-map: 0.6.1
-      tiny-invariant: 1.3.3
-      tslib: 2.6.3
-
   regenerator-runtime@0.14.1: {}
 
   resolve-from@4.0.0: {}
@@ -3763,8 +3698,6 @@ snapshots:
   slash@3.0.0: {}
 
   source-map-js@1.2.1: {}
-
-  source-map@0.6.1: {}
 
   sourcemap-codec@1.4.8: {}
 
@@ -3892,8 +3825,6 @@ snapshots:
       globalyzer: 0.1.0
       globrex: 0.1.2
 
-  tiny-invariant@1.3.3: {}
-
   tinybench@2.9.0: {}
 
   tinyexec@0.3.0: {}
@@ -3908,8 +3839,6 @@ snapshots:
     dependencies:
       os-tmpdir: 1.0.2
 
-  to-fast-properties@2.0.0: {}
-
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -3923,8 +3852,6 @@ snapshots:
       typescript: 5.6.2
 
   ts-interface-checker@0.1.13: {}
-
-  tslib@2.6.3: {}
 
   type-check@0.4.0:
     dependencies:


### PR DESCRIPTION
Closes #94 
Closes #44

Benefits
* closer to other tools in the `svelte` ecosystem
* Faster bundling (~33% speed improvement locally from 3s to 2s)
* Smaller bundle (not tested, but dropping babel should dramatically decrease the bundle size)
* more consistent formatting
* we are in full control of the printing, as we own `esrap`

Downsides
* Potentially to consistent formatting, as it looks like it's completely ignore the user input (tabs vs spaces, etc), but that's probably fixable in `esrap`
* Custom typing for special typescript types (see packages/ast-tooling/ts-estree.ts) and https://github.com/Rich-Harris/esrap/pull/13 for reasoning and considered alternatives.

Depends on https://github.com/Rich-Harris/esrap/pull/13. Currently published as `esrap-typescript-temp` for ease of use for testing. Otherwise, this would require using `pnpm link` locally with the branch mentioned before.

If we want to proceed with this (which i think we should), this needs to be done
* [ ] publish `packages/ast-tooling/ts-estree.ts` seperately so that it can also be used inside `esrap`. Later they should probably live inside `acorn-typescript` once we fork it
* [ ] make `esrap` understand what a `TSModuleDeclaration` is and how to print it
* [ ] update types inside `esrap` according to the types above. This will probably also require way more types in this new package
* [ ] merge the pr inside `esrap` and publish it
* [ ] fix todos
* [ ] Testing. I have done a few tests here and there and generally the formatting is way more consistent and matches what i would expect.