### PR TITLE
Tailwindcss default export should use `satisfies` instead of `as`

### DIFF
--- a/packages/adders/tailwindcss/index.ts
+++ b/packages/adders/tailwindcss/index.ts
@@ -80,7 +80,7 @@ export default defineAdder({
 				const rootExport = object.createEmpty();
 				if (typescript) {
 					imports.addNamed(ast, 'tailwindcss', { Config: 'Config' }, true);
-					root = common.typeAnnotateExpression(rootExport, 'Config');
+					root = common.typeAnnotateSatisfiesExpression(rootExport, 'Config');
 				}
 
 				const { astNode: exportDeclaration, value: node } = exports.defaultExport(

--- a/packages/ast-tooling/index.ts
+++ b/packages/ast-tooling/index.ts
@@ -16,7 +16,7 @@ import {
 import * as fleece from 'silver-fleece';
 import * as Walker from 'zimmerframe';
 import type { namedTypes as AstTypes } from 'ast-types';
-import type * as AstKinds from 'ast-types/gen/kinds.d.ts';
+import * as AstKinds from 'ast-types/gen/kinds';
 
 /**
  * Most of the AST tooling is pretty big in bundle size and bundling takes forever.

--- a/packages/ast-tooling/package.json
+++ b/packages/ast-tooling/package.json
@@ -1,38 +1,38 @@
 {
-	"name": "@sveltejs/ast-tooling",
-	"private": true,
-	"version": "0.0.0",
-	"type": "module",
-	"license": "MIT",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/sveltejs/cli/tree/main/packages/ast-tooling"
-	},
-	"bugs": "https://github.com/sveltejs/cli/issues",
-	"scripts": {
-		"check": "tsc",
-		"format": "pnpm lint --write",
-		"lint": "prettier --check . --config ../../prettier.config.js --ignore-path ../../.gitignore --ignore-path .gitignore --ignore-path ../../.prettierignore"
-	},
-	"files": [
-		"dist"
-	],
-	"exports": {
-		".": {
-			"types": "./dist/index.d.ts",
-			"default": "./dist/index.js"
-		}
-	},
-	"devDependencies": {
-		"@babel/parser": "^7.24.7",
-		"ast-types": "^0.14.2",
-		"dom-serializer": "^2.0.0",
-		"domhandler": "^5.0.3",
-		"domutils": "^3.1.0",
-		"htmlparser2": "^9.1.0",
-		"postcss": "^8.4.38",
-		"recast": "^0.23.7",
-		"silver-fleece": "^1.2.1",
-		"zimmerframe": "^1.1.2"
-	}
+  "name": "@sveltejs/ast-tooling",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sveltejs/cli/tree/main/packages/ast-tooling"
+  },
+  "bugs": "https://github.com/sveltejs/cli/issues",
+  "scripts": {
+    "check": "tsc",
+    "format": "pnpm lint --write",
+    "lint": "prettier --check . --config ../../prettier.config.js --ignore-path ../../.gitignore --ignore-path .gitignore --ignore-path ../../.prettierignore"
+  },
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "devDependencies": {
+    "@babel/parser": "^7.24.7",
+    "ast-types": "^0.16.1",
+    "dom-serializer": "^2.0.0",
+    "domhandler": "^5.0.3",
+    "domutils": "^3.1.0",
+    "htmlparser2": "^9.1.0",
+    "postcss": "^8.4.38",
+    "recast": "^0.23.7",
+    "silver-fleece": "^1.2.1",
+    "zimmerframe": "^1.1.2"
+  }
 }

--- a/packages/core/tooling/js/common.ts
+++ b/packages/core/tooling/js/common.ts
@@ -54,6 +54,19 @@ export function typeAnnotateExpression(
 	return expression;
 }
 
+export function typeAnnotateSatisfiesExpression(
+	node: AstKinds.ExpressionKind,
+	type: string
+): AstTypes.TSSatisfiesExpression {
+	const expression: AstTypes.TSSatisfiesExpression = {
+		type: 'TSSatisfiesExpression',
+		expression: node,
+		typeAnnotation: { type: 'TSTypeReference', typeName: { type: 'Identifier', name: type } }
+	};
+
+	return expression;
+}
+
 export function createSpreadElement(expression: AstKinds.ExpressionKind): AstTypes.SpreadElement {
 	return {
 		type: 'SpreadElement',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,8 +103,8 @@ importers:
         specifier: ^7.24.7
         version: 7.25.3
       ast-types:
-        specifier: ^0.14.2
-        version: 0.14.2
+        specifier: ^0.16.1
+        version: 0.16.1
       dom-serializer:
         specifier: ^2.0.0
         version: 2.0.0
@@ -890,10 +890,6 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
-
-  ast-types@0.14.2:
-    resolution: {integrity: sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==}
-    engines: {node: '>=4'}
 
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
@@ -2894,10 +2890,6 @@ snapshots:
   array-union@2.1.0: {}
 
   assertion-error@2.0.1: {}
-
-  ast-types@0.14.2:
-    dependencies:
-      tslib: 2.6.3
 
   ast-types@0.16.1:
     dependencies:


### PR DESCRIPTION
The previous adder would create the following config file for tailwindcss:

```ts
import type { Config } from 'tailwindcss';

export default {
	content: ['./src/**/*.{html,js,svelte,ts}'],

	theme: {
		extend: {}
	}
} as Config;
```

With these changes, we can use the `satisfies` operator instead of `as`, and gain all the type hints which that brings.

There are probably other adders that will benefit from using `satisfies`