### PR TITLE
chore: remove @types/eslint package from eslint addon

### DIFF
--- a/.changeset/eighty-bikes-yawn.md
+++ b/.changeset/eighty-bikes-yawn.md
@@ -1,5 +1,5 @@
 ---
-'@sveltejs/addons': patch
+'sv': patch
 ---
 
 chore: remove @types/eslint package from eslint addon

--- a/.changeset/eighty-bikes-yawn.md
+++ b/.changeset/eighty-bikes-yawn.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/addons': patch
+---
+
+chore: remove @types/eslint package from eslint addon

--- a/.changeset/eighty-bikes-yawn.md
+++ b/.changeset/eighty-bikes-yawn.md
@@ -2,4 +2,4 @@
 'sv': patch
 ---
 
-chore: remove @types/eslint package from eslint addon
+chore: remove `@types/eslint` package from `eslint` add-on

--- a/packages/addons/eslint/index.ts
+++ b/packages/addons/eslint/index.ts
@@ -20,7 +20,6 @@ export default defineAddon({
 		const prettierInstalled = Boolean(dependencyVersion('prettier'));
 
 		sv.devDependency('eslint', '^9.7.0');
-		sv.devDependency('@types/eslint', '^9.6.0');
 		sv.devDependency('globals', '^15.0.0');
 		sv.devDependency('eslint-plugin-svelte', '^2.36.0');
 


### PR DESCRIPTION
removed `@types/eslint` package from eslint addon as it is not required anymore
ref https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70735