### PR TITLE
Update docs

### DIFF
--- a/documentation/docs/20-commands/10-sv-create.md
+++ b/documentation/docs/20-commands/10-sv-create.md
@@ -7,24 +7,36 @@ title: sv create
 ## Usage
 
 ```bash
-npx sv create
+npx sv create [options] [path]
 ```
 
-```bash
-npx sv create ./my/path
-```
+## Options
 
-## Available options
+### `--check-types=<option>`
 
-| Option            | option values                 | default    | description                                                |
-| ----------------- | ----------------------------- | ---------- | ---------------------------------------------------------- |
-| --check-types     | typescript \| checkjs \| none | typescript | determine if type checking should be added to this project |
-| --template        | minimal \| library \| demo    | minimal    | project template                                           |
-| --no-integrations | -                             | -          | skips interactive integration installer                    |
-| --no-install      | -                             | -          | skips installing dependencies                              |
+Whether and how to add typechecking to the project:
 
-<!--
-## Programmatic interface
+- `typescript` — default to `.ts` files and use `lang="ts"` for `.svelte` components
+- `checkjs` — use [JSDoc syntax](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) for types
+- `none` — no typechecking. Not recommended!
+
+### `--template=<name>`
+
+Which project template to use:
+
+- `minimal` — barebones scaffolding for your new app
+- `demo` — showcase app with a word guessing game that works without JavaScript
+- `library` — template for a Svelte library, set up with `svelte-package`
+
+### `--no-integrations`
+
+Run the command without the interactive add-ons prompt
+
+### `--no-install`
+
+Skip dependency installation
+
+<!-- ## Programmatic interface
 
 ```js
 // TODO: this gives type checking errors in the docs site when not commented out. Need to release sv, install it in the site, and uncomment this.

--- a/documentation/docs/20-commands/10-sv-create.md
+++ b/documentation/docs/20-commands/10-sv-create.md
@@ -23,6 +23,7 @@ npx sv create ./my/path
 | --no-integrations | -                             | -          | skips interactive integration installer                    |
 | --no-install      | -                             | -          | skips installing dependencies                              |
 
+<!--
 ## Programmatic interface
 
 ```js
@@ -35,3 +36,4 @@ npx sv create ./my/path
 // 	// todo: list available option
 // });
 ```
+-->

--- a/documentation/docs/20-commands/10-sv-create.md
+++ b/documentation/docs/20-commands/10-sv-create.md
@@ -14,7 +14,7 @@ npx sv create [options] [path]
 
 <!-- TODO this flag should probably just be '--types', and the options should be 'ts' or 'jsdoc' -->
 
-### `--check-types=<option>`
+### `--check-types <option>`
 
 Whether and how to add typechecking to the project:
 
@@ -22,7 +22,7 @@ Whether and how to add typechecking to the project:
 - `checkjs` — use [JSDoc syntax](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) for types
 - `none` — no typechecking. Not recommended!
 
-### `--template=<name>`
+### `--template <name>`
 
 Which project template to use:
 

--- a/documentation/docs/20-commands/10-sv-create.md
+++ b/documentation/docs/20-commands/10-sv-create.md
@@ -12,6 +12,8 @@ npx sv create [options] [path]
 
 ## Options
 
+<!-- TODO this flag should probably just be '--types', and the options should be 'ts' or 'jsdoc' -->
+
 ### `--check-types=<option>`
 
 Whether and how to add typechecking to the project:
@@ -29,6 +31,8 @@ Which project template to use:
 - `library` — template for a Svelte library, set up with `svelte-package`
 
 ### `--no-integrations`
+
+<!-- TODO should be renamed to `--no-addons` -->
 
 Run the command without the interactive add-ons prompt
 

--- a/documentation/docs/20-commands/20-sv-add.md
+++ b/documentation/docs/20-commands/20-sv-add.md
@@ -2,7 +2,7 @@
 title: sv add
 ---
 
-`sv add` updates your code to add new functionality to an existing project.
+`sv add` updates an existing project with new functionality.
 
 ## Usage
 
@@ -11,32 +11,29 @@ npx sv add
 ```
 
 ```bash
-npx sv add tailwindcss
+npx sv add [add-ons]
 ```
 
-```bash
-npx sv add tailwindcss --cwd ./my/path
-```
+You can select multiple space-separated add-ons from [the list below](#Official-add-ons), or you can use the interactive prompt.
 
-## Available options
+## Options
 
-| Option             | default | description                                  |
-| ------------------ | ------- | -------------------------------------------- |
-| -C, --cwd          | ./      | path to the root of your svelte(kit) project |
-| --no-install       | -       | skips installing dependencies                |
-| --no-preconditions | -       | skips checking preconditions                 |
-| --no-preconditions | -       | skips checking preconditions                 |
+- `-C`, `--cwd` — path to the root of your Svelte(Kit) project
+- `--no-preconditions` — skip checking preconditions <!-- TODO what does this mean? -->
+- `--no-install` — skip dependency installation
 
-## Official integrations
+## Official add-ons
 
-- drizzle
-- eslint
-- lucia
-- mdsvex
-- paraglide
-- playwright
-- prettier
-- routify
-- storybook
-- tailwindcss
-- vitest
+<!-- TODO this should be a separate section, each of these should have their own page -->
+
+- `drizzle`
+- `eslint`
+- `lucia`
+- `mdsvex`
+- `paraglide`
+- `playwright`
+- `prettier`
+- `routify`
+- `storybook`
+- `tailwindcss`
+- `vitest`

--- a/documentation/docs/20-commands/30-sv-check.md
+++ b/documentation/docs/20-commands/30-sv-check.md
@@ -2,70 +2,110 @@
 title: sv check
 ---
 
-Provides CLI diagnostics checks for:
+`sv check` finds errors and warnings in your project, such as:
 
-- Unused CSS
-- Svelte A11y hints
+- unused CSS
+- accessibility hints
 - JavaScript/TypeScript compiler errors
 
 Requires Node 16 or later.
 
-### Usage:
+## Installation
 
-#### Local / in your project
+You will need to have the `svelte-check` package installed in your project:
 
-Installation:
-
-`npm i svelte-check --save-dev`
-
-Package.json:
-
-```json
-{
-	// ...
-	"scripts": {
-		"sv": "npx sv"
-		// ...
-	},
-	// ...
-	"devDependencies": {
-		"svelte-check": "..."
-		// ...
-	}
-}
+```bash
+npm i -D svelte-check
 ```
 
-Usage:
+## Usage
 
-`npm run sv check`
+```bash
+npx sv check
+```
 
-### Args:
+## Options
 
-| Flag                                                            | Description                                                                                                                                                                                                                                                                                                                                                                                 |
-| --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--workspace <path>`                                            | Path to your workspace. All subdirectories except node_modules and those listed in `--ignore` are checked                                                                                                                                                                                                                                                                                   |
-| `--output <human\|human-verbose\|machine\|machine-verbose>`     |
-| `--watch`                                                       | Will not exit after one pass but keep watching files for changes and rerun diagnostics                                                                                                                                                                                                                                                                                                      |
-| `--preserveWatchOutput`                                         | Do not clear the screen in watch mode                                                                                                                                                                                                                                                                                                                                                       |
-| `--tsconfig <path>`                                             | Pass a path to a tsconfig or jsconfig file. The path can be relative to the workspace path or absolute. Doing this means that only files matched by the files/include/exclude pattern of the config file are diagnosed. It also means that errors from TypeScript and JavaScript files are reported. If not given, will do an upwards traversal looking for the next jsconfig/tsconfig.json |
-| `--no-tsconfig`                                                 | Use this if you only want to check the Svelte files found in the current directory and below and ignore any JS/TS files (they will not be type-checked)                                                                                                                                                                                                                                     |
-| `--ignore <path1,path2>`                                        | Only has an effect when used in conjunction with `--no-tsconfig`. Files/folders to ignore - relative to workspace root, comma-separated, inside quotes. Example: `--ignore "dist,build"`. When used in conjunction with `--tsconfig`, this will only have effect on the files watched, not on the files that are diagnosed, which is then determined by the `tsconfig.json`                 |
-| `--fail-on-warnings`                                            | Will also exit with error code when there are warnings                                                                                                                                                                                                                                                                                                                                      |
-| `--compiler-warnings <code1:error\|ignore,code2:error\|ignore>` | A list of Svelte compiler warning codes. Each entry defines whether that warning should be ignored or treated as an error. Warnings are comma-separated, between warning code and error level is a colon; all inside quotes. Example: `--compiler-warnings "css-unused-selector:ignore,unused-export-let:error"`                                                                            |
-| `--diagnostic-sources <js,svelte,css>`                          | A list of diagnostic sources which should run diagnostics on your code. Possible values are `js` (includes TS), `svelte`, `css`. Comma-separated, inside quotes. By default all are active. Example: `--diagnostic-sources "js,svelte"`                                                                                                                                                     |
-| `--threshold <error\|warning>`                                  | Filters the diagnostics to display. `error` will output only errors while `warning` will output warnings and errors.                                                                                                                                                                                                                                                                        |
+### `--workspace <path>`
 
-### FAQ
+Path to your workspace. All subdirectories except `node_modules` and those listed in `--ignore` are checked.
 
-#### Why is there no option to only check specific files (for example only staged files)?
+### `--output <format>`
 
-`svelte-check` needs to know the whole project to do valid checks. Imagine you alter a component property `export let foo` to `export let bar`, but you don't update any of the component usages. They all have errors now but you would not catch them if you only run checks on changed files.
+How to display errors and warnings. See [machine-readable output](#Machine-readable-output).
 
-### More docs, preprocessor setup and troubleshooting
+- `human`
+- `human-verbose`
+- `machine`
+- `machine-verbose`
 
-[See here](https://github.com/sveltejs/language-tools/blob/master/docs/README.md).
+### `--watch`
 
-### Machine-Readable Output
+Keeps the process alive and watches for changes.
+
+### `--preserveWatchOutput`
+
+Prevents the screen from being cleared in watch mode.
+
+### `--tsconfig <path>`
+
+Pass a path to a `tsconfig` or `jsconfig` file. The path can be relative to the workspace path or absolute. Doing this means that only files matched by the `files`/`include`/`exclude` pattern of the config file are diagnosed. It also means that errors from TypeScript and JavaScript files are reported. If not given, will traverse upwards from the project directory looking for the next `jsconfig`/`tsconfig.json` file.
+
+### `--no-tsconfig`
+
+Use this if you only want to check the Svelte files found in the current directory and below and ignore any `.js`/`.ts` files (they will not be type-checked)
+
+### `--ignore <paths>`
+
+Files/folders to ignore, relative to workspace root. Paths should be comma-separated and quoted. Example:
+
+```bash
+npx sv check --ignore "dist,build"
+```
+
+<!-- TODO what the hell does this mean? is it possible to use --tsconfig AND --no-tsconfig? if so what would THAT mean? -->
+
+Only has an effect when used in conjunction with `--no-tsconfig`. When used in conjunction with `--tsconfig`, this will only have effect on the files watched, not on the files that are diagnosed, which is then determined by the `tsconfig.json`.
+
+### `--fail-on-warnings`
+
+If provided, warnings will cause `sv check` to exit with an error code.
+
+### `--compiler-warnings <warnings>`
+
+A quoted, comma-separated list of `code:behaviour` pairs where `code` is a [compiler warning code](../svelte/compiler-warnings) and `behaviour` is either `ignore` or `error`:
+
+```bash
+npx sv check --compiler-warnings "css_unused_selector:ignore,a11y_missing_attribute:error"
+```
+
+### `--diagnostic-sources <sources>`
+
+A quoted, comma-separated list of sources that should run diagnostics on your code. By default, all are active:
+
+<!-- TODO would be nice to have a clearer definition of what these are -->
+- `js` (includes TypeScript)
+- `svelte`
+- `css`
+
+Example:
+
+```bash
+npx sv check --diagnostic-sources "js,svelte"
+```
+
+### `--threshold <level>`
+
+Filters the diagnostics:
+
+- `warning` (default) — both errors and warnings are shown
+- `error` — only errors are shown
+
+## Troubleshooting
+
+[See the language-tools documentation](https://github.com/sveltejs/language-tools/blob/master/docs/README.md) for more information on preprocessor setup and other troubleshooting.
+
+## Machine-readable output
 
 Setting the `--output` to `machine` or `machine-verbose` will format output in a way that is easier to read
 by machines, e.g. inside CI pipelines, for code quality checks, etc.
@@ -75,9 +115,7 @@ single space character. The first column of every row contains a timestamp in mi
 which can be used for monitoring purposes. The second column gives us the "row type", based
 on which the number and types of subsequent columns may differ.
 
-The first row is of type `START` and contains the workspace folder (wrapped in quotes).
-
-###### Example:
+The first row is of type `START` and contains the workspace folder (wrapped in quotes). Example:
 
 ```
 1590680325583 START "/home/user/language-tools/packages/language-server/test/plugins/typescript/testfiles"
@@ -85,18 +123,14 @@ The first row is of type `START` and contains the workspace folder (wrapped in q
 
 Any number of `ERROR` or `WARNING` records may follow. Their structure is identical and depends on the output argoument.
 
-If the argument is `machine` it will tell us the filename, the starting line and column numbers, and the error message. The filename is relative to the workspace directory. The filename and the message are both wrapped in quotes.
-
-###### Example:
+If the argument is `machine` it will tell us the filename, the starting line and column numbers, and the error message. The filename is relative to the workspace directory. The filename and the message are both wrapped in quotes. Example:
 
 ```
 1590680326283 ERROR "codeactions.svelte" 1:16 "Cannot find module 'blubb' or its corresponding type declarations."
 1590680326778 WARNING "imported-file.svelte" 0:37 "Component has unused export property 'prop'. If it is for external reference only, please consider using `export const prop`"
 ```
 
-If the argument is `machine-verbose` it will tell us the filename, the starting line and column numbers, the ending line and column numbers, the error message, the code of diagnostic, the human-friendly description of the code and the human-friendly source of the diagnostic (eg. svelte/typescript). The filename is relative to the workspace directory. Each diagnostic is represented as an [ndjson](https://en.wikipedia.org/wiki/JSON_streaming#Newline-Delimited_JSON) line prefixed by the timestamp of the log.
-
-###### Example:
+If the argument is `machine-verbose` it will tell us the filename, the starting line and column numbers, the ending line and column numbers, the error message, the code of diagnostic, the human-friendly description of the code and the human-friendly source of the diagnostic (eg. svelte/typescript). The filename is relative to the workspace directory. Each diagnostic is represented as an [ndjson](https://en.wikipedia.org/wiki/JSON_streaming#Newline-Delimited_JSON) line prefixed by the timestamp of the log. Example:
 
 ```
 1590680326283 {"type":"ERROR","fn":"codeaction.svelte","start":{"line":1,"character":16},"end":{"line":1,"character":23},"message":"Cannot find module 'blubb' or its corresponding type declarations.","code":2307,"source":"js"}
@@ -104,22 +138,24 @@ If the argument is `machine-verbose` it will tell us the filename, the starting 
 const prop`","code":"unused-export-let","source":"svelte"}
 ```
 
-The output concludes with a `COMPLETED` message that summarizes total numbers of files, errors and warnings that were encountered during the check.
-
-###### Example:
+The output concludes with a `COMPLETED` message that summarizes total numbers of files, errors and warnings that were encountered during the check. Example:
 
 ```
 1590680326807 COMPLETED 20 FILES 21 ERRORS 1 WARNINGS 3 FILES_WITH_PROBLEMS
 ```
 
-If the application experiences a runtime error, this error will appear as a `FAILURE` record.
-
-###### Example:
+If the application experiences a runtime error, this error will appear as a `FAILURE` record. Example:
 
 ```
 1590680328921 FAILURE "Connection closed"
 ```
 
-### Credits
+## Credits
 
 - Vue's [VTI](https://github.com/vuejs/vetur/tree/master/vti) which laid the foundation for `svelte-check`
+
+## FAQ
+
+### Why is there no option to only check specific files (for example only staged files)?
+
+`svelte-check` needs to 'see' the whole project for checks to be valid. Suppose you renamed a component prop but didn't update any of the places where the prop is used — the usage sites are all errors now, but you would miss them if checks only ran on changed files.

--- a/documentation/docs/20-commands/40-sv-migrate.md
+++ b/documentation/docs/20-commands/40-sv-migrate.md
@@ -2,26 +2,34 @@
 title: sv migrate
 ---
 
-A CLI for migrating Svelte(Kit) codebases.
+`sv migrate` migrates Svelte(Kit) codebases. It delegates to the [`svelte-migrate`](https://github.com/sveltejs/kit/blob/main/packages/migrate) package.
 
-Run it using
+Some migrations may annotate your codebase with tasks for completion that you can find by searching for `@migration`.
 
-```
+## Usage
+
+```bash
 npx sv migrate [migration]
 ```
 
 ## Migrations
 
-| Migration     | From                  | To                    | Guide                                                           |
-| ------------- | --------------------- | --------------------- | --------------------------------------------------------------- |
-| `svelte-5`    | Svelte 4              | Svelte 5              | [Website](https://svelte.dev/docs/svelte/v5-migration-guide)           |
-| `sveltekit-2` | SvelteKit 1.0         | SvelteKit 2.0         | [Website](https://svelte.dev/docs/kit/migrating-to-sveltekit-2) |
-| `svelte-4`    | Svelte 3              | Svelte 4              | [Website](https://svelte.dev/docs/svelte/v4-migration-guide)           |
-| `package`     | `@sveltejs/package@1` | `@sveltejs/package@2` | [#8922](https://github.com/sveltejs/kit/pull/8922)              |
-| `routes`      | SvelteKit pre-1.0     | SvelteKit 1.0         | [#5774](https://github.com/sveltejs/kit/discussions/5774)       |
+### `svelte-5`
 
-Some migrations may annotate your codebase with tasks for completion that you can find by searching for `@migration`.
+Upgrades a Svelte 4 app to use Svelte 5, and updates individual components to use [runes](../svelte/what-are-runes) and other Svelte 5 syntax ([see migration guide](../svelte/v5-migration-guide)).
 
-## Changelog
+### `svelte-4`
 
-[The Changelog for this package is available on GitHub](https://github.com/sveltejs/kit/blob/main/packages/migrate/CHANGELOG.md).
+Upgrades a Svelte 3 app to use Svelte 4 ([see migration guide](../svelte/v4-migration-guide)).
+
+### `sveltekit-2`
+
+Upgrades a SvelteKit 1 app to SvelteKit 2 ([see migration guide](../kit/migrating-to-sveltekit-2)).
+
+### `package`
+
+Upgrades a library using `@sveltejs/package` version 1 to version 2. See the [pull request](https://github.com/sveltejs/kit/pull/8922) for more details.
+
+### `routes`
+
+Upgrades a pre-release SvelteKit app to use the filesystem routing conventions in SvelteKit 1. See the [pull request](https://github.com/sveltejs/kit/discussions/5774) for more details.


### PR DESCRIPTION
Updates the docs, in preparation for adding them to the site. You can see how it looks here: https://svelte-dev-git-add-cli-docs-svelte.vercel.app/docs/cli/overview

I replaced the tables with normal text — it's less compact, but far more readable and doesn't mess up the layout on smaller screens. Also makes it possible to add code blocks etc.