### PR TITLE
chore: use the latest adapter-auto

### DIFF
--- a/.changeset/late-rockets-argue.md
+++ b/.changeset/late-rockets-argue.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+chore: use the latest adapter-auto

--- a/.changeset/late-rockets-argue.md
+++ b/.changeset/late-rockets-argue.md
@@ -2,4 +2,4 @@
 'sv': patch
 ---
 
-chore: use the latest adapter-auto
+chore: update `adapter-auto`

--- a/packages/create/templates/demo/package.template.json
+++ b/packages/create/templates/demo/package.template.json
@@ -12,7 +12,7 @@
 	"devDependencies": {
 		"@fontsource/fira-mono": "^5.0.0",
 		"@neoconfetti/svelte": "^2.0.0",
-		"@sveltejs/adapter-auto": "^4.0.0",
+		"@sveltejs/adapter-auto": "^6.0.0",
 		"@sveltejs/kit": "^2.16.0",
 		"@sveltejs/vite-plugin-svelte": "^5.0.0",
 		"svelte": "^5.25.0",

--- a/packages/create/templates/library/package.template.json
+++ b/packages/create/templates/library/package.template.json
@@ -23,7 +23,7 @@
 		"svelte": "^5.0.0"
 	},
 	"devDependencies": {
-		"@sveltejs/adapter-auto": "^4.0.0",
+		"@sveltejs/adapter-auto": "^6.0.0",
 		"@sveltejs/kit": "^2.16.0",
 		"@sveltejs/package": "^2.0.0",
 		"@sveltejs/vite-plugin-svelte": "^5.0.0",

--- a/packages/create/templates/minimal/package.template.json
+++ b/packages/create/templates/minimal/package.template.json
@@ -10,7 +10,7 @@
 		"prepare": "svelte-kit sync || echo ''"
 	},
 	"devDependencies": {
-		"@sveltejs/adapter-auto": "^4.0.0",
+		"@sveltejs/adapter-auto": "^6.0.0",
 		"@sveltejs/kit": "^2.16.0",
 		"@sveltejs/vite-plugin-svelte": "^5.0.0",
 		"svelte": "^5.0.0",


### PR DESCRIPTION
Despite https://github.com/sveltejs/cli/pull/520, an outdated `adapter-auto` is added:

```json
{
  "devDependencies": {
    "@sveltejs/adapter-auto": "^4.0.0",
```

```
┌  Welcome to the Svelte CLI! (v0.8.1)
│
◇  Which template would you like?
│  SvelteKit minimal
│
◇  Add type checking with TypeScript?
│  Yes, using TypeScript syntax
│
◆  Project created
│
◇  What would you like to add to your project? (use arrow keys / space bar)
│  none
```

Probably because the adapter is not installed as an add-on?