### PR TITLE
fix: tailwind plugins as dev dependencies

### DIFF
--- a/.changeset/twelve-pets-film.md
+++ b/.changeset/twelve-pets-film.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/addons': patch
+---
+
+fix: tailwind plugins as dev dependencies

--- a/.changeset/twelve-pets-film.md
+++ b/.changeset/twelve-pets-film.md
@@ -1,5 +1,5 @@
 ---
-'@sveltejs/addons': patch
+'sv': patch
 ---
 
 fix: tailwind plugins as dev dependencies

--- a/packages/addons/tailwindcss/index.ts
+++ b/packages/addons/tailwindcss/index.ts
@@ -59,7 +59,7 @@ export default defineAddon({
 		for (const plugin of plugins) {
 			if (!options.plugins.includes(plugin.id)) continue;
 
-			sv.dependency(plugin.package, plugin.version);
+			sv.devDependency(plugin.package, plugin.version);
 		}
 
 		sv.file(`tailwind.config.${ext}`, (content) => {


### PR DESCRIPTION
Tailwind CSS plugins should be installed as `devDependencies` alongside `tailwindcss`.

```shell
npm install -D @tailwindcss/forms
```

https://github.com/tailwindlabs/tailwindcss-forms#installation