### PR TITLE
chore: add prepare script to run `svelte-kit sync`

### DIFF
--- a/.changeset/angry-dingos-run.md
+++ b/.changeset/angry-dingos-run.md
@@ -2,4 +2,4 @@
 'sv': patch
 ---
 
-chore: upgrade SvelteKit and add preprepare script to generate tsconfig for local installs
+chore: upgrade SvelteKit and add prepare script to generate tsconfig for local installs

--- a/.changeset/angry-dingos-run.md
+++ b/.changeset/angry-dingos-run.md
@@ -2,4 +2,4 @@
 'sv': patch
 ---
 
-chore: upgrade SvelteKit and add prepare script to generate tsconfig for local installs
+chore: add prepare script to run `svelte-kit sync`

--- a/.changeset/angry-dingos-run.md
+++ b/.changeset/angry-dingos-run.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+chore: upgrade SvelteKit and add preprepare script to generate tsconfig for local installs

--- a/packages/create/templates/demo/package.template.json
+++ b/packages/create/templates/demo/package.template.json
@@ -7,7 +7,7 @@
 		"dev": "vite dev",
 		"build": "vite build",
 		"preview": "vite preview",
-		"preprepare": "svelte-kit sync"
+		"prepare": "svelte-kit sync || echo"
 	},
 	"devDependencies": {
 		"@fontsource/fira-mono": "^5.0.0",

--- a/packages/create/templates/demo/package.template.json
+++ b/packages/create/templates/demo/package.template.json
@@ -7,7 +7,7 @@
 		"dev": "vite dev",
 		"build": "vite build",
 		"preview": "vite preview",
-		"prepare": "svelte-kit sync || echo"
+		"prepare": "svelte-kit sync || echo ''"
 	},
 	"devDependencies": {
 		"@fontsource/fira-mono": "^5.0.0",

--- a/packages/create/templates/demo/package.template.json
+++ b/packages/create/templates/demo/package.template.json
@@ -6,7 +6,8 @@
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
-		"preview": "vite preview"
+		"preview": "vite preview",
+		"preprepare": "svelte-kit sync"
 	},
 	"devDependencies": {
 		"@fontsource/fira-mono": "^5.0.0",

--- a/packages/create/templates/library/package.template.json
+++ b/packages/create/templates/library/package.template.json
@@ -5,6 +5,7 @@
 		"dev": "vite dev",
 		"build": "vite build && npm run prepack",
 		"preview": "vite preview",
+		"preprepare": "svelte-kit sync",
 		"prepack": "svelte-kit sync && svelte-package && publint"
 	},
 	"files": ["dist", "!dist/**/*.test.*", "!dist/**/*.spec.*"],

--- a/packages/create/templates/library/package.template.json
+++ b/packages/create/templates/library/package.template.json
@@ -5,7 +5,7 @@
 		"dev": "vite dev",
 		"build": "vite build && npm run prepack",
 		"preview": "vite preview",
-		"preprepare": "svelte-kit sync",
+		"prepare": "svelte-kit sync",
 		"prepack": "svelte-kit sync && svelte-package && publint"
 	},
 	"files": ["dist", "!dist/**/*.test.*", "!dist/**/*.spec.*"],

--- a/packages/create/templates/library/package.template.json
+++ b/packages/create/templates/library/package.template.json
@@ -5,7 +5,7 @@
 		"dev": "vite dev",
 		"build": "vite build && npm run prepack",
 		"preview": "vite preview",
-		"prepare": "svelte-kit sync",
+		"prepare": "svelte-kit sync || echo",
 		"prepack": "svelte-kit sync && svelte-package && publint"
 	},
 	"files": ["dist", "!dist/**/*.test.*", "!dist/**/*.spec.*"],

--- a/packages/create/templates/library/package.template.json
+++ b/packages/create/templates/library/package.template.json
@@ -5,7 +5,7 @@
 		"dev": "vite dev",
 		"build": "vite build && npm run prepack",
 		"preview": "vite preview",
-		"prepare": "svelte-kit sync || echo",
+		"prepare": "svelte-kit sync || echo ''",
 		"prepack": "svelte-kit sync && svelte-package && publint"
 	},
 	"files": ["dist", "!dist/**/*.test.*", "!dist/**/*.spec.*"],

--- a/packages/create/templates/minimal/package.template.json
+++ b/packages/create/templates/minimal/package.template.json
@@ -7,7 +7,7 @@
 		"dev": "vite dev",
 		"build": "vite build",
 		"preview": "vite preview",
-		"prepare": "svelte-kit sync || echo"
+		"prepare": "svelte-kit sync || echo ''"
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "^4.0.0",

--- a/packages/create/templates/minimal/package.template.json
+++ b/packages/create/templates/minimal/package.template.json
@@ -6,7 +6,8 @@
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
-		"preview": "vite preview"
+		"preview": "vite preview",
+		"preprepare": "svelte-kit sync"
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "^4.0.0",

--- a/packages/create/templates/minimal/package.template.json
+++ b/packages/create/templates/minimal/package.template.json
@@ -7,7 +7,7 @@
 		"dev": "vite dev",
 		"build": "vite build",
 		"preview": "vite preview",
-		"preprepare": "svelte-kit sync"
+		"prepare": "svelte-kit sync || echo"
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "^4.0.0",


### PR DESCRIPTION
closes https://github.com/sveltejs/cli/issues/388

see also https://github.com/sveltejs/kit/pull/13304

~~I went with `preprepare` as I believe it runs on solely on local installs (not installs from registry. though perhaps installs using git). Had previously been thinking about `prepare`, but that also runs on publish and we don't need to do it then~~

~~marked as draft as this currently only works on npm: https://github.com/pnpm/pnpm/issues/8987~~