### PR TITLE
chore: add keys to `{#each}` blocks

### DIFF
--- a/.changeset/selfish-houses-retire.md
+++ b/.changeset/selfish-houses-retire.md
@@ -1,0 +1,5 @@
+---
+"sv": patch
+---
+
+chore: add keys to `{#each}` blocks

--- a/packages/create/templates/demo/src/routes/sverdle/+page.svelte
+++ b/packages/create/templates/demo/src/routes/sverdle/+page.svelte
@@ -179,9 +179,9 @@
 					back
 				</button>
 
-				{#each ['qwertyuiop', 'asdfghjkl', 'zxcvbnm'] as row}
+				{#each ['qwertyuiop', 'asdfghjkl', 'zxcvbnm'] as row (row)}
 					<div class="row">
-						{#each row as letter}
+						{#each row as letter, index (index)}
 							<button
 								onclick={update}
 								data-key={letter}


### PR DESCRIPTION
In this case, specifying a key doesn’t make much practical difference, but I added it because having ESLint errors right after creating the project looks bad.