### PR TITLE
fix: add `@types/node` to `drizzle` and `storybook` add-ons

### DIFF
--- a/.changeset/odd-bikes-like.md
+++ b/.changeset/odd-bikes-like.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix: add `@types/node` as a dev dependency to the `drizzle` and `storybook` add-ons

--- a/packages/addons/common.ts
+++ b/packages/addons/common.ts
@@ -1,5 +1,6 @@
 import { imports, exports, common } from '@sveltejs/cli-core/js';
 import { parseScript, parseSvelte } from '@sveltejs/cli-core/parsers';
+import process from 'node:process';
 
 export function addEslintConfigPrettier(content: string): string {
 	const { ast, generateCode } = parseScript(content);
@@ -74,4 +75,23 @@ export function addToDemoPage(content: string, path: string): string {
 	const newLine = template.source ? '\n' : '';
 	const src = template.source + `${newLine}<a href="/demo/${path}">${path}</a>`;
 	return generateCode({ template: src });
+}
+
+/**
+ * Returns the corresponding `@types/node` version for the version of Node.js running in the current process.
+ *
+ * If the installed version of Node.js is from a `Current` release, then the major is decremented to
+ * the nearest `LTS` release version.
+ */
+export function getNodeTypesVersion(): string {
+	const nodeVersion = process.versions.node;
+	const [major] = nodeVersion.split('.');
+
+	const isLTS = Number(major) % 2 === 0;
+	if (isLTS) {
+		return `^${nodeVersion}`;
+	}
+
+	const previousLTSMajor = Number(major) - 1;
+	return `^${previousLTSMajor}`;
 }

--- a/packages/addons/common.ts
+++ b/packages/addons/common.ts
@@ -89,7 +89,7 @@ export function getNodeTypesVersion(): string {
 
 	const isLTS = Number(major) % 2 === 0;
 	if (isLTS) {
-		return `^${nodeVersion}`;
+		return `^${major}`;
 	}
 
 	const previousLTSMajor = Number(major) - 1;

--- a/packages/addons/drizzle/index.ts
+++ b/packages/addons/drizzle/index.ts
@@ -1,6 +1,7 @@
 import { common, exports, functions, imports, object, variables } from '@sveltejs/cli-core/js';
 import { defineAddon, defineAddonOptions, dedent, type OptionValues } from '@sveltejs/cli-core';
 import { parseJson, parseScript } from '@sveltejs/cli-core/parsers';
+import { getNodeTypesVersion } from '../common.ts';
 
 const PORTS = {
 	mysql: '3306',
@@ -76,6 +77,7 @@ export default defineAddon({
 
 		sv.dependency('drizzle-orm', '^0.40.0');
 		sv.devDependency('drizzle-kit', '^0.30.2');
+		sv.devDependency('@types/node', getNodeTypesVersion());
 
 		// MySQL
 		if (options.mysql === 'mysql2') sv.dependency('mysql2', '^3.12.0');

--- a/packages/addons/storybook/index.ts
+++ b/packages/addons/storybook/index.ts
@@ -1,4 +1,5 @@
 import { defineAddon } from '@sveltejs/cli-core';
+import { getNodeTypesVersion } from '../common.ts';
 
 export default defineAddon({
 	id: 'storybook',
@@ -7,5 +8,6 @@ export default defineAddon({
 	options: {},
 	run: async ({ sv }) => {
 		await sv.execute(['storybook@latest', 'init', '--skip-install', '--no-dev'], 'inherit');
+		sv.devDependency(`@types/node`, getNodeTypesVersion());
 	}
 });


### PR DESCRIPTION
closes #509

This is an alternative to #536 and #539 where `@types/node` is added to `devDependencies` by the `drizzle` and `storybook` add-ons. 

The version of `@types/node` is derived from the version of node from the current running process. Since `@types/node` only publishes types for `lts` versions of node, we'll need to install the nearest `lts` version for `current` releases. To do this, we'll just decrement the major number by one (and chop off the minor and patch numbers) to target the previous `lts` release version (note that we can detect whether a release is `lts` or `current` based on the if the major is an even or odd number, respectively)

For example: if the installed node version is `22.14.0` (`lts`), then `^22` will be added to the `package.json`. If the node version is `23.11.0` (`current`), then `^22` will be added instead. 
