### PR TITLE
chore: use pull_request_target instead of pull_request event in workflows

### DIFF
--- a/.github/workflows/docs-preview-create-request.yml
+++ b/.github/workflows/docs-preview-create-request.yml
@@ -2,7 +2,7 @@
 name: Docs preview create request
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
 

--- a/.github/workflows/docs-preview-delete-request.yml
+++ b/.github/workflows/docs-preview-delete-request.yml
@@ -2,7 +2,7 @@
 name: Docs preview delete request
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
     types: [closed]

--- a/documentation/docs/10-introduction/10-overview.md
+++ b/documentation/docs/10-introduction/10-overview.md
@@ -2,8 +2,6 @@
 title: Overview
 ---
 
-<!-- gah -->
-
 The command line interface (CLI), `sv`, is a toolkit for creating and maintaining Svelte applications.
 
 ## Usage

--- a/documentation/docs/10-introduction/10-overview.md
+++ b/documentation/docs/10-introduction/10-overview.md
@@ -2,6 +2,8 @@
 title: Overview
 ---
 
+<!-- gah -->
+
 The command line interface (CLI), `sv`, is a toolkit for creating and maintaining Svelte applications.
 
 ## Usage

--- a/documentation/docs/10-introduction/10-overview.md
+++ b/documentation/docs/10-introduction/10-overview.md
@@ -2,8 +2,6 @@
 title: Overview
 ---
 
-<!-- testing, delete me... -->
-
 The command line interface (CLI), `sv`, is a toolkit for creating and maintaining Svelte applications.
 
 ## Usage


### PR DESCRIPTION
This allows preview deployments to be created for PRs from external contributors