### PR TITLE
chore: bump eslint-config-prettier

### DIFF
--- a/.changeset/quick-paws-breathe.md
+++ b/.changeset/quick-paws-breathe.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/addons': patch
+---
+
+chore: bump eslint-config-prettier

--- a/packages/addons/eslint/index.ts
+++ b/packages/addons/eslint/index.ts
@@ -28,7 +28,7 @@ export default defineAddon({
 
 		if (typescript) sv.devDependency('typescript-eslint', '^8.0.0');
 
-		if (prettierInstalled) sv.devDependency('eslint-config-prettier', '^9.1.0');
+		if (prettierInstalled) sv.devDependency('eslint-config-prettier', '^10.0.1');
 
 		sv.file('package.json', (content) => {
 			const { data, generateCode } = parseJson(content);


### PR DESCRIPTION
[v10](https://github.com/prettier/eslint-config-prettier/releases/tag/v10.0.0) has no breaking changes. new feature:

- https://github.com/prettier/eslint-config-prettier/pull/272