### PR TITLE
fix: make `drizzle` next steps more precise

### DIFF
--- a/.changeset/hungry-beds-speak.md
+++ b/.changeset/hungry-beds-speak.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix: make `drizzle` next steps more precise

--- a/packages/addons/drizzle/index.ts
+++ b/packages/addons/drizzle/index.ts
@@ -343,6 +343,10 @@ export default defineAddon({
 			steps.push(
 				`Run ${highlighter.command(`${packageManager} run db:start`)} to start the docker container`
 			);
+		} else {
+			steps.push(
+				`Check ${highlighter.env('DATABASE_URL')} in ${highlighter.path('.env')} and adjust it to your needs`
+			);
 		}
 		steps.push(
 			`Run ${highlighter.command(`${packageManager} run db:push`)} to update your database schema`


### PR DESCRIPTION
Closes #377 

Linked issue was suggesting only adding text for neon databases. After a second thought the current steps are not precise and may lead to unexpected results in most (non docker) cases.