### PR TITLE
feat: added `app-state` migration into `svelte-5` migration

### DIFF
--- a/.changeset/strange-islands-float.md
+++ b/.changeset/strange-islands-float.md
@@ -1,0 +1,5 @@
+---
+"svelte-migrate": minor
+---
+
+feat: added `app-state` migration into `svelte-5` migration

--- a/packages/migrate/migrations/svelte-5/index.js
+++ b/packages/migrate/migrations/svelte-5/index.js
@@ -17,7 +17,7 @@ import {
 } from '../../utils.js';
 import { migrate as migrate_svelte_4 } from '../svelte-4/index.js';
 import { migrate as migrate_sveltekit_2 } from '../sveltekit-2/index.js';
-import { migrate as migrate_app_state } from '../app-state/index.js';
+import { transform_svelte_code as transform_app_state_code } from '../app-state/migrate.js';
 import { transform_module_code, transform_svelte_code, update_pkg_json } from './migrate.js';
 
 export async function migrate() {
@@ -197,33 +197,21 @@ export async function migrate() {
 		if (extensions.some((ext) => file.endsWith(ext))) {
 			if (svelte_extensions.some((ext) => file.endsWith(ext))) {
 				if (do_migration) {
+					if (kit_dep) {
+						update_svelte_file(
+							file,
+							(code) => code,
+							(code) => transform_app_state_code(code)
+						);
+					}
 					update_svelte_file(file, transform_module_code, (code) =>
 						transform_svelte_code(code, migrate, { filename: file, use_ts })
 					);
+					
 				}
 			} else {
 				update_js_file(file, transform_module_code);
 			}
-		}
-	}
-
-	if (kit_dep) {
-		try {
-			p.log.info(pc.bold(pc.blue('Running app-state migration for SvelteKit compatibility...')));
-			await migrate_app_state();
-			p.log.success(
-				pc.bold(
-					pc.green(
-						'app-state migration complete. $app/store imports have been updated to $app/state.'
-					)
-				)
-			);
-		} catch (e) {
-			console.log(e);
-			p.log.error(
-				pc.bold(
-					pc.red(
-						'❌ Error during app-state migration.')));
 		}
 	}
 

--- a/packages/migrate/migrations/svelte-5/index.js
+++ b/packages/migrate/migrations/svelte-5/index.js
@@ -17,6 +17,7 @@ import {
 } from '../../utils.js';
 import { migrate as migrate_svelte_4 } from '../svelte-4/index.js';
 import { migrate as migrate_sveltekit_2 } from '../sveltekit-2/index.js';
+import { migrate as migrate_app_state } from '../app-state/index.js';
 import { transform_module_code, transform_svelte_code, update_pkg_json } from './migrate.js';
 
 export async function migrate() {
@@ -203,6 +204,26 @@ export async function migrate() {
 			} else {
 				update_js_file(file, transform_module_code);
 			}
+		}
+	}
+
+	if (kit_dep) {
+		try {
+			p.log.info(pc.bold(pc.blue('Running app-state migration for SvelteKit compatibility...')));
+			await migrate_app_state();
+			p.log.success(
+				pc.bold(
+					pc.green(
+						'app-state migration complete. $app/store imports have been updated to $app/state.'
+					)
+				)
+			);
+		} catch (e) {
+			console.log(e);
+			p.log.error(
+				pc.bold(
+					pc.red(
+						'❌ Error during app-state migration.')));
 		}
 	}
 

--- a/packages/migrate/migrations/svelte-5/index.js
+++ b/packages/migrate/migrations/svelte-5/index.js
@@ -207,7 +207,6 @@ export async function migrate() {
 					update_svelte_file(file, transform_module_code, (code) =>
 						transform_svelte_code(code, migrate, { filename: file, use_ts })
 					);
-					
 				}
 			} else {
 				update_js_file(file, transform_module_code);


### PR DESCRIPTION
Fixes #485 

This is the simplest approach I could think of--I know it can get a little hairy with all the versions of Svelte and SvelteKit out there. Still, I believe most of the logic is already in place with the CLI to make sure the user has the right versioning heading into the migration.

This only runs the app-state migration script if the user has SvelteKit. It doesn't really log anything or add any error handling--I'll leave those up to you if desired.

Also, I know you guys have a contributing guide on the docket, but I was wondering how exactly you test this CLI on your own projects. I ask because I ended up using `npm link` which is pretty standard, but I had to edit [these lines of code](https://github.com/sveltejs/cli/blob/d1f4432c0e31677ae754d50394547eeff820ddfe/packages/cli/commands/migrate.ts#L28C3-L34C79) to make sure that when I tested my fixes locally that it linked to my scripts instead of pulling `@latest` from `npx` 🙏 