### PR TITLE
fix: `tailwindcss` import insertions and execution order

### DIFF
--- a/.changeset/silver-geese-punch.md
+++ b/.changeset/silver-geese-punch.md
@@ -1,0 +1,5 @@
+---
+"sv": patch
+---
+
+fix: `tailwindcss` import insertions and execution order

--- a/packages/adders/tailwindcss/index.ts
+++ b/packages/adders/tailwindcss/index.ts
@@ -128,13 +128,18 @@ export default defineAdder({
 		{
 			name: () => 'src/app.css',
 			content: ({ content }) => {
-				const { ast, generateCode } = parseCss(content);
 				const layerImports = ['base', 'components', 'utilities'].map(
-					(layer) => `"tailwindcss/${layer}"`
+					(layer) => `tailwindcss/${layer}`
 				);
+				if (layerImports.every((i) => content.includes(i))) {
+					return content;
+				}
+
+				const { ast, generateCode } = parseCss(content);
 				const originalFirst = ast.first;
 
-				const nodes = addImports(ast, layerImports);
+				const specifiers = layerImports.map((i) => `'${i}'`);
+				const nodes = addImports(ast, specifiers);
 
 				if (
 					originalFirst !== ast.first &&

--- a/packages/cli/commands/add/index.ts
+++ b/packages/cli/commands/add/index.ts
@@ -508,6 +508,7 @@ async function runAdders({
 	// and adders with dependencies runs later on, based on the adders they depend on.
 	// based on https://stackoverflow.com/a/72030336/16075084
 	details.sort((a, b) => {
+		if (!a.dependsOn && !b.dependsOn) return 0;
 		if (!a.dependsOn) return -1;
 		if (!b.dependsOn) return 1;
 


### PR DESCRIPTION
closes #220

This is a good instance where having [`runsAfter`](https://github.com/sveltejs/cli/pull/86) would've been useful. While `tailwindcss` doesn't require `prettier` to function, ensuring that it's executed _after_ `prettier` would've guaranteed that the `prettier-plugin-tailwindcss` is installed when they've both been selected

rather than bringing `runsAfter` back, I've tweaked the sorting order so that 2 adders that don't have `dependsOn` specified stay in place, which is just a temp fix

Re: Duplicate `@import` statements - this was another case where `"` vs `'` made a difference