### PR TITLE
feat: expose `runsAfter` to add-ons

### DIFF
--- a/.changeset/loose-colts-sin.md
+++ b/.changeset/loose-colts-sin.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+feat: expose `runsAfter` to add-ons

--- a/packages/addons/storybook/index.ts
+++ b/packages/addons/storybook/index.ts
@@ -6,6 +6,10 @@ export default defineAddon({
 	shortDescription: 'frontend workshop',
 	homepage: 'https://storybook.js.org',
 	options: {},
+	setup: ({ runsAfter }) => {
+		runsAfter('vitest');
+		runsAfter('eslint');
+	},
 	run: async ({ sv }) => {
 		await sv.execute(['storybook@latest', 'init', '--skip-install', '--no-dev'], 'inherit');
 		sv.devDependency(`@types/node`, getNodeTypesVersion());

--- a/packages/cli/lib/install.ts
+++ b/packages/cli/lib/install.ts
@@ -87,11 +87,15 @@ export function setupAddons(
 	const addonSetupResults: Record<string, AddonSetupResult> = {};
 
 	for (const addon of addons) {
-		const setupResult: AddonSetupResult = { unsupported: [], dependsOn: [] };
+		const setupResult: AddonSetupResult = { unsupported: [], dependsOn: [], runsAfter: [] };
 		addon.setup?.({
 			...workspace,
-			dependsOn: (name) => setupResult.dependsOn.push(name),
-			unsupported: (reason) => setupResult.unsupported.push(reason)
+			dependsOn: (name) => {
+				setupResult.dependsOn.push(name);
+				setupResult.runsAfter.push(name);
+			},
+			unsupported: (reason) => setupResult.unsupported.push(reason),
+			runsAfter: (name) => setupResult.runsAfter.push(name)
 		});
 		addonSetupResults[addon.id] = setupResult;
 	}
@@ -181,13 +185,10 @@ async function runAddon({ addon, multiple, workspace }: RunAddon) {
 }
 
 // orders addons by putting addons that don't require any other addon in the front.
-// This is a drastic simplification, as this could still cause some inconvenient cituations,
+// This is a drastic simplification, as this could still cause some inconvenient circumstances,
 // but works for now in contrary to the previous implementation
 function orderAddons(addons: Array<Addon<any>>, setupResults: Record<string, AddonSetupResult>) {
 	return addons.sort((a, b) => {
-		// Adding storybook last means it will correctly detect and integrate with other addons like vitest and eslint
-		if (a.id === 'storybook') return 1;
-		if (b.id === 'storybook') return -1;
-		return setupResults[a.id]?.dependsOn?.length - setupResults[b.id]?.dependsOn?.length;
+		return setupResults[a.id]?.runsAfter?.length - setupResults[b.id]?.runsAfter?.length;
 	});
 }

--- a/packages/core/addon/config.ts
+++ b/packages/core/addon/config.ts
@@ -37,6 +37,7 @@ export type Addon<Args extends OptionDefinition> = {
 		workspace: Workspace<Args> & {
 			dependsOn: (name: string) => void;
 			unsupported: (reason: string) => void;
+			runsAfter: (addonName: string) => void;
 		}
 	) => MaybePromise<void>;
 	run: (workspace: Workspace<Args> & { sv: SvApi }) => MaybePromise<void>;
@@ -59,7 +60,7 @@ export function defineAddon<Args extends OptionDefinition>(config: Addon<Args>):
 	return config;
 }
 
-export type AddonSetupResult = { dependsOn: string[]; unsupported: string[] };
+export type AddonSetupResult = { dependsOn: string[]; unsupported: string[]; runsAfter: string[] };
 
 export type AddonWithoutExplicitArgs = Addon<Record<string, Question>>;
 export type AddonConfigWithoutExplicitArgs = Addon<Record<string, Question>>;


### PR DESCRIPTION
Supersedes #547 
Closes #550 

As described in the issue, we now have an add-on that needs to run after some other add-ons. This feature was previously removed as part of #86 since it was not used anymore.

In contrary to the original implementation in #86, if an add-on calls `dependsOn`, `runsAfter` is also called in order to only have one property based on which the ordering of the add-ons should occur.