### PR TITLE
add sync request workflow

### DIFF
--- a/.github/workflows/sync-request.yml
+++ b/.github/workflows/sync-request.yml
@@ -1,0 +1,21 @@
+name: Sync request
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.SYNC_REQUEST_TOKEN }}
+          repository: sveltejs/svelte.dev
+          event-type: sync-request
+          client-payload: |-
+            {
+              "package": "cli"
+            }


### PR DESCRIPTION
This adds a workflow that _in theory_ will dispatch a sync request to the `sveltejs/svelte.dev` repo that, on merges to `main`, will create or update a PR like this one: https://github.com/sveltejs/svelte.dev/pull/729

The only way I can really test this is by merging this and pushing an innocuous docs change, so that's what I'll do