### PR TITLE
chore(POC): simpler / more flexible api

### DIFF
--- a/packages/adders/common.ts
+++ b/packages/adders/common.ts
@@ -65,10 +65,7 @@ export function addEslintConfigPrettier({ content }: FileEditor<Record<string, Q
 	return generateCode();
 }
 
-export function addToDemoPage(
-	{ content }: FileEditor<Record<string, Question>>,
-	path: string
-): string {
+export function addToDemoPage(content: string, path: string): string {
 	const { template, generateCode } = parseSvelte(content);
 
 	for (const node of template.ast.childNodes) {

--- a/packages/adders/paraglide/index.ts
+++ b/packages/adders/paraglide/index.ts
@@ -10,27 +10,11 @@ import {
 	object,
 	variables,
 	exports,
-	kit
+	kit as kitJs
 } from '@sveltejs/cli-core/js';
 import * as html from '@sveltejs/cli-core/html';
 import { parseHtml, parseJson, parseScript, parseSvelte } from '@sveltejs/cli-core/parsers';
 import { addToDemoPage } from '../common.ts';
-
-const DEFAULT_INLANG_PROJECT = {
-	$schema: 'https://inlang.com/schema/project-settings',
-	modules: [
-		'https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-empty-pattern@1/dist/index.js',
-		'https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-identical-pattern@1/dist/index.js',
-		'https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-missing-translation@1/dist/index.js',
-		'https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-without-source@1/dist/index.js',
-		'https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-valid-js-identifier@1/dist/index.js',
-		'https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@2/dist/index.js',
-		'https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@0/dist/index.js'
-	],
-	'plugin.inlang.messageFormat': {
-		pathPattern: './messages/{languageTag}.json'
-	}
-};
 
 export const options = defineAdderOptions({
 	availableLanguageTags: {
@@ -66,20 +50,28 @@ export default defineAdder({
 	environments: { svelte: false, kit: true },
 	homepage: 'https://inlang.com',
 	options,
-	packages: [
-		{
-			name: '@inlang/paraglide-sveltekit',
-			version: '^0.11.1',
-			dev: false
-		}
-	],
-	files: [
-		{
-			// create an inlang project if it doesn't exist yet
-			name: () => 'project.inlang/settings.json',
-			condition: ({ cwd }) => !fs.existsSync(path.join(cwd, 'project.inlang/settings.json')),
-			content: ({ options, content }) => {
+	run: ({ files, cwd, options, typescript, kit, packages, dependencyVersion }) => {
+		packages.dependency('@inlang/paraglide-sveltekit', '^0.11.1');
+
+		if (!fs.existsSync(path.join(cwd, 'project.inlang/settings.json'))) {
+			files.update('project.inlang/settings.json', (content) => {
 				const { data, generateCode } = parseJson(content);
+
+				const DEFAULT_INLANG_PROJECT = {
+					$schema: 'https://inlang.com/schema/project-settings',
+					modules: [
+						'https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-empty-pattern@1/dist/index.js',
+						'https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-identical-pattern@1/dist/index.js',
+						'https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-missing-translation@1/dist/index.js',
+						'https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-without-source@1/dist/index.js',
+						'https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-valid-js-identifier@1/dist/index.js',
+						'https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@2/dist/index.js',
+						'https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@0/dist/index.js'
+					],
+					'plugin.inlang.messageFormat': {
+						pathPattern: './messages/{languageTag}.json'
+					}
+				};
 
 				for (const key in DEFAULT_INLANG_PROJECT) {
 					data[key] = DEFAULT_INLANG_PROJECT[key as keyof typeof DEFAULT_INLANG_PROJECT];
@@ -91,158 +83,141 @@ export default defineAdder({
 				data.languageTags = validLanguageTags;
 
 				return generateCode();
+			});
+		}
+
+		// add the vite plugin
+		files.update(`vite.config.${typescript ? 'ts' : 'js'}`, (content) => {
+			const { ast, generateCode } = parseScript(content);
+
+			const vitePluginName = 'paraglide';
+			imports.addNamed(ast, '@inlang/paraglide-sveltekit/vite', { paraglide: vitePluginName });
+
+			const { value: rootObject } = exports.defaultExport(ast, functions.call('defineConfig', []));
+			const param1 = functions.argumentByIndex(rootObject, 0, object.createEmpty());
+
+			const pluginsArray = object.property(param1, 'plugins', array.createEmpty());
+			const pluginFunctionCall = functions.call(vitePluginName, []);
+			const pluginConfig = object.create({
+				project: common.createLiteral('./project.inlang'),
+				outdir: common.createLiteral('./src/lib/paraglide')
+			});
+			functions.argumentByIndex(pluginFunctionCall, 0, pluginConfig);
+			array.push(pluginsArray, pluginFunctionCall);
+
+			return generateCode();
+		});
+
+		// src/lib/i18n file
+		files.update(`src/lib/i18n.${typescript ? 'ts' : 'js'}`, (content) => {
+			const { ast, generateCode } = parseScript(content);
+
+			imports.addNamed(ast, '@inlang/paraglide-sveltekit', { createI18n: 'createI18n' });
+			imports.addDefault(ast, '$lib/paraglide/runtime', '* as runtime');
+
+			const createI18nExpression = common.expressionFromString('createI18n(runtime)');
+			const i18n = variables.declaration(ast, 'const', 'i18n', createI18nExpression);
+
+			const existingExport = exports.namedExport(ast, 'i18n', i18n);
+			if (existingExport.declaration != i18n) {
+				log.warn('Setting up $lib/i18n failed because it already exports an i18n function');
 			}
-		},
-		{
-			// add the vite plugin
-			name: ({ typescript }) => `vite.config.${typescript ? 'ts' : 'js'}`,
-			content: ({ content }) => {
-				const { ast, generateCode } = parseScript(content);
 
-				const vitePluginName = 'paraglide';
-				imports.addNamed(ast, '@inlang/paraglide-sveltekit/vite', { paraglide: vitePluginName });
+			return generateCode();
+		});
 
-				const { value: rootObject } = exports.defaultExport(
-					ast,
-					functions.call('defineConfig', [])
+		// reroute hook
+		files.update(`src/hooks.${typescript ? 'ts' : 'js'}`, (content) => {
+			const { ast, generateCode } = parseScript(content);
+
+			imports.addNamed(ast, '$lib/i18n', {
+				i18n: 'i18n'
+			});
+
+			const expression = common.expressionFromString('i18n.reroute()');
+			const rerouteIdentifier = variables.declaration(ast, 'const', 'reroute', expression);
+
+			const existingExport = exports.namedExport(ast, 'reroute', rerouteIdentifier);
+			if (existingExport.declaration != rerouteIdentifier) {
+				log.warn('Adding the reroute hook automatically failed. Add it manually');
+			}
+
+			return generateCode();
+		});
+
+		// handle hook
+		files.update(`src/hooks.server.${typescript ? 'ts' : 'js'}`, (content) => {
+			const { ast, generateCode } = parseScript(content);
+
+			imports.addNamed(ast, '$lib/i18n', {
+				i18n: 'i18n'
+			});
+
+			const hookHandleContent = 'i18n.handle()';
+			kitJs.addHooksHandle(ast, typescript, 'handleParaglide', hookHandleContent);
+
+			return generateCode();
+		});
+
+		// add the <ParaglideJS> component to the layout
+		files.update(`${kit?.routesDirectory}/+layout.svelte`, (content) => {
+			const { script, template, generateCode } = parseSvelte(content, { typescript });
+
+			const paraglideComponentName = 'ParaglideJS';
+			imports.addNamed(script.ast, '@inlang/paraglide-sveltekit', {
+				[paraglideComponentName]: paraglideComponentName
+			});
+			imports.addNamed(script.ast, '$lib/i18n', {
+				i18n: 'i18n'
+			});
+
+			if (template.source.length === 0) {
+				const svelteVersion = dependencyVersion('svelte');
+				if (!svelteVersion) throw new Error('Failed to determine svelte version');
+
+				html.addSlot(script.ast, template.ast, svelteVersion);
+			}
+
+			const templateCode = new MagicString(template.generateCode());
+			if (!templateCode.original.includes('<ParaglideJS')) {
+				templateCode.indent();
+				templateCode.prepend('<ParaglideJS {i18n}>\n');
+				templateCode.append('\n</ParaglideJS>');
+			}
+
+			return generateCode({ script: script.generateCode(), template: templateCode.toString() });
+		});
+
+		// add the text-direction and lang attribute placeholders to app.html
+		files.update('src/app.html', (content) => {
+			const { ast, generateCode } = parseHtml(content);
+
+			const htmlNode = ast.children.find(
+				(child): child is html.HtmlElement =>
+					child.type === html.HtmlElementType.Tag && child.name === 'html'
+			);
+			if (!htmlNode) {
+				log.warn(
+					"Could not find <html> node in app.html. You'll need to add the language placeholder manually"
 				);
-				const param1 = functions.argumentByIndex(rootObject, 0, object.createEmpty());
-
-				const pluginsArray = object.property(param1, 'plugins', array.createEmpty());
-				const pluginFunctionCall = functions.call(vitePluginName, []);
-				const pluginConfig = object.create({
-					project: common.createLiteral('./project.inlang'),
-					outdir: common.createLiteral('./src/lib/paraglide')
-				});
-				functions.argumentByIndex(pluginFunctionCall, 0, pluginConfig);
-				array.push(pluginsArray, pluginFunctionCall);
-
 				return generateCode();
 			}
-		},
-		{
-			// src/lib/i18n file
-			name: ({ typescript }) => `src/lib/i18n.${typescript ? 'ts' : 'js'}`,
-			content({ content }) {
-				const { ast, generateCode } = parseScript(content);
+			htmlNode.attribs = {
+				...htmlNode.attribs,
+				lang: '%paraglide.lang%',
+				dir: '%paraglide.textDirection%'
+			};
 
-				imports.addNamed(ast, '@inlang/paraglide-sveltekit', { createI18n: 'createI18n' });
-				imports.addDefault(ast, '$lib/paraglide/runtime', '* as runtime');
+			return generateCode();
+		});
 
-				const createI18nExpression = common.expressionFromString('createI18n(runtime)');
-				const i18n = variables.declaration(ast, 'const', 'i18n', createI18nExpression);
+		if (options.demo) {
+			files.update(`${kit?.routesDirectory}/demo/+page.svelte`, (content) => {
+				return addToDemoPage(content, 'paraglide');
+			});
 
-				const existingExport = exports.namedExport(ast, 'i18n', i18n);
-				if (existingExport.declaration != i18n) {
-					log.warn('Setting up $lib/i18n failed because it already exports an i18n function');
-				}
-
-				return generateCode();
-			}
-		},
-		{
-			// reroute hook
-			name: ({ typescript }) => `src/hooks.${typescript ? 'ts' : 'js'}`,
-			content({ content }) {
-				const { ast, generateCode } = parseScript(content);
-
-				imports.addNamed(ast, '$lib/i18n', {
-					i18n: 'i18n'
-				});
-
-				const expression = common.expressionFromString('i18n.reroute()');
-				const rerouteIdentifier = variables.declaration(ast, 'const', 'reroute', expression);
-
-				const existingExport = exports.namedExport(ast, 'reroute', rerouteIdentifier);
-				if (existingExport.declaration != rerouteIdentifier) {
-					log.warn('Adding the reroute hook automatically failed. Add it manually');
-				}
-
-				return generateCode();
-			}
-		},
-		{
-			// handle hook
-			name: ({ typescript }) => `src/hooks.server.${typescript ? 'ts' : 'js'}`,
-			content({ content, typescript }) {
-				const { ast, generateCode } = parseScript(content);
-
-				imports.addNamed(ast, '$lib/i18n', {
-					i18n: 'i18n'
-				});
-
-				const hookHandleContent = 'i18n.handle()';
-				kit.addHooksHandle(ast, typescript, 'handleParaglide', hookHandleContent);
-
-				return generateCode();
-			}
-		},
-		{
-			// add the <ParaglideJS> component to the layout
-			name: ({ kit }) => `${kit?.routesDirectory}/+layout.svelte`,
-			content: ({ content, dependencyVersion, typescript }) => {
-				const { script, template, generateCode } = parseSvelte(content, { typescript });
-
-				const paraglideComponentName = 'ParaglideJS';
-				imports.addNamed(script.ast, '@inlang/paraglide-sveltekit', {
-					[paraglideComponentName]: paraglideComponentName
-				});
-				imports.addNamed(script.ast, '$lib/i18n', {
-					i18n: 'i18n'
-				});
-
-				if (template.source.length === 0) {
-					const svelteVersion = dependencyVersion('svelte');
-					if (!svelteVersion) throw new Error('Failed to determine svelte version');
-
-					html.addSlot(script.ast, template.ast, svelteVersion);
-				}
-
-				const templateCode = new MagicString(template.generateCode());
-				if (!templateCode.original.includes('<ParaglideJS')) {
-					templateCode.indent();
-					templateCode.prepend('<ParaglideJS {i18n}>\n');
-					templateCode.append('\n</ParaglideJS>');
-				}
-
-				return generateCode({ script: script.generateCode(), template: templateCode.toString() });
-			}
-		},
-		{
-			// add the text-direction and lang attribute placeholders to app.html
-			name: () => 'src/app.html',
-			content: ({ content }) => {
-				const { ast, generateCode } = parseHtml(content);
-
-				const htmlNode = ast.children.find(
-					(child): child is html.HtmlElement =>
-						child.type === html.HtmlElementType.Tag && child.name === 'html'
-				);
-				if (!htmlNode) {
-					log.warn(
-						"Could not find <html> node in app.html. You'll need to add the language placeholder manually"
-					);
-					return generateCode();
-				}
-				htmlNode.attribs = {
-					...htmlNode.attribs,
-					lang: '%paraglide.lang%',
-					dir: '%paraglide.textDirection%'
-				};
-
-				return generateCode();
-			}
-		},
-		{
-			name: ({ kit }) => `${kit?.routesDirectory}/demo/+page.svelte`,
-			condition: ({ options }) => options.demo,
-			content: (editor) => addToDemoPage(editor, 'paraglide')
-		},
-		{
 			// add usage example
-			name: ({ kit }) => `${kit?.routesDirectory}/demo/paraglide/+page.svelte`,
-			condition: ({ options }) => options.demo,
-			content({ content, options, typescript }) {
+			files.update(`${kit?.routesDirectory}/demo/paraglide/+page.svelte`, (content) => {
 				const { script, template, generateCode } = parseSvelte(content, { typescript });
 
 				imports.addDefault(script.ast, '$lib/paraglide/messages.js', '* as m');
@@ -265,15 +240,15 @@ export default defineAdder({
 					scriptCode.trim();
 					scriptCode.append('\n\n');
 					scriptCode.append(dedent`
-					${ts('', '/**')} 
-					${ts('', '* @param import("$lib/paraglide/runtime").AvailableLanguageTag newLanguage')} 
-					${ts('', '*/')} 
-					function switchToLanguage(newLanguage${ts(': AvailableLanguageTag')}) {
-						const canonicalPath = i18n.route($page.url.pathname);
-						const localisedPath = i18n.resolveRoute(canonicalPath, newLanguage);
-						goto(localisedPath);
-					}
-				`);
+						${ts('', '/**')} 
+						${ts('', '* @param import("$lib/paraglide/runtime").AvailableLanguageTag newLanguage')} 
+						${ts('', '*/')} 
+						function switchToLanguage(newLanguage${ts(': AvailableLanguageTag')}) {
+							const canonicalPath = i18n.route($page.url.pathname);
+							const localisedPath = i18n.resolveRoute(canonicalPath, newLanguage);
+							goto(localisedPath);
+						}
+					`);
 				}
 
 				const templateCode = new MagicString(template.source);
@@ -293,26 +268,26 @@ export default defineAdder({
 				templateCode.append(`<div>\n${links}\n</div>`);
 
 				return generateCode({ script: scriptCode.toString(), template: templateCode.toString() });
-			}
+			});
 		}
-	],
-	postInstall: ({ cwd, options }) => {
-		const jsonData: Record<string, string> = {};
-		jsonData['$schema'] = 'https://inlang.com/schema/inlang-message-format';
 
 		const { validLanguageTags } = parseLanguageTagInput(options.availableLanguageTags);
 		for (const languageTag of validLanguageTags) {
-			jsonData.hello_world = `Hello, {name} from ${languageTag}!`;
+			files.update(`messages/${languageTag}.json`, (content) => {
+				const { data, generateCode } = parseJson(content);
+				data['$schema'] = 'https://inlang.com/schema/inlang-message-format';
+				data.hello_world = `Hello, {name} from ${languageTag}!`;
 
-			const filePath = `messages/${languageTag}.json`;
-			const directoryPath = path.dirname(filePath);
-			const fullDirectoryPath = path.join(cwd, directoryPath);
-			const fullFilePath = path.join(cwd, filePath);
-
-			fs.mkdirSync(fullDirectoryPath, { recursive: true });
-			fs.writeFileSync(fullFilePath, JSON.stringify(jsonData, null, 2) + '\n');
+				return generateCode();
+			});
 		}
 	},
+
+	// todo: to remove (start)
+	packages: [],
+	files: [],
+	// todo: to remove (end)
+
 	nextSteps: ({ highlighter }) => {
 		const steps = [
 			`Edit your messages in ${highlighter.path('messages/en.json')}`,

--- a/packages/adders/paraglide/index.ts
+++ b/packages/adders/paraglide/index.ts
@@ -50,11 +50,11 @@ export default defineAdder({
 	environments: { svelte: false, kit: true },
 	homepage: 'https://inlang.com',
 	options,
-	run: ({ files, cwd, options, typescript, kit, packages, dependencyVersion }) => {
-		packages.dependency('@inlang/paraglide-sveltekit', '^0.11.1');
+	run: ({ api, cwd, options, typescript, kit, dependencyVersion }) => {
+		api.dependency('@inlang/paraglide-sveltekit', '^0.11.1');
 
 		if (!fs.existsSync(path.join(cwd, 'project.inlang/settings.json'))) {
-			files.update('project.inlang/settings.json', (content) => {
+			api.updateFile('project.inlang/settings.json', (content) => {
 				const { data, generateCode } = parseJson(content);
 
 				const DEFAULT_INLANG_PROJECT = {
@@ -87,7 +87,7 @@ export default defineAdder({
 		}
 
 		// add the vite plugin
-		files.update(`vite.config.${typescript ? 'ts' : 'js'}`, (content) => {
+		api.updateFile(`vite.config.${typescript ? 'ts' : 'js'}`, (content) => {
 			const { ast, generateCode } = parseScript(content);
 
 			const vitePluginName = 'paraglide';
@@ -109,7 +109,7 @@ export default defineAdder({
 		});
 
 		// src/lib/i18n file
-		files.update(`src/lib/i18n.${typescript ? 'ts' : 'js'}`, (content) => {
+		api.updateFile(`src/lib/i18n.${typescript ? 'ts' : 'js'}`, (content) => {
 			const { ast, generateCode } = parseScript(content);
 
 			imports.addNamed(ast, '@inlang/paraglide-sveltekit', { createI18n: 'createI18n' });
@@ -127,7 +127,7 @@ export default defineAdder({
 		});
 
 		// reroute hook
-		files.update(`src/hooks.${typescript ? 'ts' : 'js'}`, (content) => {
+		api.updateFile(`src/hooks.${typescript ? 'ts' : 'js'}`, (content) => {
 			const { ast, generateCode } = parseScript(content);
 
 			imports.addNamed(ast, '$lib/i18n', {
@@ -146,7 +146,7 @@ export default defineAdder({
 		});
 
 		// handle hook
-		files.update(`src/hooks.server.${typescript ? 'ts' : 'js'}`, (content) => {
+		api.updateFile(`src/hooks.server.${typescript ? 'ts' : 'js'}`, (content) => {
 			const { ast, generateCode } = parseScript(content);
 
 			imports.addNamed(ast, '$lib/i18n', {
@@ -160,7 +160,7 @@ export default defineAdder({
 		});
 
 		// add the <ParaglideJS> component to the layout
-		files.update(`${kit?.routesDirectory}/+layout.svelte`, (content) => {
+		api.updateFile(`${kit?.routesDirectory}/+layout.svelte`, (content) => {
 			const { script, template, generateCode } = parseSvelte(content, { typescript });
 
 			const paraglideComponentName = 'ParaglideJS';
@@ -189,7 +189,7 @@ export default defineAdder({
 		});
 
 		// add the text-direction and lang attribute placeholders to app.html
-		files.update('src/app.html', (content) => {
+		api.updateFile('src/app.html', (content) => {
 			const { ast, generateCode } = parseHtml(content);
 
 			const htmlNode = ast.children.find(
@@ -212,12 +212,12 @@ export default defineAdder({
 		});
 
 		if (options.demo) {
-			files.update(`${kit?.routesDirectory}/demo/+page.svelte`, (content) => {
+			api.updateFile(`${kit?.routesDirectory}/demo/+page.svelte`, (content) => {
 				return addToDemoPage(content, 'paraglide');
 			});
 
 			// add usage example
-			files.update(`${kit?.routesDirectory}/demo/paraglide/+page.svelte`, (content) => {
+			api.updateFile(`${kit?.routesDirectory}/demo/paraglide/+page.svelte`, (content) => {
 				const { script, template, generateCode } = parseSvelte(content, { typescript });
 
 				imports.addDefault(script.ast, '$lib/paraglide/messages.js', '* as m');
@@ -273,7 +273,7 @@ export default defineAdder({
 
 		const { validLanguageTags } = parseLanguageTagInput(options.availableLanguageTags);
 		for (const languageTag of validLanguageTags) {
-			files.update(`messages/${languageTag}.json`, (content) => {
+			api.updateFile(`messages/${languageTag}.json`, (content) => {
 				const { data, generateCode } = parseJson(content);
 				data['$schema'] = 'https://inlang.com/schema/inlang-message-format';
 				data.hello_world = `Hello, {name} from ${languageTag}!`;

--- a/packages/core/adder/config.ts
+++ b/packages/core/adder/config.ts
@@ -27,7 +27,7 @@ export type Scripts<Args extends OptionDefinition> = {
 
 // todo: rename
 export type FileApi = {
-	update: (name: string, content: (content: string) => string) => string;
+	updateFile: (name: string, content: (content: string) => string) => string;
 };
 
 // todo: rename
@@ -55,7 +55,7 @@ export type Adder<Args extends OptionDefinition> = {
 	) => string[];
 
 	run: (
-		workspace: Workspace<Args> & { files: FileApi; packages: PackageApi; scripts: ScriptApi }
+		workspace: Workspace<Args> & { api: FileApi & PackageApi & ScriptApi }
 	) => MaybePromise<void>;
 
 	// todo: to remove (start)

--- a/packages/core/adder/config.ts
+++ b/packages/core/adder/config.ts
@@ -25,6 +25,22 @@ export type Scripts<Args extends OptionDefinition> = {
 	condition?: ConditionDefinition<Args>;
 };
 
+// todo: rename
+export type FileApi = {
+	update: (name: string, content: (content: string) => string) => string;
+};
+
+// todo: rename
+export type PackageApi = {
+	dependency: (pkg: string, version: string) => void;
+	devDependency: (pkg: string, version: string) => void;
+};
+
+// todo: rename
+export type ScriptApi = {
+	run: (args: { description: string; args: string[]; stdio: 'inherit' | 'pipe' }) => void;
+};
+
 export type Adder<Args extends OptionDefinition> = {
 	id: string;
 	alias?: string;
@@ -32,16 +48,23 @@ export type Adder<Args extends OptionDefinition> = {
 	homepage?: string;
 	options: Args;
 	dependsOn?: string[];
-	packages: Array<PackageDefinition<Args>>;
-	scripts?: Array<Scripts<Args>>;
-	files: Array<FileType<Args>>;
-	preInstall?: (workspace: Workspace<Args>) => MaybePromise<void>;
-	postInstall?: (workspace: Workspace<Args>) => MaybePromise<void>;
 	nextSteps?: (
 		data: {
 			highlighter: Highlighter;
 		} & Workspace<Args>
 	) => string[];
+
+	run: (
+		workspace: Workspace<Args> & { files: FileApi; packages: PackageApi; scripts: ScriptApi }
+	) => MaybePromise<void>;
+
+	// todo: to remove (start)
+	files: Array<FileType<Args>>;
+	preInstall?: (workspace: Workspace<Args>) => MaybePromise<void>;
+	postInstall?: (workspace: Workspace<Args>) => MaybePromise<void>;
+	packages: Array<PackageDefinition<Args>>;
+	scripts?: Array<Scripts<Args>>;
+	// todo: to remove (end)
 };
 
 export type Highlighter = {


### PR DESCRIPTION
Closes #85 

This is a POC to start visualizing stuff and initiate discussions. Besides of some new types & adapting the `paraglide` adder, I haven't done any implementation. So expect plenty of type errors and failing pipelines.

Up until now I was keeping my mouth shut about #85 as I had many doubts if this was the right way going forward. Also I had a hard time imagining how this would look in a real adder. Now that this is done with this POC it was eye opening how many flexibilities this will bring us & the community. Besides copying some code, there are nearly zero changes that affect the functionality of the adders. Since most of the functionality already exists it should be straight forward to implement this, once we come up with the "final" api. Most of the work probably needs to be done inside the adders, as there is lots of stuff that needs to be moved.