### PR TITLE
fix: package manager detection in non interactive environments

### DIFF
--- a/.changeset/tall-moons-marry.md
+++ b/.changeset/tall-moons-marry.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix: package manager detection in non interactive environments

--- a/packages/cli/utils/package-manager.ts
+++ b/packages/cli/utils/package-manager.ts
@@ -22,6 +22,10 @@ export async function packageManagerPrompt(cwd: string): Promise<AgentName | und
 	const detected = await detect({ cwd });
 	const agent = detected?.name ?? getUserAgent();
 
+	// If we are in a non interactive environment just go with the detected package manager.
+	// There is no need to prompt in that case.
+	if (!process.stdout.isTTY) return agent;
+
 	const pm = await p.select({
 		message: 'Which package manager do you want to install dependencies with?',
 		options: agentOptions,


### PR DESCRIPTION
Closes #502 
`p.select(` was actually throwing, which caused the formatting relevant source code to be skipped.

@hyunbinseo Could you please check if this works for you? `pkg-pr-new` url will be posted in a second.