### PR TITLE
fix: don't generate sourcemaps in CI

### DIFF
--- a/.changeset/shy-pandas-learn.md
+++ b/.changeset/shy-pandas-learn.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix: don't generate sourcemaps for release

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -107,7 +107,7 @@ function getConfig(project) {
 		output: {
 			dir: outDir,
 			format: 'esm',
-			sourcemap: true
+			sourcemap: !process.env.CI
 		},
 		external,
 		plugins: [


### PR DESCRIPTION
Detected by @benmccann in https://github.com/sveltejs/cli/pull/371

There is no sense to generate the sourcemaps in CI and publish them. Locally, this seems to save about 65 % of our bundle size.