### PR TITLE
fix: update lucia adder

### DIFF
--- a/.changeset/nice-lemons-attend.md
+++ b/.changeset/nice-lemons-attend.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix: update lucia add-on

--- a/packages/adders/lucia/index.ts
+++ b/packages/adders/lucia/index.ts
@@ -230,9 +230,9 @@ export default defineAdder({
 				if (!ms.original.includes('export const sessionCookieName')) {
 					ms.append("\n\nexport const sessionCookieName = 'auth-session';");
 				}
-				if (!ms.original.includes('function generateSessionToken')) {
+				if (!ms.original.includes('export function generateSessionToken')) {
 					const generateSessionToken = dedent`					
-						function generateSessionToken() {
+						export function generateSessionToken() {
 							const bytes = crypto.getRandomValues(new Uint8Array(20));
 							const token = encodeBase32LowerCaseNoPadding(bytes);
 							return token;

--- a/packages/adders/lucia/index.ts
+++ b/packages/adders/lucia/index.ts
@@ -365,7 +365,6 @@ export default defineAdder({
 			content: ({ content, typescript }) => {
 				const { ast, generateCode } = parseScript(content);
 				imports.addNamespace(ast, '$lib/server/auth.js', 'auth');
-				imports.addNamed(ast, '$app/environment', { dev: 'dev' });
 				kit.addHooksHandle(ast, typescript, 'handleAuth', getAuthHandleContent());
 				return generateCode();
 			}
@@ -394,7 +393,6 @@ export default defineAdder({
 					import { encodeBase32LowerCaseNoPadding } from '@oslojs/encoding';
 					import { fail, redirect } from '@sveltejs/kit';
 					import { eq } from 'drizzle-orm';
-					import { dev } from '$app/environment';
 					import * as auth from '$lib/server/auth';
 					import { db } from '$lib/server/db';
 					import * as table from '$lib/server/db/schema';

--- a/packages/adders/lucia/index.ts
+++ b/packages/adders/lucia/index.ts
@@ -212,7 +212,7 @@ export default defineAdder({
 				imports.addNamespace(ast, '$lib/server/db/schema', 'table');
 				imports.addNamed(ast, '$lib/server/db', { db: 'db' });
 				imports.addNamed(ast, '@oslojs/encoding', {
-					encodeBase32LowerCaseNoPadding: 'encodeBase32LowerCaseNoPadding',
+					encodeBase64url: 'encodeBase64url',
 					encodeHexLowerCase: 'encodeHexLowerCase'
 				});
 				imports.addNamed(ast, '@oslojs/crypto/sha2', { sha256: 'sha256' });
@@ -233,8 +233,8 @@ export default defineAdder({
 				if (!ms.original.includes('export function generateSessionToken')) {
 					const generateSessionToken = dedent`					
 						export function generateSessionToken() {
-							const bytes = crypto.getRandomValues(new Uint8Array(20));
-							const token = encodeBase32LowerCaseNoPadding(bytes);
+							const bytes = crypto.getRandomValues(new Uint8Array(18));
+							const token = encodeBase64url(bytes);
 							return token;
 						}`;
 					ms.append(`\n\n${generateSessionToken}`);
@@ -390,7 +390,7 @@ export default defineAdder({
 				const [ts] = utils.createPrinter(typescript);
 				return dedent`
 					import { hash, verify } from '@node-rs/argon2';
-					import { encodeBase32LowerCaseNoPadding } from '@oslojs/encoding';
+					import { encodeBase64url } from '@oslojs/encoding';
 					import { fail, redirect } from '@sveltejs/kit';
 					import { eq } from 'drizzle-orm';
 					import * as auth from '$lib/server/auth';
@@ -480,7 +480,7 @@ export default defineAdder({
 					function generateUserId() {
 						// ID with 120 bits of entropy, or about the same as UUID v4.
 						const bytes = crypto.getRandomValues(new Uint8Array(15));
-						const id = encodeBase32LowerCaseNoPadding(bytes);
+						const id = encodeBase64url(bytes);
 						return id;
 					}
 

--- a/packages/adders/lucia/index.ts
+++ b/packages/adders/lucia/index.ts
@@ -255,18 +255,8 @@ export default defineAdder({
 						}`;
 					ms.append(`\n\n${createSession}`);
 				}
-				if (!ms.original.includes('async function invalidateSession')) {
-					const invalidateSession = dedent`					
-						${ts('', '/**')}
-						${ts('', ' * @param {string} sessionId')}
-						${ts('', ' */')}
-						export async function invalidateSession(sessionId${ts(': string')}) {
-							await db.delete(table.session).where(eq(table.session.id, sessionId));
-						}`;
-					ms.append(`\n\n${invalidateSession}`);
-				}
 				if (!ms.original.includes('async function validateSession')) {
-					const validateSession = dedent`					
+					const validateSessionToken = dedent`					
 						${ts('', '/** @param {string} token */')}
 						export async function validateSessionToken(token${ts(': string')}) {
 							const sessionId = encodeHexLowerCase(sha256(new TextEncoder().encode(token)));
@@ -302,7 +292,7 @@ export default defineAdder({
 	
 							return { session, user };
 						}`;
-					ms.append(`\n\n${validateSession}`);
+					ms.append(`\n\n${validateSessionToken}`);
 				}
 				if (!ms.original.includes('async function invalidateSession')) {
 					const invalidateSession = dedent`					
@@ -315,7 +305,7 @@ export default defineAdder({
 					ms.append(`\n\n${invalidateSession}`);
 				}
 				if (typescript && !ms.original.includes('export function setSessionTokenCookie')) {
-					const invalidateSession = dedent`					
+					const setSessionTokenCookie = dedent`					
 						${ts('', '/**')}
 						${ts('', ' * @param {import("@sveltejs/kit").RequestEvent} event')}
 						${ts('', ' * @param {string} token')}
@@ -327,10 +317,10 @@ export default defineAdder({
 								path: '/'
 							});
 						}`;
-					ms.append(`\n\n${invalidateSession}`);
+					ms.append(`\n\n${setSessionTokenCookie}`);
 				}
 				if (typescript && !ms.original.includes('export function deleteSessionTokenCookie')) {
-					const invalidateSession = dedent`					
+					const deleteSessionTokenCookie = dedent`					
 						${ts('', '/**')}
 						${ts('', ' * @param {import("@sveltejs/kit").RequestEvent} event')}
 						${ts('', ' * @param {string} token')}
@@ -342,7 +332,7 @@ export default defineAdder({
 								path: '/'
 							});
 						}`;
-					ms.append(`\n\n${invalidateSession}`);
+					ms.append(`\n\n${deleteSessionTokenCookie}`);
 				}
 				return ms.toString();
 			}

--- a/packages/adders/lucia/index.ts
+++ b/packages/adders/lucia/index.ts
@@ -257,7 +257,7 @@ export default defineAdder({
 						}`;
 					ms.append(`\n\n${createSession}`);
 				}
-				if (!ms.original.includes('async function validateSession')) {
+				if (!ms.original.includes('async function validateSessionToken')) {
 					const validateSessionToken = dedent`					
 						${ts('', '/** @param {string} token */')}
 						export async function validateSessionToken(token${ts(': string')}) {
@@ -295,6 +295,11 @@ export default defineAdder({
 							return { session, user };
 						}`;
 					ms.append(`\n\n${validateSessionToken}`);
+				}
+				if (typescript && !ms.original.includes('export type SessionValidationResult')) {
+					const sessionType =
+						'export type SessionValidationResult = Awaited<ReturnType<typeof validateSession>>;';
+					ms.append(`\n\n${sessionType}`);
 				}
 				if (!ms.original.includes('async function invalidateSession')) {
 					const invalidateSession = dedent`					

--- a/packages/adders/lucia/index.ts
+++ b/packages/adders/lucia/index.ts
@@ -327,9 +327,8 @@ export default defineAdder({
 				if (!ms.original.includes('export function deleteSessionTokenCookie')) {
 					const deleteSessionTokenCookie = dedent`					
 						${ts('', '/** @param {import("@sveltejs/kit").RequestEvent} event */')}
-						export function deleteSessionTokenCookie(event${ts(': RequestEvent')}, token${ts(': string')}, expiresAt${ts(': Date')}) {
-							event.cookies.set(sessionCookieName, '', {
-								expires: expiresAt,
+						export function deleteSessionTokenCookie(event${ts(': RequestEvent')}) {
+							event.cookies.delete(sessionCookieName, {
 								path: '/'
 							});
 						}`;

--- a/packages/adders/lucia/index.ts
+++ b/packages/adders/lucia/index.ts
@@ -298,7 +298,7 @@ export default defineAdder({
 				}
 				if (typescript && !ms.original.includes('export type SessionValidationResult')) {
 					const sessionType =
-						'export type SessionValidationResult = Awaited<ReturnType<typeof validateSession>>;';
+						'export type SessionValidationResult = Awaited<ReturnType<typeof validateSessionToken>>;';
 					ms.append(`\n\n${sessionType}`);
 				}
 				if (!ms.original.includes('async function invalidateSession')) {

--- a/packages/adders/lucia/index.ts
+++ b/packages/adders/lucia/index.ts
@@ -304,7 +304,7 @@ export default defineAdder({
 						}`;
 					ms.append(`\n\n${invalidateSession}`);
 				}
-				if (typescript && !ms.original.includes('export function setSessionTokenCookie')) {
+				if (!ms.original.includes('export function setSessionTokenCookie')) {
 					const setSessionTokenCookie = dedent`					
 						${ts('', '/**')}
 						${ts('', ' * @param {import("@sveltejs/kit").RequestEvent} event')}
@@ -319,7 +319,7 @@ export default defineAdder({
 						}`;
 					ms.append(`\n\n${setSessionTokenCookie}`);
 				}
-				if (typescript && !ms.original.includes('export function deleteSessionTokenCookie')) {
+				if (!ms.original.includes('export function deleteSessionTokenCookie')) {
 					const deleteSessionTokenCookie = dedent`					
 						${ts('', '/** @param {import("@sveltejs/kit").RequestEvent} event */')}
 						export function deleteSessionTokenCookie(event${ts(': RequestEvent')}, token${ts(': string')}, expiresAt${ts(': Date')}) {

--- a/packages/adders/lucia/index.ts
+++ b/packages/adders/lucia/index.ts
@@ -240,9 +240,11 @@ export default defineAdder({
 					ms.append(`\n\n${generateSessionToken}`);
 				}
 				if (!ms.original.includes('async function createSession')) {
-					const createSession = dedent`					
-						${ts('', '/** @param {string} token */')}
-						${ts('', '/** @param {string} userId */')}
+					const createSession = dedent`
+						${ts('', '/**')}
+						${ts('', ' * @param {string} token')}
+						${ts('', ' * @param {string} userId')}
+						${ts('', ' */')}
 						export async function createSession(token${ts(': string')}, userId${ts(': string')}) {
 							const sessionId = encodeHexLowerCase(sha256(new TextEncoder().encode(token)));
 							const session${ts(': table.Session')} = {
@@ -296,9 +298,7 @@ export default defineAdder({
 				}
 				if (!ms.original.includes('async function invalidateSession')) {
 					const invalidateSession = dedent`					
-						${ts('', '/**')}
-						${ts('', ' * @param {string} sessionId')}
-						${ts('', ' */')}
+						${ts('', '/** @param {string} sessionId */')}
 						export async function invalidateSession(sessionId${ts(': string')})${ts(': Promise<void>')} {
 							await db.delete(table.session).where(eq(table.session.id, sessionId));
 						}`;
@@ -321,11 +321,7 @@ export default defineAdder({
 				}
 				if (typescript && !ms.original.includes('export function deleteSessionTokenCookie')) {
 					const deleteSessionTokenCookie = dedent`					
-						${ts('', '/**')}
-						${ts('', ' * @param {import("@sveltejs/kit").RequestEvent} event')}
-						${ts('', ' * @param {string} token')}
-						${ts('', ' * @param {Date} expiresAt')}
-						${ts('', ' */')}
+						${ts('', '/** @param {import("@sveltejs/kit").RequestEvent} event */')}
 						export function deleteSessionTokenCookie(event${ts(': RequestEvent')}, token${ts(': string')}, expiresAt${ts(': Date')}) {
 							event.cookies.set(sessionCookieName, '', {
 								expires: expiresAt,


### PR DESCRIPTION
- Adds `setSessionTokenCookie()` and `deleteSessionTokenCookie()` (closes #122)
- Fixes sessions to be consistent with lucia-auth.com. This isn't a security issue, but the hashing part wasn't implement properly which negated the benefits it provided.
- Update `generateUserId()` to be consistent with `generateSessionToken()` and easier to deal with.
- Removed return types to be consistent with the rest of the codebase.

I haven't added change sets yet and I'm not sure how to test the adder.