### PR TITLE
docs: lowercase npm and pnpm

### DIFF
--- a/community-addon-template/README.md
+++ b/community-addon-template/README.md
@@ -37,7 +37,7 @@ npm start
 
 ## Sharing your add-on
 
-When you're ready to publish your add-on to NPM, run:
+When you're ready to publish your add-on to npm, run:
 
 ```shell
 npm publish

--- a/documentation/docs/10-introduction/20-faq.md
+++ b/documentation/docs/10-introduction/20-faq.md
@@ -6,11 +6,11 @@ title: Frequently asked questions
 
 Running the `sv` cli differs for each package manager. Here is a list of the most common commands:
 
-- **NPM** : `npx sv create`
-- **PNPM** : `pnpx sv create` or `pnpm dlx sv create`
-- **Yarn** : `yarn dlx sv create`
+- **npm** : `npx sv create`
+- **pnpm** : `pnpx sv create` or `pnpm dlx sv create`
 - **Bun** : `bunx sv create`
 - **Deno** : `deno run npm:sv create`
+- **Yarn** : `yarn dlx sv create`
 
 ## `npx sv` is not working
 

--- a/documentation/docs/10-introduction/20-faq.md
+++ b/documentation/docs/10-introduction/20-faq.md
@@ -14,7 +14,7 @@ Running the `sv` cli differs for each package manager. Here is a list of the mos
 
 ## `npx sv` is not working
 
-Some package mangers prefer to run locally installed tools instead of downloading and executing packages from the registry. This issue mostly occurs with `npm` and `yarn`. This usually results in an error message or looks like the command you were trying to execute did not do anything.
+Some package managers prefer to run locally installed tools instead of downloading and executing packages from the registry. This issue mostly occurs with `npm` and `yarn`. This usually results in an error message or looks like the command you were trying to execute did not do anything.
 
 Here is a list of issues with possible solutions that users have encountered in the past:
 

--- a/documentation/docs/10-introduction/20-faq.md
+++ b/documentation/docs/10-introduction/20-faq.md
@@ -4,7 +4,7 @@ title: Frequently asked questions
 
 ## How do I run the `sv` CLI?
 
-Running the `sv` cli differs for each package manager. Here is a list of the most common commands:
+Running `sv` looks slightly different for each package manager. Here is a list of the most common commands:
 
 - **npm** : `npx sv create`
 - **pnpm** : `pnpx sv create` or `pnpm dlx sv create`

--- a/packages/cli/commands/add/fetch-packages.ts
+++ b/packages/cli/commands/add/fetch-packages.ts
@@ -110,7 +110,7 @@ export async function getPackageJSON({ cwd, packageName }: GetPackageJSONOptions
 
 	return {
 		pkg,
-		// fallback to providing the NPM package URL
+		// fallback to providing the npm package URL
 		repo: pkg.repository?.url ?? `https://www.npmjs.com/package/${npm}`
 	};
 }


### PR DESCRIPTION
'npm' should never be capitalized; the same goes for pnpm. (I also moved Yarn to the bottom of the list, reflecting its priority)