### PR TITLE
docs: remove API usage from readme

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -8,21 +8,6 @@ npx sv
 
 ...and follow the prompts.
 
-## API
-
-You can also use `sv` programmatically:
-
-```js
-import { create } from 'sv';
-
-await create('my-new-app', {
-  name: 'my-new-app',
-  template: 'default' // or 'skeleton' or 'skeletonlib'
-});
-```
-
-`checkjs` means your project will use TypeScript to typecheck JavaScript via [JSDoc comments](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html).
-
 ## Acknowledgements
 
 Thank you to [Christopher Brown](https://github.com/chbrown) who originally owned the `sv` name on npm for graciously allowing it to be used for this package. You can find the original `sv` package at [`@chbrown/sv`](https://www.npmjs.com/package/@chbrown/sv).


### PR DESCRIPTION
as suggested by other maintainers on discord, this probably shouldn't be quite so prominent