### PR TITLE
fix: Always add Storybook last

### DIFF
--- a/.changeset/slimy-rivers-think.md
+++ b/.changeset/slimy-rivers-think.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+Always add Storybook after all other addons

--- a/packages/cli/lib/install.ts
+++ b/packages/cli/lib/install.ts
@@ -185,6 +185,11 @@ async function runAddon({ addon, multiple, workspace }: RunAddon) {
 // but works for now in contrary to the previouse implementation
 function orderAddons(addons: Array<Addon<any>>, setupResults: Record<string, AddonSetupResult>) {
 	return addons.sort(
-		(a, b) => setupResults[a.id]?.dependsOn?.length - setupResults[b.id]?.dependsOn?.length
+		(a, b) => {
+			// Adding storybook last means it will correctly detect and integrate with other addons like vitest and eslint
+			if (a.id === 'storybook') return 1;
+			if (b.id === 'storybook') return -1;
+			return setupResults[a.id]?.dependsOn?.length - setupResults[b.id]?.dependsOn?.length;
+		}
 	);
 }


### PR DESCRIPTION
Ensure that if Storybook is selected during creation, it is always added after the other addon.

See _Side note_ in https://github.com/sveltejs/cli/issues/497#issuecomment-2823449201 for context