### PR TITLE
chore: fix template repo updater

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,4 +44,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Update Template Repo
+        if: steps.changesets.outputs.published
+        run: pnpm -F @sveltejs/create update-template-repo
+        env:
           UPDATE_TEMPLATE_SSH_KEY: ${{ secrets.UPDATE_TEMPLATE_SSH_KEY }}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,8 +13,7 @@
 	"scripts": {
 		"check": "tsc",
 		"format": "pnpm lint --write",
-		"lint": "prettier --check . --config ../../prettier.config.js --ignore-path ../../.gitignore --ignore-path .gitignore --ignore-path ../../.prettierignore",
-		"postpublish": "pnpm -F @sveltejs/create update-template-repo"
+		"lint": "prettier --check . --config ../../prettier.config.js --ignore-path ../../.gitignore --ignore-path .gitignore --ignore-path ../../.prettierignore"
 	},
 	"files": [
 		"dist"

--- a/packages/create/scripts/update-template-repo.sh
+++ b/packages/create/scripts/update-template-repo.sh
@@ -31,8 +31,9 @@ if [ "$CI" ]; then
 	git config user.name '[bot]'
 fi
 
-# commit the new files
-git add -A
-git commit -m "version $npm_package_version"
-
-git push git@github.com:sveltejs/kit-template-default.git main -f
+# commit when there are new files
+if [[ `git status --porcelain` ]]; then
+	git add -A
+	git commit -m "version $npm_package_version"
+	git push git@github.com:sveltejs/kit-template-default.git main -f
+fi

--- a/packages/create/scripts/update-template-repo.sh
+++ b/packages/create/scripts/update-template-repo.sh
@@ -7,6 +7,11 @@ get_abs_filename() {
   echo "$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
 }
 
+get_sv_version() {
+	pnpm -F sv exec node -p "require('./package.json').version"
+}
+
+VERSION=$(get_sv_version)
 DIR=$(get_abs_filename $(dirname "$0"))
 TMP=$(get_abs_filename "$DIR/../node_modules/.tmp")
 
@@ -34,6 +39,6 @@ fi
 # commit when there are new files
 if [[ `git status --porcelain` ]]; then
 	git add -A
-	git commit -m "version $npm_package_version"
+	git commit -m "version $VERSION"
 	git push git@github.com:sveltejs/kit-template-default.git main -f
 fi


### PR DESCRIPTION
closes #243 

- Removed the `postpublish` script and moved the updater to its own workflow step
- Added a check to only commit new files when the working tree is dirty
- Template repo's commit message now references the `sv` version