### PR TITLE
fix: allow `tailwindcss` plugins to be added after initial execution

### DIFF
--- a/.changeset/ninety-islands-cross.md
+++ b/.changeset/ninety-islands-cross.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix: properly add tailwind plugins on subsequent add-on executions

--- a/packages/addons/tailwindcss/index.ts
+++ b/packages/addons/tailwindcss/index.ts
@@ -89,9 +89,12 @@ export default defineAddon({
 			for (const plugin of plugins) {
 				if (!options.plugins.includes(plugin.id)) continue;
 
-				// Checks for both double and single quote variants
-				const pkgs = [`'${plugin.package}'`, `"${plugin.package}"`];
-				const atRule = atRules.find((x) => x.name === 'plugin' && pkgs.includes(x.params));
+				const atRule = atRules.find(
+					(rule) =>
+						rule.name === 'plugin' &&
+						// Checks for both double and single quote variants
+						rule.params.replace(/['"]/g, '') === plugin.package
+				);
 				if (!atRule) {
 					const pluginImport = `\n@plugin '${plugin.package}';`;
 					code = code.substring(0, pluginPos) + pluginImport + code.substring(pluginPos);

--- a/packages/addons/tailwindcss/index.ts
+++ b/packages/addons/tailwindcss/index.ts
@@ -87,10 +87,9 @@ export default defineAddon({
 			const importsTailwind = findAtRule('import', 'tailwindcss');
 			if (!importsTailwind) {
 				code = "@import 'tailwindcss';\n" + code;
+				// reparse to account for the newly added tailwindcss import
+				atRules = parseCss(code).ast.nodes.filter((node) => node.type === 'atrule');
 			}
-
-			// reparse to account for the newly added tailwindcss import
-			atRules = parseCss(code).ast.nodes.filter((node) => node.type === 'atrule');
 
 			const lastAtRule = atRules.findLast((rule) => ['plugin', 'import'].includes(rule.name));
 			const pluginPos = lastAtRule!.source!.end!.offset;

--- a/packages/addons/tailwindcss/index.ts
+++ b/packages/addons/tailwindcss/index.ts
@@ -88,9 +88,10 @@ export default defineAddon({
 			const atRules = ast.nodes.filter((x) => x.type === 'atrule');
 			for (const plugin of plugins) {
 				if (!options.plugins.includes(plugin.id)) continue;
-				const atRule = atRules.find(
-					(x) => x.name === 'plugin' && x.params === `'${plugin.package}'`
-				);
+
+				// Checks for both double and single quote variants
+				const pkgs = [`'${plugin.package}'`, `"${plugin.package}"`];
+				const atRule = atRules.find((x) => x.name === 'plugin' && pkgs.includes(x.params));
 				if (!atRule) {
 					const pluginImport = `\n@plugin '${plugin.package}';`;
 					code = code.substring(0, pluginPos) + pluginImport + code.substring(pluginPos);


### PR DESCRIPTION
Fixes a bug where tailwind plugins wouldn't be added on subsequent `sv add tailwindcss` runs.