### PR TITLE
feat: incorporate `<svelte:html>` into templates

### DIFF
--- a/.changeset/forty-roses-occur.md
+++ b/.changeset/forty-roses-occur.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/create': minor
+---
+
+feat: incorporate `<svelte:html>` into templates

--- a/packages/create/templates/demo/src/app.html
+++ b/packages/create/templates/demo/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html %svelte.htmlAttributes%>
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />

--- a/packages/create/templates/demo/src/routes/+layout.svelte
+++ b/packages/create/templates/demo/src/routes/+layout.svelte
@@ -6,6 +6,8 @@
 	let { children } = $props();
 </script>
 
+<svelte:html lang="en" />
+
 <div class="app">
 	<Header />
 

--- a/packages/create/templates/library/src/app.html
+++ b/packages/create/templates/library/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html %svelte.htmlAttributes%>
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />

--- a/packages/create/templates/library/src/routes/+layout.svelte
+++ b/packages/create/templates/library/src/routes/+layout.svelte
@@ -1,0 +1,8 @@
+<script>
+	/** @type {{children: import('svelte').Snippet}} */
+    let { children } = $props();
+</script>
+
+<svelte:html lang="en" />
+
+{@render children()}

--- a/packages/create/templates/minimal/src/app.html
+++ b/packages/create/templates/minimal/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html %svelte.htmlAttributes%>
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />

--- a/packages/create/templates/minimal/src/routes/+layout.svelte
+++ b/packages/create/templates/minimal/src/routes/+layout.svelte
@@ -1,0 +1,8 @@
+<script>
+	/** @type {{children: import('svelte').Snippet}} */
+    let { children } = $props();
+</script>
+
+<svelte:html lang="en" />
+
+{@render children()}


### PR DESCRIPTION
Related to https://github.com/sveltejs/kit/pull/13065

TBH I don't love the fact that it's one more file for the minimal template and the library template, but it is what it is.