### PR TITLE
Paraglide: Fix typing for newLanguage in demo code

### DIFF
--- a/.changeset/healthy-boxes-laugh.md
+++ b/.changeset/healthy-boxes-laugh.md
@@ -1,0 +1,5 @@
+---
+"sv": patch
+---
+
+fix: updated jsdoc type for `paraglide` demo

--- a/packages/addons/paraglide/index.ts
+++ b/packages/addons/paraglide/index.ts
@@ -239,7 +239,7 @@ export default defineAddon({
 					scriptCode.append('\n\n');
 					scriptCode.append(dedent`
 						${ts('', '/**')} 
-						${ts('', '* @param import("$lib/paraglide/runtime").AvailableLanguageTag newLanguage')} 
+						${ts('', '* @param {import("$lib/paraglide/runtime").AvailableLanguageTag} newLanguage')} 
 						${ts('', '*/')} 
 						function switchToLanguage(newLanguage${ts(': AvailableLanguageTag')}) {
 							const canonicalPath = i18n.route($page.url.pathname);


### PR DESCRIPTION
The paraglide demo contains sample code for a language switcher with typing in JSDoc.

Currently the typing is not working, as it is missing curly brackets.