### PR TITLE
fix(prettier): always use JSON config

### DIFF
--- a/packages/addons/prettier/index.ts
+++ b/packages/addons/prettier/index.ts
@@ -23,7 +23,7 @@ export default defineAddon({
 			`;
 		});
 
-		sv.file('.prettierrc', (content) => {
+		sv.file('.prettierrc.json', (content) => {
 			const { data, generateCode } = parseJson(content);
 			if (Object.keys(data).length === 0) {
 				// we'll only set these defaults if there is no pre-existing config

--- a/packages/addons/tailwindcss/index.ts
+++ b/packages/addons/tailwindcss/index.ts
@@ -132,7 +132,7 @@ export default defineAddon({
 		}
 
 		if (dependencyVersion('prettier')) {
-			sv.file('.prettierrc', (content) => {
+			sv.file('.prettierrc.json', (content) => {
 				const { data, generateCode } = parseJson(content);
 				const PLUGIN_NAME = 'prettier-plugin-tailwindcss';
 


### PR DESCRIPTION
If the project already has a `.prettierrc` which is YAML, we will currently throw an uncaught exception trying to parse it as JSON.

This switches to always using `.prettierrc.json`, so we can safely assume it should be valid JSON if it exists.

Alternatively, we could try/catch the parsing and overwrite if it fails. Or, more expensive, try JSON and then try YAML...