### PR TITLE
fix: mysql2 closed state (drizzle addon)

### DIFF
--- a/.changeset/poor-ducks-own.md
+++ b/.changeset/poor-ducks-own.md
@@ -2,4 +2,4 @@
 'sv': patch
 ---
 
-fix: mysql2 closed state (drizzle addon)
+fix: use connection pool when using mysql2 with Drizzle

--- a/.changeset/poor-ducks-own.md
+++ b/.changeset/poor-ducks-own.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix: mysql2 closed state (drizzle addon)

--- a/.changeset/poor-ducks-own.md
+++ b/.changeset/poor-ducks-own.md
@@ -2,4 +2,4 @@
 'sv': patch
 ---
 
-fix: use connection pool when using mysql2 with Drizzle
+fix: use connection pool when using mysql2 with `drizzle`

--- a/packages/addons/drizzle/index.ts
+++ b/packages/addons/drizzle/index.ts
@@ -309,9 +309,7 @@ export default defineAddon({
 				imports.addDefault(ast, 'mysql2/promise', 'mysql');
 				imports.addNamed(ast, 'drizzle-orm/mysql2', { drizzle: 'drizzle' });
 
-				clientExpression = common.expressionFromString(
-					'await mysql.createConnection(env.DATABASE_URL)'
-				);
+				clientExpression = common.expressionFromString('mysql.createPool(env.DATABASE_URL)');
 			}
 			// PostgreSQL
 			if (options.postgresql === 'neon') {


### PR DESCRIPTION
Changed `await mysql.createConnection()` to `mysql.createPool()`

--

When using `mysql.createConnection()`, the connection will end up getting closed if it's not used for longer than [wait_timeout](https://dev.mysql.com/doc/refman/8.4/en/server-system-variables.html#sysvar_wait_timeout). Error message from mysql2 after a period of inactivity can be seen below:

```
Error: Can't add new command when connection is in closed state
```

Since drizzle doesn't handle any of the connection, you would need to juggle the database client and drizzle around before querying to make sure the connection to the database wasn't closed.

I haven't experienced this with postgres.js, as it's seemingly using [pools by default](https://github.com/porsager/postgres?tab=readme-ov-file#the-connection-pool).

If not using pools with mysql2 is intentional, please let me know, thanks.