### PR TITLE
docs: add cli documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Read the [SvelteKit documentation](https://svelte.dev/docs/kit) for more details
 
 ### Packages
 
-| Package                            | Changelog                                  |
-| ---------------------------------- | ------------------------------------------ |
-| [sv](packages/cli)                 | [Changelog](packages/cli/CHANGELOG.md)     |
-| [svelte-migrate](packages/migrate) | [Changelog](packages/migrate/CHANGELOG.md) |
+| Package                            | Changelog                                  | Documentation                                         |
+| ---------------------------------- | ------------------------------------------ | ----------------------------------------------------- |
+| [sv](packages/cli)                 | [Changelog](packages/cli/CHANGELOG.md)     | [Documentation](https://svelte.dev/docs/cli/overview) |
+| [svelte-migrate](packages/migrate) | [Changelog](packages/migrate/CHANGELOG.md) |                                                       |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Read the [SvelteKit documentation](https://svelte.dev/docs/kit) for more details
 
 ### Packages
 
-| Package                            | Changelog                                  | Documentation                                         |
-| ---------------------------------- | ------------------------------------------ | ----------------------------------------------------- |
-| [sv](packages/cli)                 | [Changelog](packages/cli/CHANGELOG.md)     | [Documentation](https://svelte.dev/docs/cli/overview) |
-| [svelte-migrate](packages/migrate) | [Changelog](packages/migrate/CHANGELOG.md) |                                                       |
+| Package                            | Changelog                                  | Documentation                                           |
+| ---------------------------------- | ------------------------------------------ | ------------------------------------------------------- |
+| [sv](packages/cli)                 | [Changelog](packages/cli/CHANGELOG.md)     | [Documentation](https://svelte.dev/docs/cli/overview)   |
+| [svelte-migrate](packages/migrate) | [Changelog](packages/migrate/CHANGELOG.md) | [Documentation](https://svelte.dev/docs/cli/sv-migrate) |
 
 ## Contributing
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,18 +1,14 @@
 # sv - the Svelte CLI
 
-[Documentation](https://svelte.dev/docs/cli/overview)
-
 A command line interface (CLI) for creating and maintaining [Svelte](https://svelte.dev) applications. Just run:
 
 ```bash
 npx sv
 ```
 
-## Acknowledgements
+## Documentation
 
-Thank you to [Christopher Brown](https://github.com/chbrown) who originally owned the `sv` name on npm for graciously allowing it to be used for this package. You can find the original `sv` package at [`@chbrown/sv`](https://www.npmjs.com/package/@chbrown/sv).
-
-This project was formed by merging the `create-svelte` and `svelte-add` CLIs. Thank you to [J](https://github.com/babichjacob) for starting the community-led `svelte-add` project and to the [`svelte-add` contributors](https://github.com/svelte-add/svelte-add/graphs/contributors).
+[Documentation](https://svelte.dev/docs/cli/overview)
 
 ## Changelog
 
@@ -21,3 +17,9 @@ This project was formed by merging the `create-svelte` and `svelte-add` CLIs. Th
 ## License
 
 [MIT](../../LICENSE)
+
+## Acknowledgements
+
+Thank you to [Christopher Brown](https://github.com/chbrown) who originally owned the `sv` name on npm for graciously allowing it to be used for this package. You can find the original `sv` package at [`@chbrown/sv`](https://www.npmjs.com/package/@chbrown/sv).
+
+This project was formed by merging the `create-svelte` and `svelte-add` CLIs. Thank you to [J](https://github.com/babichjacob) for starting the community-led `svelte-add` project and to the [`svelte-add` contributors](https://github.com/svelte-add/svelte-add/graphs/contributors).

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,5 +1,7 @@
 # sv - the Svelte CLI
 
+[Documentation](https://svelte.dev/docs/cli/overview)
+
 A command line interface (CLI) for creating and maintaining [Svelte](https://svelte.dev) applications. Just run:
 
 ```bash

--- a/packages/migrate/README.md
+++ b/packages/migrate/README.md
@@ -1,6 +1,6 @@
 # svelte-migrate
 
-A CLI for migrating Svelte(Kit) codebases. [Documentation](https://svelte.dev/docs/cli/sv-migrate)
+A CLI for migrating Svelte(Kit) codebases.
 
 Run it directly using:
 
@@ -25,6 +25,10 @@ npx sv migrate [migration]
 | `routes`      | SvelteKit pre-1.0     | SvelteKit 1.0         | [#5774](https://github.com/sveltejs/kit/discussions/5774)       |
 
 Some migrations may annotate your codebase with tasks for completion that you can find by searching for `@migration`.
+
+## Documentation
+
+[Documentation](https://svelte.dev/docs/cli/sv-migrate)
 
 ## Changelog
 

--- a/packages/migrate/README.md
+++ b/packages/migrate/README.md
@@ -1,6 +1,6 @@
 # svelte-migrate
 
-A CLI for migrating Svelte(Kit) codebases.
+A CLI for migrating Svelte(Kit) codebases. [Documentation](https://svelte.dev/docs/cli/sv-migrate)
 
 Run it directly using:
 


### PR DESCRIPTION
I didn't know `sv create` had such comprehensive documentation.

Adding the package documentation link in the README will help.