### PR TITLE
feat: allow sub path migration or none at all

### DIFF
--- a/.changeset/strange-ducks-melt.md
+++ b/.changeset/strange-ducks-melt.md
@@ -1,0 +1,5 @@
+---
+'svelte-migrate': minor
+---
+
+feat: allow sub path migration or none at all for Svelte 5 migration

--- a/packages/migrate/migrations/svelte-5/index.js
+++ b/packages/migrate/migrations/svelte-5/index.js
@@ -140,7 +140,7 @@ export async function migrate() {
 			.concat([
 				{
 					title: 'custom (overrides selection, allows to specify sub folders)',
-					value: ',',
+					value: ',', // a value that definitely isn't a valid folder name so it cannot clash
 					selected: false
 				}
 			])
@@ -154,7 +154,7 @@ export async function migrate() {
 		const custom = await prompts({
 			type: 'list',
 			name: 'value',
-			message: 'Specify folders (comma separated)'
+			message: 'Specify folder paths (comma separated)'
 		});
 
 		if (!custom.value) {

--- a/packages/migrate/migrations/svelte-5/index.js
+++ b/packages/migrate/migrations/svelte-5/index.js
@@ -18,10 +18,6 @@ export async function migrate() {
 		bail('Please re-run this script in a directory with a package.json');
 	}
 
-	console.log(
-		'This migration is experimental — please report any bugs to https://github.com/sveltejs/svelte/issues'
-	);
-
 	const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
 
 	const svelte_dep = pkg.devDependencies?.svelte ?? pkg.dependencies?.svelte;
@@ -141,11 +137,40 @@ export async function migrate() {
 				(dir) => fs.statSync(dir).isDirectory() && dir !== 'node_modules' && !dir.startsWith('.')
 			)
 			.map((dir) => ({ title: dir, value: dir, selected: true }))
+			.concat([
+				{
+					title: 'custom (overrides selection, allows to specify sub folders)',
+					value: ',',
+					selected: false
+				}
+			])
 	});
 
 	if (!folders.value?.length) {
 		process.exit(1);
 	}
+
+	if (folders.value.includes(',')) {
+		const custom = await prompts({
+			type: 'list',
+			name: 'value',
+			message: 'Specify folders (comma separated)'
+		});
+
+		if (!custom.value) {
+			process.exit(1);
+		}
+
+		folders.value = custom.value.map((/** @type {string} */ folder) => (folder = folder.trim()));
+	}
+
+	const do_migration = await prompts({
+		type: 'confirm',
+		name: 'value',
+		message:
+			'Do you want to use the migration tool to convert your Svelte components to the new syntax? (You can also do this per component or sub path later)',
+		initial: true
+	});
 
 	update_pkg_json();
 
@@ -171,9 +196,11 @@ export async function migrate() {
 	for (const file of files) {
 		if (extensions.some((ext) => file.endsWith(ext))) {
 			if (svelte_extensions.some((ext) => file.endsWith(ext))) {
-				update_svelte_file(file, transform_module_code, (code) =>
-					transform_svelte_code(code, migrate, { filename: file, use_ts })
-				);
+				if (do_migration.value) {
+					update_svelte_file(file, transform_module_code, (code) =>
+						transform_svelte_code(code, migrate, { filename: file, use_ts })
+					);
+				}
 			} else {
 				update_js_file(file, transform_module_code);
 			}


### PR DESCRIPTION
This adds two new prompts to the Svelte migration:
- custom folder prompt (from multiselect); if selected you can specify what folders exactly to migrate. closes #390
- adds a way to skip migrating your components if you want to do it incrementally but still benefit from having your package.json and entry points migrated automatically