### PR TITLE
fix: avoid server round trips when playing Sverdle with a keyboard

### DIFF
--- a/.changeset/three-humans-pay.md
+++ b/.changeset/three-humans-pay.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/create': patch
+---
+
+fix: ensure Sverdle keyboard events modify game state without a trip to the server if client-side JavaScript is enabled

--- a/packages/create/templates/demo/src/routes/sverdle/+page.svelte
+++ b/packages/create/templates/demo/src/routes/sverdle/+page.svelte
@@ -99,7 +99,7 @@
 
 		document
 			.querySelector(`[data-key="${event.key}" i]`)
-			?.dispatchEvent(new MouseEvent('click', { cancelable: true }));
+			?.dispatchEvent(new MouseEvent('click', { cancelable: true, bubbles: true }));
 	}
 </script>
 


### PR DESCRIPTION
This PR modifies the create-svelte default template to ensure `keydown` events while playing Sverdle correctly avoid making a request to the server if client-side JS is available. Apparently, the synthetic mouse event needs to bubble to trigger the `onclick` handler. If not, it triggers the `formaction` on the button instead.