### PR TITLE
chore: remove `"library"` keyword

### DIFF
--- a/packages/create/templates/library/package.template.json
+++ b/packages/create/templates/library/package.template.json
@@ -32,5 +32,5 @@
 		"typescript": "^5.3.2",
 		"vite": "^6.0.0"
 	},
-	"keywords": ["svelte", "library"]
+	"keywords": ["svelte"]
 }


### PR DESCRIPTION
As mentioned in https://github.com/sveltejs/cli/pull/473#issuecomment-2708430630, I'm not sure we really need `"library"` as a keyword since almost everything published to npm could have that as a keyword

I didn't add a changeset for this one since the original PR hasn't been released yet and the changelog entry there says "chore: add keywords to library template" which seems fitting enough even if we merge this