### PR TITLE
chore: remove unused drizzle driver code

### DIFF
--- a/packages/addons/drizzle/index.ts
+++ b/packages/addons/drizzle/index.ts
@@ -210,10 +210,6 @@ export default defineAddon({
 				dialect: common.createLiteral(dialect)
 			});
 
-			// The `driver` property is only required for _some_ sqlite DBs.
-			// We'll need to remove it if it's anything but sqlite
-			if (options.database !== 'sqlite') object.removeProperty(objExpression, 'driver');
-
 			return generateCode();
 		});
 


### PR DESCRIPTION
I'm not sure that this line does anything. It looks like at some point there was a `driver` property defined for the non-sqlite DBs, but I don't see anything setting it, so don't know that this line is needed anymore