### PR TITLE
fix(prettier): skip non-JSON prettierrc config

### DIFF
--- a/.changeset/pretty-emus-breathe.md
+++ b/.changeset/pretty-emus-breathe.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix: warn on an unparsable `.prettierrc` config file

--- a/packages/addons/prettier/index.ts
+++ b/packages/addons/prettier/index.ts
@@ -29,7 +29,7 @@ export default defineAddon({
 				({ data, generateCode } = parseJson(content));
 			} catch {
 				log.warn(
-					'A `.prettierrc` config already exists and cannot be parsed. Skipping initialization.'
+					'A `.prettierrc` config already exists and cannot be parsed as JSON. Skipping initialization.'
 				);
 				return content;
 			}

--- a/packages/addons/prettier/index.ts
+++ b/packages/addons/prettier/index.ts
@@ -24,7 +24,15 @@ export default defineAddon({
 		});
 
 		sv.file('.prettierrc', (content) => {
-			const { data, generateCode } = parseJson(content);
+			let data, generateCode;
+			try {
+				({ data, generateCode } = parseJson(content));
+			} catch {
+				log.warn(
+					'A `.prettierrc` config already exists and cannot be parsed. Skipping initialization.'
+				);
+				return content;
+			}
 			if (Object.keys(data).length === 0) {
 				// we'll only set these defaults if there is no pre-existing config
 				data.useTabs = true;

--- a/packages/addons/prettier/index.ts
+++ b/packages/addons/prettier/index.ts
@@ -29,7 +29,7 @@ export default defineAddon({
 				({ data, generateCode } = parseJson(content));
 			} catch {
 				log.warn(
-					'A `.prettierrc` config already exists and cannot be parsed as JSON. Skipping initialization.'
+					`A ${colors.yellow('.prettierrc')} config already exists and cannot be parsed as JSON. Skipping initialization.`
 				);
 				return content;
 			}


### PR DESCRIPTION
If the project already has a `.prettierrc` which is YAML, we will currently throw an uncaught exception trying to parse it as JSON.

This change means we will skip such files and only try to mutate JSON configs.