### PR TITLE
add bun lockfiles to generated `.prettierignore`

### DIFF
--- a/packages/addons/prettier/index.ts
+++ b/packages/addons/prettier/index.ts
@@ -18,6 +18,8 @@ export default defineAddon({
 				package-lock.json
 				pnpm-lock.yaml
 				yarn.lock
+				bun.lock
+				bun.lockb
 			`;
 		});
 


### PR DESCRIPTION
Adding both the binary lockfile and the new [text-based lockfile](https://bun.sh/blog/bun-lock-text-lockfile) that is becoming the default in Bun v1.2.