### PR TITLE
chore: replace `create-svelte` in library template readme

### DIFF
--- a/.changeset/stupid-geckos-deliver.md
+++ b/.changeset/stupid-geckos-deliver.md
@@ -1,5 +1,5 @@
 ---
-"@sveltejs/create": patch
+"sv": patch
 ---
 
 chore: replace `create-svelte` in library template readme

--- a/.changeset/stupid-geckos-deliver.md
+++ b/.changeset/stupid-geckos-deliver.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/create": patch
+---
+
+chore: replace `create-svelte` in library template readme

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,4 @@ temp/
 package-lock.json
 yarn.lock
 vite.config.js.timestamp-*
-/packages/create-svelte/template/CHANGELOG.md
 .test-output

--- a/packages/create/shared/+library/README.md
+++ b/packages/create/shared/+library/README.md
@@ -1,6 +1,6 @@
-# create-svelte
+# Svelte library
 
-Everything you need to build a Svelte library, powered by [`create-svelte`](https://github.com/sveltejs/kit/tree/main/packages/create-svelte).
+Everything you need to build a Svelte library, powered by [`sv`](https://npmjs.com/package/sv).
 
 Read more about creating a library [in the docs](https://svelte.dev/docs/kit/packaging).
 


### PR DESCRIPTION
closes https://github.com/sveltejs/cli/issues/498