### PR TITLE
fix: use `eslint-plugin-svelte` v3

### DIFF
--- a/.changeset/lazy-boxes-compete.md
+++ b/.changeset/lazy-boxes-compete.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix: use `eslint-plugin-svelte` v3

--- a/packages/addons/eslint/index.ts
+++ b/packages/addons/eslint/index.ts
@@ -78,7 +78,7 @@ export default defineAddon({
 				eslintConfigs.push(common.createSpreadElement(tsConfig));
 			}
 
-			const svelteConfig = common.expressionFromString('svelte.configs.recommended');
+			const svelteConfig = common.expressionFromString('svelte.configs["flat/recommended"]');
 			eslintConfigs.push(common.createSpreadElement(svelteConfig));
 
 			const globalsBrowser = common.createSpreadElement(

--- a/packages/addons/eslint/index.ts
+++ b/packages/addons/eslint/index.ts
@@ -22,10 +22,8 @@ export default defineAddon({
 
 		sv.devDependency('eslint', '^9.18.0');
 		sv.devDependency('@eslint/compat', '^1.2.5');
-		sv.devDependency('globals', '^15.14.0');
 		sv.devDependency('eslint-plugin-svelte', '^3.0.0');
 		sv.devDependency('globals', '^16.0.0');
-		sv.devDependency('eslint-plugin-svelte', '^2.46.1');
 		sv.devDependency('@eslint/js', '^9.18.0');
 
 		if (typescript) sv.devDependency('typescript-eslint', '^8.20.0');
@@ -78,7 +76,7 @@ export default defineAddon({
 				eslintConfigs.push(common.createSpreadElement(tsConfig));
 			}
 
-			const svelteConfig = common.expressionFromString('svelte.configs["flat/recommended"]');
+			const svelteConfig = common.expressionFromString('svelte.configs.recommended');
 			eslintConfigs.push(common.createSpreadElement(svelteConfig));
 
 			const globalsBrowser = common.createSpreadElement(


### PR DESCRIPTION
Fixes the version added for `eslint-plugin-svelte`. It seems like a bad merge added duplicates.

Closes #457