### PR TITLE
fix: consistent package manager detection

### DIFF
--- a/.changeset/stale-rockets-raise.md
+++ b/.changeset/stale-rockets-raise.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix: improve package manager detection

--- a/packages/adders/drizzle/index.ts
+++ b/packages/adders/drizzle/index.ts
@@ -380,14 +380,18 @@ export default defineAdder({
 			}
 		}
 	],
-	nextSteps: ({ options, highlighter }) => {
+	nextSteps: ({ options, highlighter, packageManager }) => {
 		const steps = [
 			`You will need to set ${highlighter.env('DATABASE_URL')} in your production environment`
 		];
 		if (options.docker) {
-			steps.push(`Run ${highlighter.command('npm run db:start')} to start the docker container`);
+			steps.push(
+				`Run ${highlighter.command(`${packageManager} run db:start`)} to start the docker container`
+			);
 		}
-		steps.push(`Run ${highlighter.command('npm run db:push')} to update your database schema`);
+		steps.push(
+			`Run ${highlighter.command(`${packageManager} run db:push`)} to update your database schema`
+		);
 
 		return steps;
 	}

--- a/packages/adders/lucia/index.ts
+++ b/packages/adders/lucia/index.ts
@@ -590,8 +590,10 @@ export default defineAdder({
 			}
 		}
 	],
-	nextSteps: ({ highlighter, options }) => {
-		const steps = [`Run ${highlighter.command('npm run db:push')} to update your database schema`];
+	nextSteps: ({ highlighter, options, packageManager }) => {
+		const steps = [
+			`Run ${highlighter.command(`${packageManager} run db:push`)} to update your database schema`
+		];
 		if (options.demo) {
 			steps.push(`Visit ${highlighter.route('/demo/lucia')} route to view the demo`);
 		}

--- a/packages/cli/commands/add/index.ts
+++ b/packages/cli/commands/add/index.ts
@@ -6,7 +6,7 @@ import { exec } from 'tinyexec';
 import { Command, Option } from 'commander';
 import * as p from '@sveltejs/clack-prompts';
 import * as pkg from 'empathic/package';
-import { resolveCommand } from 'package-manager-detector';
+import { resolveCommand, type AgentName } from 'package-manager-detector';
 import pc from 'picocolors';
 import {
 	officialAdders,
@@ -95,7 +95,7 @@ type SelectedAdder = { type: 'official' | 'community'; adder: AdderWithoutExplic
 export async function runAddCommand(
 	options: Options,
 	selectedAdderIds: string[]
-): Promise<{ nextSteps?: string }> {
+): Promise<{ nextSteps?: string; packageManager?: AgentName }> {
 	const selectedAdders: SelectedAdder[] = selectedAdderIds.map((id) => ({
 		type: 'official',
 		adder: getAdderDetails(id)
@@ -267,7 +267,7 @@ export async function runAddCommand(
 
 	// prompt which adders to apply
 	if (selectedAdders.length === 0) {
-		const workspace = createWorkspace(options.cwd);
+		const workspace = createWorkspace({ cwd: options.cwd });
 		const projectType = workspace.kit ? 'kit' : 'svelte';
 		const adderOptions = officialAdders
 			.map((adder) => {
@@ -301,7 +301,7 @@ export async function runAddCommand(
 		const dependents =
 			adder.dependsOn?.filter((dep) => !selectedAdders.some((a) => a.adder.id === dep)) ?? [];
 
-		const workspace = createWorkspace(options.cwd);
+		const workspace = createWorkspace({ cwd: options.cwd });
 		for (const depId of dependents) {
 			const dependent = officialAdders.find((a) => a.id === depId) as AdderWithoutExplicitArgs;
 			if (!dependent) throw new Error(`Adder '${adder.id}' depends on an invalid '${depId}'`);
@@ -330,7 +330,7 @@ export async function runAddCommand(
 	// run precondition checks
 	if (options.preconditions && selectedAdders.length > 0) {
 		// add global checks
-		const { kit } = createWorkspace(options.cwd);
+		const { kit } = createWorkspace({ cwd: options.cwd });
 		const projectType = kit ? 'kit' : 'svelte';
 		const adders = selectedAdders.map(({ adder }) => adder);
 		const { preconditions } = common.getGlobalPreconditions(options.cwd, projectType, adders);
@@ -418,30 +418,31 @@ export async function runAddCommand(
 		}
 	}
 
+	// prompt for package manager
+	let packageManager: AgentName | undefined;
+	if (options.install && selectedAdders.length > 0) {
+		packageManager = await common.packageManagerPrompt(options.cwd);
+	}
+
 	// apply adders
 	let filesToFormat: string[] = [];
 	if (Object.keys({ ...official, ...community }).length > 0) {
-		filesToFormat = await runAdders({ cwd: options.cwd, official, community });
+		filesToFormat = await runAdders({ cwd: options.cwd, packageManager, official, community });
 		p.log.success('Successfully setup integrations');
 	}
 
 	// install dependencies
-	let depsStatus: 'installed' | 'skipped' = 'skipped';
-	if (options.install && selectedAdders.length > 0) {
-		depsStatus = await common.suggestInstallingDependencies(options.cwd);
+	if (packageManager && options.install && selectedAdders.length > 0) {
+		await common.installDependencies(packageManager, options.cwd);
 	}
 
 	// format modified/created files with prettier (if available)
-	const workspace = createWorkspace(options.cwd);
-	if (
-		filesToFormat.length > 0 &&
-		depsStatus === 'installed' &&
-		!!workspace.dependencyVersion('prettier')
-	) {
+	const workspace = createWorkspace({ cwd: options.cwd, packageManager });
+	if (filesToFormat.length > 0 && packageManager && !!workspace.dependencyVersion('prettier')) {
 		const { start, stop } = p.spinner();
 		start('Formatting modified files');
 		try {
-			await common.formatFiles(options.cwd, filesToFormat);
+			await common.formatFiles({ packageManager, cwd: options.cwd, paths: filesToFormat });
 			stop('Successfully formatted modified files');
 		} catch (e) {
 			stop('Failed to format files');
@@ -472,7 +473,7 @@ export async function runAddCommand(
 			// instead of returning an empty string, we'll return `undefined`
 			.join('\n\n') || undefined;
 
-	return { nextSteps };
+	return { nextSteps, packageManager };
 }
 
 type AdderId = string;
@@ -481,6 +482,7 @@ export type AdderOption = Record<AdderId, QuestionValues>;
 
 export type InstallAdderOptions = {
 	cwd: string;
+	packageManager?: AgentName;
 	official?: AdderOption;
 	community?: AdderOption;
 };
@@ -491,7 +493,8 @@ export type InstallAdderOptions = {
 async function runAdders({
 	cwd,
 	official = {},
-	community = {}
+	community = {},
+	packageManager
 }: InstallAdderOptions): Promise<string[]> {
 	const adderDetails = Object.keys(official).map((id) => getAdderDetails(id));
 	const commDetails = Object.keys(community).map(
@@ -514,7 +517,7 @@ async function runAdders({
 	const filesToFormat = new Set<string>();
 	for (const config of details) {
 		const adderId = config.id;
-		const workspace = createWorkspace(cwd);
+		const workspace = createWorkspace({ cwd, packageManager });
 
 		workspace.options = official[adderId] ?? community[adderId]!;
 

--- a/packages/cli/commands/add/index.ts
+++ b/packages/cli/commands/add/index.ts
@@ -418,6 +418,8 @@ export async function runAddCommand(
 		}
 	}
 
+	// we'll return early when no adders are selected,
+	// indicating that installing deps was skipped and no PM was selected
 	if (selectedAdders.length === 0) return { packageManager: null };
 
 	// prompt for package manager

--- a/packages/cli/commands/add/workspace.ts
+++ b/packages/cli/commands/add/workspace.ts
@@ -42,10 +42,8 @@ export function createWorkspace({ cwd, packageManager }: CreateWorkspaceOptions)
 		dependencies[key] = value.replaceAll(/[^\d|.]/g, '');
 	}
 
-	const kit = dependencies['@sveltejs/kit'] ? parseKitOptions(resolvedCwd) : undefined;
-
 	return {
-		kit,
+		kit: dependencies['@sveltejs/kit'] ? parseKitOptions(resolvedCwd) : undefined,
 		packageManager: packageManager ?? getUserAgent() ?? 'npm',
 		cwd: resolvedCwd,
 		dependencyVersion: (pkg) => dependencies[pkg],

--- a/packages/cli/commands/create.ts
+++ b/packages/cli/commands/create.ts
@@ -147,10 +147,7 @@ async function createProject(cwd: string, options: Options) {
 		);
 		packageManager = pm;
 		integrationNextSteps = nextSteps;
-	}
-
-	// show install prompt even if no integrations are selected
-	if (!packageManager && options.install) {
+	} else if (options.install) {
 		// `runAddCommand` includes the installing dependencies prompt. if it's skipped,
 		// then we'll prompt to install dependencies here
 		packageManager = await common.packageManagerPrompt(projectPath);

--- a/packages/cli/commands/create.ts
+++ b/packages/cli/commands/create.ts
@@ -13,6 +13,7 @@ import {
 } from '@sveltejs/create';
 import * as common from '../common.js';
 import { runAddCommand } from './add/index.ts';
+import { detectSync, type AgentName } from 'package-manager-detector';
 
 const langs = ['typescript', 'checkjs', 'none'] as const;
 const templateChoices = templates.map((t) => t.name);
@@ -42,17 +43,17 @@ export const create = new Command('create')
 		const cwd = v.parse(ProjectPathSchema, projectPath);
 		const options = v.parse(OptionsSchema, opts);
 		common.runCommand(async () => {
-			const { directory, integrationNextSteps } = await createProject(cwd, options);
+			const { directory, integrationNextSteps, packageManager } = await createProject(cwd, options);
 			const highlight = (str: string) => pc.bold(pc.cyan(str));
 
 			let i = 1;
 			const initialSteps: string[] = [];
 			const relative = path.relative(process.cwd(), directory);
-			const pm = common.detectPackageManager(cwd);
+			const pm = packageManager ?? detectSync({ cwd })?.name ?? common.getUserAgent() ?? 'npm';
 			if (relative !== '') {
 				initialSteps.push(`${i++}: ${highlight(`cd ${relative}`)}`);
 			}
-			if (!common.packageManager) {
+			if (!packageManager) {
 				initialSteps.push(`${i++}: ${highlight(`${pm} install`)}`);
 			}
 
@@ -137,20 +138,24 @@ async function createProject(cwd: string, options: Options) {
 
 	p.log.success('Project created');
 
-	let integrationNextSteps;
+	let packageManager: AgentName | undefined;
+	let integrationNextSteps: string | undefined;
 	if (options.integrations) {
-		const { nextSteps } = await runAddCommand(
-			{ cwd: projectPath, install: false, preconditions: true, community: [] },
+		const { nextSteps, packageManager: pm } = await runAddCommand(
+			{ cwd: projectPath, install: options.install, preconditions: true, community: [] },
 			[]
 		);
+		packageManager = pm;
 		integrationNextSteps = nextSteps;
 	}
+
 	// show install prompt even if no integrations are selected
-	if (options.install) {
+	if (!packageManager && options.install) {
 		// `runAddCommand` includes the installing dependencies prompt. if it's skipped,
 		// then we'll prompt to install dependencies here
-		await common.suggestInstallingDependencies(projectPath);
+		packageManager = await common.packageManagerPrompt(projectPath);
+		if (packageManager) await common.installDependencies(packageManager, projectPath);
 	}
 
-	return { directory: projectPath, integrationNextSteps };
+	return { directory: projectPath, integrationNextSteps, packageManager };
 }


### PR DESCRIPTION
closes #151

unifies the `packageManager` field such that the value that's passed to adders (for uses such as in `nextSteps`) is the same as the chosen PM from the user prompt