### PR TITLE
chore: update vite and related packages

### DIFF
--- a/.changeset/gold-cougars-report.md
+++ b/.changeset/gold-cougars-report.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+chore: update `vite@6` and related packages

--- a/packages/addons/vitest-addon/index.ts
+++ b/packages/addons/vitest-addon/index.ts
@@ -10,7 +10,7 @@ export default defineAddon({
 	run: ({ sv, typescript }) => {
 		const ext = typescript ? 'ts' : 'js';
 
-		sv.devDependency('vitest', '^2.1.8');
+		sv.devDependency('vitest', '^3.0.0');
 
 		sv.file('package.json', (content) => {
 			const { data, generateCode } = parseJson(content);

--- a/packages/create/templates/demo/package.json
+++ b/packages/create/templates/demo/package.json
@@ -11,11 +11,11 @@
 	"devDependencies": {
 		"@fontsource/fira-mono": "^5.0.0",
 		"@neoconfetti/svelte": "^2.0.0",
-		"@sveltejs/adapter-auto": "^3",
-		"@sveltejs/kit": "^2",
-		"@sveltejs/vite-plugin-svelte": "^4.0.0",
+		"@sveltejs/adapter-auto": "^4.0.0",
+		"@sveltejs/kit": "^2.9.0",
+		"@sveltejs/vite-plugin-svelte": "^5.0.0",
 		"svelte": "^5.0.0",
 		"typescript": "^5.3.3",
-		"vite": "^5.4.11"
+		"vite": "^6.0.0"
 	}
 }

--- a/packages/create/templates/demo/package.template.json
+++ b/packages/create/templates/demo/package.template.json
@@ -12,9 +12,9 @@
 		"@fontsource/fira-mono": "^5.0.0",
 		"@neoconfetti/svelte": "^2.0.0",
 		"@sveltejs/adapter-auto": "^4.0.0",
-		"@sveltejs/kit": "^2.0.0",
-		"@sveltejs/vite-plugin-svelte": "^4.0.0",
+		"@sveltejs/kit": "^2.9.0",
+		"@sveltejs/vite-plugin-svelte": "^5.0.0",
 		"svelte": "^5.0.0",
-		"vite": "^5.4.11"
+		"vite": "^6.0.0"
 	}
 }

--- a/packages/create/templates/demo/package.template.json
+++ b/packages/create/templates/demo/package.template.json
@@ -12,7 +12,7 @@
 		"@fontsource/fira-mono": "^5.0.0",
 		"@neoconfetti/svelte": "^2.0.0",
 		"@sveltejs/adapter-auto": "^4.0.0",
-		"@sveltejs/kit": "^2.9.0",
+		"@sveltejs/kit": "^2.16.0",
 		"@sveltejs/vite-plugin-svelte": "^5.0.0",
 		"svelte": "^5.0.0",
 		"vite": "^6.0.0"

--- a/packages/create/templates/library/package.template.json
+++ b/packages/create/templates/library/package.template.json
@@ -23,7 +23,7 @@
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "^4.0.0",
-		"@sveltejs/kit": "^2.9.0",
+		"@sveltejs/kit": "^2.16.0",
 		"@sveltejs/package": "^2.0.0",
 		"@sveltejs/vite-plugin-svelte": "^5.0.0",
 		"publint": "^0.3.2",

--- a/packages/create/templates/library/package.template.json
+++ b/packages/create/templates/library/package.template.json
@@ -23,12 +23,12 @@
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "^4.0.0",
-		"@sveltejs/kit": "^2.0.0",
+		"@sveltejs/kit": "^2.9.0",
 		"@sveltejs/package": "^2.0.0",
-		"@sveltejs/vite-plugin-svelte": "^4.0.0",
+		"@sveltejs/vite-plugin-svelte": "^5.0.0",
 		"publint": "^0.3.2",
 		"svelte": "^5.0.0",
 		"typescript": "^5.3.2",
-		"vite": "^5.4.11"
+		"vite": "^6.0.0"
 	}
 }

--- a/packages/create/templates/minimal/package.template.json
+++ b/packages/create/templates/minimal/package.template.json
@@ -10,7 +10,7 @@
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "^4.0.0",
-		"@sveltejs/kit": "^2.9.0",
+		"@sveltejs/kit": "^2.16.0",
 		"@sveltejs/vite-plugin-svelte": "^5.0.0",
 		"svelte": "^5.0.0",
 		"vite": "^6.0.0"

--- a/packages/create/templates/minimal/package.template.json
+++ b/packages/create/templates/minimal/package.template.json
@@ -10,9 +10,9 @@
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "^4.0.0",
-		"@sveltejs/kit": "^2.0.0",
-		"@sveltejs/vite-plugin-svelte": "^4.0.0",
+		"@sveltejs/kit": "^2.9.0",
+		"@sveltejs/vite-plugin-svelte": "^5.0.0",
 		"svelte": "^5.0.0",
-		"vite": "^5.4.11"
+		"vite": "^6.0.0"
 	}
 }


### PR DESCRIPTION
`vitest@3` has been released. `vite@6` can be used.

- [`vitest@3.0.0`]: Support Vite 6

[`vitest@3.0.0`]: https://github.com/vitest-dev/vitest/releases/tag/v3.0.0

Previous attempts:

- https://github.com/sveltejs/cli/pull/340
- https://github.com/sveltejs/cli/pull/353 (reverts above PR)

Additional changes:

- Vitest add-on has been update to `^3.0.0`.

```
┌  Welcome to the Svelte CLI! (v0.6.13)
│
◇  Where would you like your project to be created?
│  ./
│
◇  Which template would you like?
│  SvelteKit minimal
│
◇  Add type checking with Typescript?
│  Yes, using Typescript syntax
│
◆  Project created
│
◇  What would you like to add to your project? (use arrow keys / space bar)
│  vitest
```

```shell
pnpm add @sveltejs/vite-plugin-svelte@latest vite@latest vitest@latest
pnpm test # works
pnpm test:unit # works
```
