### PR TITLE
fix: add missing eslint import in generated package.json

### DIFF
--- a/.changeset/lemon-cycles-mix.md
+++ b/.changeset/lemon-cycles-mix.md
@@ -2,4 +2,4 @@
 'sv': patch
 ---
 
-fix: properly add ESLint dependency
+fix: properly add `eslint` dependency

--- a/.changeset/lemon-cycles-mix.md
+++ b/.changeset/lemon-cycles-mix.md
@@ -1,5 +1,5 @@
 ---
-'@sveltejs/addons': patch
+'sv': patch
 ---
 
 fix: properly add ESLint dependency

--- a/.changeset/lemon-cycles-mix.md
+++ b/.changeset/lemon-cycles-mix.md
@@ -2,4 +2,4 @@
 '@sveltejs/addons': patch
 ---
 
-Properly add ESLint dependency
+fix: properly add ESLint dependency

--- a/.changeset/lemon-cycles-mix.md
+++ b/.changeset/lemon-cycles-mix.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/addons': patch
+---
+
+Properly add ESLint dependency

--- a/packages/addons/eslint/index.ts
+++ b/packages/addons/eslint/index.ts
@@ -24,6 +24,7 @@ export default defineAddon({
 		sv.devDependency('@eslint/compat', '^1.2.3');
 		sv.devDependency('globals', '^15.0.0');
 		sv.devDependency('eslint-plugin-svelte', '^2.36.0');
+		sv.devDependency('@eslint/js', '^9.17.0');
 
 		if (typescript) sv.devDependency('typescript-eslint', '^8.0.0');
 


### PR DESCRIPTION
Fixes #374
I used version `@eslint/js@^9.17.0` since that's what's installed on our pnpm lockfile for this project, but maybe we can require lower?