### PR TITLE
feat: migrate to `$app/state`

### DIFF
--- a/.changeset/sixty-shrimps-mate.md
+++ b/.changeset/sixty-shrimps-mate.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+feat: migrate to `$app/state`

--- a/packages/addons/paraglide/index.ts
+++ b/packages/addons/paraglide/index.ts
@@ -231,7 +231,7 @@ export default defineAddon({
 
 				imports.addDefault(script.ast, '$lib/paraglide/messages.js', '* as m');
 				imports.addNamed(script.ast, '$app/navigation', { goto: 'goto' });
-				imports.addNamed(script.ast, '$app/stores', { page: 'page' });
+				imports.addNamed(script.ast, '$app/state', { page: 'page' });
 				imports.addNamed(script.ast, '$lib/i18n', { i18n: 'i18n' });
 				if (typescript) {
 					imports.addNamed(
@@ -253,7 +253,7 @@ export default defineAddon({
 						${ts('', '* @param {import("$lib/paraglide/runtime").AvailableLanguageTag} newLanguage')} 
 						${ts('', '*/')} 
 						function switchToLanguage(newLanguage${ts(': AvailableLanguageTag')}) {
-							const canonicalPath = i18n.route($page.url.pathname);
+							const canonicalPath = i18n.route(page.url.pathname);
 							const localisedPath = i18n.resolveRoute(canonicalPath, newLanguage);
 							goto(localisedPath);
 						}

--- a/packages/core/tests/js/common/jsdoc-comment/input.ts
+++ b/packages/core/tests/js/common/jsdoc-comment/input.ts
@@ -1,5 +1,5 @@
 function switchToLanguage(newLanguage) {
-	const canonicalPath = i18n.route($page.url.pathname);
+	const canonicalPath = i18n.route(page.url.pathname);
 	const localisedPath = i18n.resolveRoute(canonicalPath, newLanguage);
 	goto(localisedPath);
 }

--- a/packages/core/tests/js/common/jsdoc-comment/output.ts
+++ b/packages/core/tests/js/common/jsdoc-comment/output.ts
@@ -2,7 +2,7 @@
  * @param {import("$lib/paraglide/runtime").AvailableLanguageTag} newLanguage
  */
 function switchToLanguage(newLanguage) {
-	const canonicalPath = i18n.route($page.url.pathname);
+	const canonicalPath = i18n.route(page.url.pathname);
 	const localisedPath = i18n.resolveRoute(canonicalPath, newLanguage);
 	goto(localisedPath);
 }

--- a/packages/create/templates/demo/src/routes/Header.svelte
+++ b/packages/create/templates/demo/src/routes/Header.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { page } from '$app/stores';
+	import { page } from '$app/state';
 	import logo from '$lib/images/svelte-logo.svg';
 	import github from '$lib/images/github.svg';
 </script>
@@ -16,13 +16,13 @@
 			<path d="M0,0 L1,2 C1.5,3 1.5,3 2,3 L2,0 Z" />
 		</svg>
 		<ul>
-			<li aria-current={$page.url.pathname === '/' ? 'page' : undefined}>
+			<li aria-current={page.url.pathname === '/' ? 'page' : undefined}>
 				<a href="/">Home</a>
 			</li>
-			<li aria-current={$page.url.pathname === '/about' ? 'page' : undefined}>
+			<li aria-current={page.url.pathname === '/about' ? 'page' : undefined}>
 				<a href="/about">About</a>
 			</li>
-			<li aria-current={$page.url.pathname.startsWith('/sverdle') ? 'page' : undefined}>
+			<li aria-current={page.url.pathname.startsWith('/sverdle') ? 'page' : undefined}>
 				<a href="/sverdle">Sverdle</a>
 			</li>
 		</ul>


### PR DESCRIPTION
Companion for https://github.com/sveltejs/cli/pull/354 and https://github.com/sveltejs/kit/pull/13140 respectively

* uses `$app/state` in the paraglide addon
* uses `$app/state` in the `demo` template