### PR TITLE
chore: utilize prepack lifecycle script

### DIFF
--- a/.changeset/pretty-balloons-leave.md
+++ b/.changeset/pretty-balloons-leave.md
@@ -1,5 +1,5 @@
 ---
-'@sveltejs/create': patch
+'sv': patch
 ---
 
 chore: utilize prepack lifecycle script

--- a/.changeset/pretty-balloons-leave.md
+++ b/.changeset/pretty-balloons-leave.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/create': patch
+---
+
+chore: utilize prepack lifecycle script

--- a/packages/create/templates/library/package.template.json
+++ b/packages/create/templates/library/package.template.json
@@ -3,10 +3,9 @@
 	"version": "0.0.1",
 	"scripts": {
 		"dev": "vite dev",
-		"build": "vite build && npm run package",
+		"build": "vite build && npm run prepack",
 		"preview": "vite preview",
-		"package": "svelte-kit sync && svelte-package && publint",
-		"prepublishOnly": "npm run package"
+		"prepack": "svelte-kit sync && svelte-package && publint"
 	},
 	"files": ["dist", "!dist/**/*.test.*", "!dist/**/*.spec.*"],
 	"sideEffects": ["**/*.css"],
@@ -27,7 +26,7 @@
 		"@sveltejs/kit": "^2.0.0",
 		"@sveltejs/package": "^2.0.0",
 		"@sveltejs/vite-plugin-svelte": "^4.0.0",
-		"publint": "^0.2.0",
+		"publint": "^0.3.2",
 		"svelte": "^5.0.0",
 		"typescript": "^5.3.2",
 		"vite": "^5.4.11"


### PR DESCRIPTION
The `prepack` lifecycle script runs before the [`npm pack`](https://docs.npmjs.com/cli/v10/using-npm/scripts#npm-pack) and `npm publish` commands.

By utilizing this:

1. the `prepublishOnly` lifecycle script can be removed, which contained an `npm` command.[^1]
2. it works with `npm pack`.

> [!NOTE]  
> The `publint@0.3` CLI does run the `pack` command, but it does not run the lifecycle scripts.
>
> So `&& publint` should be included at the end of the `prepack` script.
>
> This is correctly implemented from [`publint@0.3.2`](https://github.com/publint/publint/releases/tag/publint%400.3.2), thus the SemVer is updated to `^0.3.2`.
>
> - https://github.com/publint/publint/issues/129#issuecomment-2589151355

[^1]: I hope they are changed to [`node --run`](https://nodejs.org/api/cli.html#--run) in the future when SvelteKit requires Node.js 22+.