### PR TITLE
chore: remove language tags from prompt

### DIFF
--- a/packages/adders/paraglide/index.ts
+++ b/packages/adders/paraglide/index.ts
@@ -33,7 +33,7 @@ const DEFAULT_INLANG_PROJECT = {
 
 export const options = defineAdderOptions({
 	availableLanguageTags: {
-		question: `Which language tags would you like to support? ${colors.gray('(e.g. en,de-ch)')}`,
+		question: `Which languages would you like to support? ${colors.gray('(e.g. en,de-ch)')}`,
 		type: 'string',
 		default: 'en',
 		validate(input: any) {


### PR DESCRIPTION
got some feedback from the paraglide team that a lot of people might now know what "language tags" are