### PR TITLE
chore: update addon dependencies

### DIFF
--- a/.changeset/nervous-apples-attack.md
+++ b/.changeset/nervous-apples-attack.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+chore: update addon dependencies

--- a/packages/addons/drizzle/index.ts
+++ b/packages/addons/drizzle/index.ts
@@ -74,7 +74,7 @@ export default defineAddon({
 	run: ({ sv, typescript, options, kit }) => {
 		const ext = typescript ? 'ts' : 'js';
 
-		sv.dependency('drizzle-orm', '^0.39.3');
+		sv.dependency('drizzle-orm', '^0.40.0');
 		sv.devDependency('drizzle-kit', '^0.30.2');
 
 		// MySQL

--- a/packages/addons/drizzle/index.ts
+++ b/packages/addons/drizzle/index.ts
@@ -74,7 +74,7 @@ export default defineAddon({
 	run: ({ sv, typescript, options, kit }) => {
 		const ext = typescript ? 'ts' : 'js';
 
-		sv.dependency('drizzle-orm', '^0.38.4');
+		sv.dependency('drizzle-orm', '^0.39.3');
 		sv.devDependency('drizzle-kit', '^0.30.2');
 
 		// MySQL

--- a/packages/addons/eslint/index.ts
+++ b/packages/addons/eslint/index.ts
@@ -23,7 +23,7 @@ export default defineAddon({
 		sv.devDependency('eslint', '^9.18.0');
 		sv.devDependency('@eslint/compat', '^1.2.5');
 		sv.devDependency('globals', '^16.0.0');
-		sv.devDependency('eslint-plugin-svelte', '^3.0.0');
+		sv.devDependency('eslint-plugin-svelte', '^2.46.1');
 		sv.devDependency('@eslint/js', '^9.18.0');
 
 		if (typescript) sv.devDependency('typescript-eslint', '^8.20.0');

--- a/packages/addons/eslint/index.ts
+++ b/packages/addons/eslint/index.ts
@@ -22,7 +22,7 @@ export default defineAddon({
 
 		sv.devDependency('eslint', '^9.18.0');
 		sv.devDependency('@eslint/compat', '^1.2.5');
-		sv.devDependency('globals', '^15.14.0');
+		sv.devDependency('globals', '^16.0.0');
 		sv.devDependency('eslint-plugin-svelte', '^2.46.1');
 		sv.devDependency('@eslint/js', '^9.18.0');
 

--- a/packages/addons/eslint/index.ts
+++ b/packages/addons/eslint/index.ts
@@ -23,7 +23,7 @@ export default defineAddon({
 		sv.devDependency('eslint', '^9.18.0');
 		sv.devDependency('@eslint/compat', '^1.2.5');
 		sv.devDependency('globals', '^16.0.0');
-		sv.devDependency('eslint-plugin-svelte', '^2.46.1');
+		sv.devDependency('eslint-plugin-svelte', '^3.0.0');
 		sv.devDependency('@eslint/js', '^9.18.0');
 
 		if (typescript) sv.devDependency('typescript-eslint', '^8.20.0');

--- a/packages/addons/vitest-addon/index.ts
+++ b/packages/addons/vitest-addon/index.ts
@@ -13,7 +13,7 @@ export default defineAddon({
 		sv.devDependency('vitest', '^3.0.0');
 		sv.devDependency('@testing-library/svelte', '^5.2.4');
 		sv.devDependency('@testing-library/jest-dom', '^6.6.3');
-		sv.devDependency('jsdom', '^25.0.1');
+		sv.devDependency('jsdom', '^26.0.0');
 
 		sv.file('package.json', (content) => {
 			const { data, generateCode } = parseJson(content);


### PR DESCRIPTION
Created a PR similar to https://github.com/sveltejs/cli/pull/357

Only reviewed applied major dependency bumps:

- [`drizzle-orm@0.39`](https://github.com/drizzle-team/drizzle-orm/releases/tag/0.39.0)
- [`drizzle-orm@0.40`](https://github.com/drizzle-team/drizzle-orm/releases/tag/0.40.0)
- [`globals@16`](https://github.com/sindresorhus/globals/releases/tag/v16.0.0)
- [`jsdom@26`](https://github.com/jsdom/jsdom/releases/tag/26.0.0)