### PR TITLE
chore: lint files after testing

### DIFF
--- a/packages/addons/_tests/all-addons/test.ts
+++ b/packages/addons/_tests/all-addons/test.ts
@@ -3,6 +3,7 @@ import { expect } from '@playwright/test';
 import { setupTest } from '../_setup/suite.ts';
 import { officialAddons } from '../../index.ts';
 import type { AddonMap, OptionMap } from 'sv';
+import { execSync } from 'node:child_process';
 
 const windowsCI = process.env.CI && process.platform === 'win32';
 const addons = officialAddons.reduce<AddonMap>((addonMap, addon) => {
@@ -25,6 +26,9 @@ test.concurrent.for(kitOnly)('run all addons - %s', async (variant, { page, ...c
 	const { close } = await prepareServer({ cwd, page });
 	// kill server process when we're done
 	ctx.onTestFinished(async () => await close());
+
+	// all files that we generated should be linted
+	expect(() => execSync('pnpm lint', { cwd, stdio: 'pipe' })).not.toThrowError();
 
 	expect(true).toBe(true);
 });


### PR DESCRIPTION
This is not a real PR. This should be used to gather input if we want this or not, while also being used as a quick reproduction.

Relates #308 

Idea is to solve the problem more globally and in a future-proof way. After the `all-addons` test has run, we will initiate `pnpm lint` (which runs `prettier` and `eslint` behind the scenes) if any of our generated code does not match the linting rules we enforce while adding `eslint` and `prettier` respectively. If we want to keep this kind of test in the future, we should properly separate into it's own test that exclusively tests linting all add-ons. But this is enough to get a rough idea.

To summarize, the results are pretty bad. After running `pnpm format` on the results of the test i got 36 files that did not match the prettier output (4 of those with EOL mismatches). Most of the files are related to the spaces / tabs issue we were trying to solve with #100 (roughly 9 files). Another 10 files are created outside of our control (`storbook`'s `src/stories` folder), but that would still leave us with 22 wrongly formatted files. 

If we add `eslint` to the story, we get another 5 errors (3 `paraglide`, 1 `lucia`, 1 `storybook`).

I do think this is an important test to have, but I think the timing is off. We first need to solve a few of those other issues, especially the tabs / spaces one.