### PR TITLE
fix: pass `schema` to `drizzle` client for better type generation

### DIFF
--- a/.changeset/swift-poets-wonder.md
+++ b/.changeset/swift-poets-wonder.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix: pass `schema` to `drizzle` client for better type generation

--- a/packages/addons/drizzle/index.ts
+++ b/packages/addons/drizzle/index.ts
@@ -261,7 +261,6 @@ export default defineAddon({
 			const { ast, generateCode } = parseScript(content);
 
 			imports.addNamed(ast, '$env/dynamic/private', { env: 'env' });
-			imports.addNamespace(ast, './schema', 'schema');
 
 			// env var checks
 			const dbURLCheck = common.statementFromString(
@@ -270,6 +269,7 @@ export default defineAddon({
 			common.addStatement(ast, dbURLCheck);
 
 			let clientExpression;
+			let addSchema = true;
 			// SQLite
 			if (options.sqlite === 'better-sqlite3') {
 				imports.addDefault(ast, 'better-sqlite3', 'Database');
@@ -304,12 +304,14 @@ export default defineAddon({
 				clientExpression = common.expressionFromString(
 					'await mysql.createConnection(env.DATABASE_URL)'
 				);
+				addSchema = false;
 			}
 			if (options.mysql === 'planetscale') {
 				imports.addNamed(ast, '@planetscale/database', { Client: 'Client' });
 				imports.addNamed(ast, 'drizzle-orm/planetscale-serverless', { drizzle: 'drizzle' });
 
 				clientExpression = common.expressionFromString('new Client({ url: env.DATABASE_URL })');
+				addSchema = false;
 			}
 			// PostgreSQL
 			if (options.postgresql === 'neon') {
@@ -330,11 +332,14 @@ export default defineAddon({
 			common.addStatement(ast, clientIdentifier);
 
 			const drizzleCall = functions.callByIdentifier('drizzle', ['client']);
-			drizzleCall.arguments.push(
-				object.create({
-					schema: variables.identifier('schema')
-				})
-			);
+			if (addSchema) {
+				imports.addNamespace(ast, './schema', 'schema');
+				drizzleCall.arguments.push(
+					object.create({
+						schema: variables.identifier('schema')
+					})
+				);
+			}
 			const db = variables.declaration(ast, 'const', 'db', drizzleCall);
 			exports.namedExport(ast, 'db', db);
 

--- a/packages/addons/drizzle/index.ts
+++ b/packages/addons/drizzle/index.ts
@@ -297,19 +297,13 @@ export default defineAddon({
 				}
 			}
 			// MySQL
-			if (options.mysql === 'mysql2') {
+			if (options.mysql === 'mysql2' || options.mysql === 'planetscale') {
 				imports.addDefault(ast, 'mysql2/promise', 'mysql');
 				imports.addNamed(ast, 'drizzle-orm/mysql2', { drizzle: 'drizzle' });
 
 				clientExpression = common.expressionFromString(
 					'await mysql.createConnection(env.DATABASE_URL)'
 				);
-			}
-			if (options.mysql === 'planetscale') {
-				imports.addNamed(ast, '@planetscale/database', { Client: 'Client' });
-				imports.addNamed(ast, 'drizzle-orm/planetscale-serverless', { drizzle: 'drizzle' });
-
-				clientExpression = common.expressionFromString('new Client({ url: env.DATABASE_URL })');
 			}
 			// PostgreSQL
 			if (options.postgresql === 'neon') {
@@ -329,12 +323,20 @@ export default defineAddon({
 			const clientIdentifier = variables.declaration(ast, 'const', 'client', clientExpression);
 			common.addStatement(ast, clientIdentifier);
 
+			// create drizzle function call
 			const drizzleCall = functions.callByIdentifier('drizzle', ['client']);
-			drizzleCall.arguments.push(
-				object.create({
-					schema: variables.identifier('schema')
-				})
-			);
+
+			// add schema to support `db.query`
+			const paramObject = object.create({
+				schema: variables.identifier('schema')
+			});
+			if (options.database == 'mysql') {
+				const mode = options.mysql == 'planetscale' ? 'planetscale' : 'default';
+				object.property(paramObject, 'mode', common.createLiteral(mode));
+			}
+			drizzleCall.arguments.push(paramObject);
+
+			// create `db` export
 			const db = variables.declaration(ast, 'const', 'db', drizzleCall);
 			exports.namedExport(ast, 'db', db);
 

--- a/packages/addons/drizzle/index.ts
+++ b/packages/addons/drizzle/index.ts
@@ -261,6 +261,7 @@ export default defineAddon({
 			const { ast, generateCode } = parseScript(content);
 
 			imports.addNamed(ast, '$env/dynamic/private', { env: 'env' });
+			imports.addNamespace(ast, './schema', 'schema');
 
 			// env var checks
 			const dbURLCheck = common.statementFromString(
@@ -329,6 +330,11 @@ export default defineAddon({
 			common.addStatement(ast, clientIdentifier);
 
 			const drizzleCall = functions.callByIdentifier('drizzle', ['client']);
+			drizzleCall.arguments.push(
+				object.create({
+					schema: variables.identifier('schema')
+				})
+			);
 			const db = variables.declaration(ast, 'const', 'db', drizzleCall);
 			exports.namedExport(ast, 'db', db);
 


### PR DESCRIPTION
closes #452 

This PR basically changes `src\lib\server\db\index.ts` from 
```js
export const db = drizzle(client);
```

to 
```js
export const db = drizzle(client, {
    schema
});
```


For both mysql based  options (mysql2 and planetscale) another property [`mode`](https://orm.drizzle.team/docs/rqb#modes) is added to the config object. 

I' was unable to test the planetscale implementation though, as their pricing is off the charts.  We should consider dropping it in the future.