### PR TITLE
fix: rename cloudflare-pages to cloudflare

### DIFF
--- a/.changeset/honest-eels-fly.md
+++ b/.changeset/honest-eels-fly.md
@@ -1,5 +1,5 @@
 ---
-"@sveltejs/addons": patch
+"sv": patch
 ---
 
 fix: rename Cloudflare adapter option from cloudflare-pages to cloudflare

--- a/.changeset/honest-eels-fly.md
+++ b/.changeset/honest-eels-fly.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/addons": patch
+---
+
+fix: rename Cloudflare adapter option from cloudflare-pages to cloudflare

--- a/.changeset/honest-eels-fly.md
+++ b/.changeset/honest-eels-fly.md
@@ -2,4 +2,4 @@
 "sv": patch
 ---
 
-fix: rename Cloudflare adapter option from cloudflare-pages to cloudflare
+fix: rename Cloudflare adapter option from `cloudflare-pages` to `cloudflare`

--- a/packages/addons/sveltekit-adapter/index.ts
+++ b/packages/addons/sveltekit-adapter/index.ts
@@ -13,7 +13,7 @@ const adapters: Adapter[] = [
 	{ id: 'node', package: '@sveltejs/adapter-node', version: '^5.2.12' },
 	{ id: 'static', package: '@sveltejs/adapter-static', version: '^3.0.8' },
 	{ id: 'vercel', package: '@sveltejs/adapter-vercel', version: '^5.6.3' },
-	{ id: 'cloudflare-pages', package: '@sveltejs/adapter-cloudflare', version: '^7.0.0' },
+	{ id: 'cloudflare', package: '@sveltejs/adapter-cloudflare', version: '^7.0.0' },
 	{ id: 'netlify', package: '@sveltejs/adapter-netlify', version: '^5.0.0' }
 ];
 


### PR DESCRIPTION
The Cloudflare adapter is no longer Cloudflare Pages-specific. It currently supports Cloudflare Workers Static Assets too

https://svelte.dev/docs/kit/adapter-cloudflare