### PR TITLE
docs: fix link to SvelteKit docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # sv - the Svelte CLI
 
-Read the [SvelteKit documentation](https://svelte.dev/docs/kit) for more details about getting started with a newly created app.
+Read the [SvelteKit documentation](https://kit.svelte.dev/docs/introduction) for more details about getting started with a newly created app.
 
 ### Packages
 


### PR DESCRIPTION
The original link returns a 404.