### PR TITLE
feat: display package manager output during dependency installs

### DIFF
--- a/.changeset/fluffy-readers-attend.md
+++ b/.changeset/fluffy-readers-attend.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+feat: display package manager output during dependency installs

--- a/packages/clack-prompts/index.ts
+++ b/packages/clack-prompts/index.ts
@@ -603,6 +603,54 @@ function buildBox(message = '', title = '', dimmed = true) {
 
 export const note = (message = '', title = ''): void => buildBox(message, title, true);
 export const box = (message = '', title = ''): void => buildBox(message, title, false);
+export const taskLog = (title: string) => {
+	const BAR = color.dim(S_BAR);
+	const ACTIVE = color.green(S_STEP_ACTIVE);
+	const SUCCESS = color.green(S_SUCCESS);
+	const ERROR = color.red(S_ERROR);
+
+	// heading
+	process.stdout.write(`${BAR}\n`);
+	process.stdout.write(`${ACTIVE}  ${title}\n`);
+
+	let output = '';
+
+	// clears previous output
+	const clear = (buffer = 0): void => {
+		if (!output) return;
+		const lines = output.split('\n').length + buffer;
+		process.stdout.write(cursor.up(lines));
+		process.stdout.write(erase.down(lines));
+	};
+
+	// logs the output
+	const print = (): void => {
+		const lines = output.split('\n');
+		for (const line of lines) {
+			const msg = color.dim(`${BAR}  ${line}\n`);
+			process.stdout.write(msg);
+		}
+	};
+
+	return {
+		set text(data: string) {
+			clear();
+			output += data;
+			print();
+		},
+
+		fail(message: string): void {
+			clear(1);
+			process.stdout.write(`${ERROR}  ${message}\n`);
+			// log the output on failure
+			print();
+		},
+		success(message: string): void {
+			clear(1);
+			process.stdout.write(`${SUCCESS}  ${message}\n`);
+		}
+	};
+};
 
 export const cancel = (message = ''): void => {
 	process.stdout.write(`${color.gray(S_BAR_END)}  ${color.red(message)}\n\n`);

--- a/packages/clack-prompts/index.ts
+++ b/packages/clack-prompts/index.ts
@@ -640,13 +640,13 @@ export const taskLog = (title: string) => {
 		},
 
 		fail(message: string): void {
-			clear(1);
+			clear(1); // includes clearing the `title`
 			process.stdout.write(`${ERROR}  ${message}\n`);
 			// log the output on failure
 			print();
 		},
 		success(message: string): void {
-			clear(1);
+			clear(1); // includes clearing the `title`
 			process.stdout.write(`${SUCCESS}  ${message}\n`);
 		}
 	};

--- a/packages/clack-prompts/index.ts
+++ b/packages/clack-prompts/index.ts
@@ -605,7 +605,7 @@ export const note = (message = '', title = ''): void => buildBox(message, title,
 export const box = (message = '', title = ''): void => buildBox(message, title, false);
 export const taskLog = (title: string) => {
 	const BAR = color.dim(S_BAR);
-	const ACTIVE = color.green(S_STEP_ACTIVE);
+	const ACTIVE = color.green(S_STEP_SUBMIT);
 	const SUCCESS = color.green(S_SUCCESS);
 	const ERROR = color.red(S_ERROR);
 

--- a/packages/clack-prompts/index.ts
+++ b/packages/clack-prompts/index.ts
@@ -619,8 +619,7 @@ export const taskLog = (title: string) => {
 	const clear = (buffer = 0): void => {
 		if (!output) return;
 		const lines = output.split('\n').length + buffer;
-		process.stdout.write(cursor.up(lines));
-		process.stdout.write(erase.down(lines));
+		process.stdout.write(erase.lines(lines + 1));
 	};
 
 	// logs the output
@@ -638,7 +637,6 @@ export const taskLog = (title: string) => {
 			output += data;
 			print();
 		},
-
 		fail(message: string): void {
 			clear(1); // includes clearing the `title`
 			process.stdout.write(`${ERROR}  ${message}\n`);

--- a/packages/cli/utils/package-manager.ts
+++ b/packages/cli/utils/package-manager.ts
@@ -32,7 +32,7 @@ export async function packageManagerPrompt(cwd: string): Promise<AgentName | und
 }
 
 export async function installDependencies(agent: AgentName, cwd: string): Promise<void> {
-	const box = p.taskLog(`Installing dependencies with ${agent}...`);
+	const task = p.taskLog(`Installing dependencies with ${agent}...`);
 
 	try {
 		const { command, args } = constructCommand(COMMANDS[agent].install, [])!;
@@ -42,17 +42,17 @@ export async function installDependencies(agent: AgentName, cwd: string): Promis
 		});
 
 		proc.process?.stdout?.on('data', (data) => {
-			box.text = data;
+			task.text = data;
 		});
 		proc.process?.stderr?.on('data', (data) => {
-			box.text = data;
+			task.text = data;
 		});
 
 		await proc;
 
-		box.success('Successfully installed dependencies');
+		task.success('Successfully installed dependencies');
 	} catch {
-		box.fail('Failed to install dependencies');
+		task.fail('Failed to install dependencies');
 		p.cancel('Operation failed.');
 		process.exit(2);
 	}

--- a/packages/cli/utils/package-manager.ts
+++ b/packages/cli/utils/package-manager.ts
@@ -32,7 +32,7 @@ export async function packageManagerPrompt(cwd: string): Promise<AgentName | und
 }
 
 export async function installDependencies(agent: AgentName, cwd: string): Promise<void> {
-	const box = p.taskLog(`Installing dependencies with ${agent}`);
+	const box = p.taskLog(`Installing dependencies with ${agent}...`);
 
 	try {
 		const { command, args } = constructCommand(COMMANDS[agent].install, [])!;


### PR DESCRIPTION
If the process for installing deps exits unexpectedly, the package manager's output is kept on screen. If it's successful, the output cleared.

demo:
![img](https://i.imgur.com/wqghO1B.gif)