### PR TITLE
fix: `onlyBuiltDependencies` not added on new projects

### DIFF
--- a/.changeset/nine-phones-shout.md
+++ b/.changeset/nine-phones-shout.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix: `onlyBuiltDependencies` not added on new projects

--- a/packages/cli/utils/package-manager.ts
+++ b/packages/cli/utils/package-manager.ts
@@ -80,12 +80,15 @@ export function addPnpmBuildDependendencies(
 	// other package managers are currently not affected by this change
 	if (!packageManager || packageManager !== 'pnpm') return;
 
-	// find the workspace root
+	// find the workspace root (if present)
 	const pnpmWorkspacePath = find.up('pnpm-workspace.yaml', { cwd });
-	if (!pnpmWorkspacePath) return;
+	let packageDirectory;
+
+	if (pnpmWorkspacePath) packageDirectory = path.dirname(pnpmWorkspacePath);
+	else packageDirectory = cwd;
 
 	// load the package.json
-	const pkgPath = path.join(path.dirname(pnpmWorkspacePath), 'package.json');
+	const pkgPath = path.join(packageDirectory, 'package.json');
 	const content = fs.readFileSync(pkgPath, 'utf-8');
 	const { data, generateCode } = parseJson(content);
 


### PR DESCRIPTION
Relates https://github.com/sveltejs/cli/pull/432
Relates https://github.com/sveltejs/cli/pull/424
Relates https://github.com/sveltejs/cli/pull/388

I fixed the tests in my last commit in the other PR, but broke it for newly create projects. Here is the fix