### PR TITLE
fix: update `README.md` generated by `sv create`

### DIFF
--- a/.changeset/real-bobcats-act.md
+++ b/.changeset/real-bobcats-act.md
@@ -2,4 +2,4 @@
 "@sveltejs/create": patch
 ---
 
-docs: replace mention of `create-svelte` in newly created `README.md`
+chore: replace mention of `create-svelte` in newly created `README.md`

--- a/.changeset/real-bobcats-act.md
+++ b/.changeset/real-bobcats-act.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/create": patch
+---
+
+docs: replace mention of `create-svelte` in newly created `README.md`

--- a/packages/create/shared/README.md
+++ b/packages/create/shared/README.md
@@ -1,6 +1,6 @@
-# create-svelte
+# sv
 
-Everything you need to build a Svelte project, powered by [`create-svelte`](https://github.com/sveltejs/kit/tree/main/packages/create-svelte).
+Everything you need to build a Svelte project, powered by [`sv`](https://github.com/sveltejs/cli).
 
 ## Creating a project
 


### PR DESCRIPTION
The default `README.md` still has references to the older `create-svelte` package, whereas all code blocks got updated with `sv` CLI.