### PR TITLE
chore: color help screen

### DIFF
--- a/.changeset/tough-gorillas-switch.md
+++ b/.changeset/tough-gorillas-switch.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+chore: color help screen

--- a/packages/cli/common.ts
+++ b/packages/cli/common.ts
@@ -8,7 +8,31 @@ import { COMMANDS, constructCommand, resolveCommand } from 'package-manager-dete
 import type { Argument, HelpConfiguration, Option } from 'commander';
 import type { AdderWithoutExplicitArgs, Precondition } from '@sveltejs/cli-core';
 
+// partially sourced from https://github.com/tj/commander.js/blob/970ecae402b253de691e6a9066fea22f38fe7431/lib/help.js#L12
 export const helpConfig: HelpConfiguration = {
+	subcommandTerm: (cmd) => {
+		const humanReadableArgName = (arg: Argument) => {
+			const nameOutput = arg.name() + (arg.variadic === true ? '...' : '');
+
+			return arg.required ? '<' + nameOutput + '>' : '[' + nameOutput + ']';
+		};
+
+		// Legacy. Ignores custom usage string, and nested commands.
+		const args = cmd.registeredArguments.map((arg) => humanReadableArgName(arg)).join(' ');
+		const aliases = cmd.aliases();
+		return (
+			pc.blue(cmd.name()) +
+			(aliases[0] ? '|' + aliases[0] : '') +
+			(cmd.options.length ? ' [options]' : '') + // simplistic check for non-help option
+			(args ? ' ' + args : '')
+		);
+	},
+	argumentTerm: (arg) => {
+		return pc.blue(arg.name());
+	},
+	optionTerm: (option) => {
+		return pc.blue(option.flags);
+	},
 	argumentDescription: formatDescription,
 	optionDescription: formatDescription
 };


### PR DESCRIPTION
Closes #195

Adds some basic color support. Colors can now easily be changed. 
The problem is that this currently not supported by `commander`m but a PR is on it's way: https://github.com/tj/commander.js/pull/2251
In the meantime it was necessary to pull in a small amount of code from commander to make this work. We might need to debate if it's worth it to pull in that code or to wait.

From a readability pov, i do think this is a major improvement.

![image](https://github.com/user-attachments/assets/df847a89-c883-4b4f-9523-69bbe1dc0d48)

![image](https://github.com/user-attachments/assets/e9bd536c-cc86-48b2-a888-bf6b64abb643)