### PR TITLE
fix typo with `"$app/stores"`

### DIFF
--- a/documentation/docs/20-commands/40-sv-migrate.md
+++ b/documentation/docs/20-commands/40-sv-migrate.md
@@ -16,7 +16,7 @@ npx sv migrate [migration]
 
 ### `app-state`
 
-Migrates `$app/store` usage to `$app/state` in `.svelte` files. See the [migration guide](/docs/kit/migrating-to-sveltekit-2#SvelteKit-2.12:-$app-stores-deprecated) for more details.
+Migrates `$app/stores` usage to `$app/state` in `.svelte` files. See the [migration guide](/docs/kit/migrating-to-sveltekit-2#SvelteKit-2.12:-$app-stores-deprecated) for more details.
 
 ### `svelte-5`
 


### PR DESCRIPTION
should be `$app/stores` not `$app/store`