### PR TITLE
docs: add `self-closing-tags` migration

### DIFF
--- a/.changeset/tender-donkeys-attack.md
+++ b/.changeset/tender-donkeys-attack.md
@@ -1,0 +1,5 @@
+---
+'svelte-migrate': patch
+---
+
+docs: add `self-closing-tags` migration

--- a/documentation/docs/20-commands/40-sv-migrate.md
+++ b/documentation/docs/20-commands/40-sv-migrate.md
@@ -18,6 +18,10 @@ npx sv migrate [migration]
 
 Upgrades a Svelte 4 app to use Svelte 5, and updates individual components to use [runes](../svelte/what-are-runes) and other Svelte 5 syntax ([see migration guide](../svelte/v5-migration-guide)).
 
+### `self-closing-tags`
+
+Replaces all the self-closing non-void elements in your `.svelte` files. See the [pull request](https://github.com/sveltejs/kit/pull/12128) for more details.
+
 ### `svelte-4`
 
 Upgrades a Svelte 3 app to use Svelte 4 ([see migration guide](../svelte/v4-migration-guide)).

--- a/packages/migrate/README.md
+++ b/packages/migrate/README.md
@@ -16,13 +16,14 @@ npx sv migrate [migration]
 
 ## Migrations
 
-| Migration     | From                  | To                    | Guide                                                           |
-| ------------- | --------------------- | --------------------- | --------------------------------------------------------------- |
-| `sveltekit-2` | SvelteKit 1.0         | SvelteKit 2.0         | [Website](https://svelte.dev/docs/kit/migrating-to-sveltekit-2) |
-| `svelte-4`    | Svelte 3              | Svelte 4              | [Website](https://svelte.dev/docs/svelte/v4-migration-guide)    |
-| `svelte-5`    | Svelte 4              | Svelte 5              |                                                                 |
-| `package`     | `@sveltejs/package@1` | `@sveltejs/package@2` | [#8922](https://github.com/sveltejs/kit/pull/8922)              |
-| `routes`      | SvelteKit pre-1.0     | SvelteKit 1.0         | [#5774](https://github.com/sveltejs/kit/discussions/5774)       |
+| Migration           | From                  | To                    | Guide                                                           |
+| ------------------- | --------------------- | --------------------- | --------------------------------------------------------------- |
+| `svelte-5`          | Svelte 4              | Svelte 5              | [Website](https://svelte.dev/docs/svelte/v5-migration-guide)    |
+| `self-closing-tags` | Svelte 4              | Svelte 4              | [#12128](https://github.com/sveltejs/kit/pull/12128)            |
+| `svelte-4`          | Svelte 3              | Svelte 4              | [Website](https://svelte.dev/docs/svelte/v4-migration-guide)    |
+| `sveltekit-2`       | SvelteKit 1.0         | SvelteKit 2.0         | [Website](https://svelte.dev/docs/kit/migrating-to-sveltekit-2) |
+| `package`           | `@sveltejs/package@1` | `@sveltejs/package@2` | [#8922](https://github.com/sveltejs/kit/pull/8922)              |
+| `routes`            | SvelteKit pre-1.0     | SvelteKit 1.0         | [#5774](https://github.com/sveltejs/kit/discussions/5774)       |
 
 Some migrations may annotate your codebase with tasks for completion that you can find by searching for `@migration`.
 


### PR DESCRIPTION
Closes #348
Additionally re-orders the migrations inside the `packages/migrate/README.md` to the same order as displayed on the website, which seem way more logical.