### PR TITLE
fix: disable preconditions during `create`

### DIFF
--- a/.changeset/small-queens-press.md
+++ b/.changeset/small-queens-press.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix: disable add-on preconditions during `create`

--- a/packages/cli/commands/create.ts
+++ b/packages/cli/commands/create.ts
@@ -161,7 +161,7 @@ async function createProject(cwd: string, options: Options) {
 	if (options.addOns) {
 		// `runAddCommand` includes installing dependencies
 		const { nextSteps, packageManager: pm } = await runAddCommand(
-			{ cwd: projectPath, install: options.install, preconditions: true, community: [] },
+			{ cwd: projectPath, install: options.install, preconditions: false, community: [] },
 			[]
 		);
 		packageManager = pm;


### PR DESCRIPTION
closes #286

It's safe to assume that an add-on's preconditions will always be met as we only provide the add-ons that are valid for the current environment