### PR TITLE
Deno also requires `deno task dev`

### DIFF
--- a/packages/cli/commands/create.ts
+++ b/packages/cli/commands/create.ts
@@ -75,7 +75,7 @@ export const create = new Command('create')
 				initialSteps.push(`${i++}: ${highlight(`${pm} install`)}`);
 			}
 
-			const pmRun = pm === 'npm' ? 'npm run dev --' : `${pm} dev`;
+			const pmRun = pm === 'npm' ? 'npm run dev --' : pm === 'deno' ? 'deno task dev' : `${pm} dev`;
 			const steps = [
 				...initialSteps,
 				`${i++}: ${highlight('git init && git add -A && git commit -m "Initial commit"')} (optional)`,


### PR DESCRIPTION
The output says to run `3: deno dev --open` but it requires `deno task dev --open`

This is a quick fix.