### PR TITLE
chore: leverage expressionFromString more in drizzle adder

### DIFF
--- a/packages/addons/_tests/drizzle/test.ts
+++ b/packages/addons/_tests/drizzle/test.ts
@@ -43,7 +43,7 @@ test.concurrent.for(testCases)(
 
 		const ts = variant === 'kit-ts';
 		const drizzleConfig = path.resolve(cwd, `drizzle.config.${ts ? 'ts' : 'js'}`);
-		const content = fs.readFileSync(drizzleConfig, 'utf8').replace('strict: true,', '');
+		const content = fs.readFileSync(drizzleConfig, 'utf8').replace(/strict: true[,\s]/, '');
 		fs.writeFileSync(drizzleConfig, content, 'utf8');
 
 		const routes = path.resolve(cwd, 'src', 'routes');

--- a/packages/addons/drizzle/index.ts
+++ b/packages/addons/drizzle/index.ts
@@ -189,12 +189,12 @@ export default defineAddon({
 				ast,
 				common.expressionFromString(`
 					defineConfig({
-						schema: "./src/lib/server/db/schema.${typescript ? 'ts' : 'js'}".
+						schema: "./src/lib/server/db/schema.${typescript ? 'ts' : 'js'}",
 						dialect: ${options.sqlite === 'turso' ? 'turso' : options.database}
 						dbCredentials: {
 							url: process.env.DATABASE_URL,
 							${options.sqlite === 'turso' ? 'authToken: process.env.DATABASE_AUTH_TOKEN' : undefined}
-						}
+						},
 						verbose: true,
 						strict: true
 					})`)

--- a/packages/addons/drizzle/index.ts
+++ b/packages/addons/drizzle/index.ts
@@ -190,7 +190,7 @@ export default defineAddon({
 				common.expressionFromString(`
 					defineConfig({
 						schema: "./src/lib/server/db/schema.${typescript ? 'ts' : 'js'}",
-						dialect: ${options.sqlite === 'turso' ? 'turso' : options.database},
+						dialect: "${options.sqlite === 'turso' ? 'turso' : options.database}",
 						dbCredentials: {
 							url: process.env.DATABASE_URL,
 							${options.sqlite === 'turso' ? 'authToken: process.env.DATABASE_AUTH_TOKEN' : undefined}

--- a/packages/addons/drizzle/index.ts
+++ b/packages/addons/drizzle/index.ts
@@ -190,7 +190,7 @@ export default defineAddon({
 				common.expressionFromString(`
 					defineConfig({
 						schema: "./src/lib/server/db/schema.${typescript ? 'ts' : 'js'}",
-						dialect: ${options.sqlite === 'turso' ? 'turso' : options.database}
+						dialect: ${options.sqlite === 'turso' ? 'turso' : options.database},
 						dbCredentials: {
 							url: process.env.DATABASE_URL,
 							${options.sqlite === 'turso' ? 'authToken: process.env.DATABASE_AUTH_TOKEN' : undefined}

--- a/packages/addons/drizzle/index.ts
+++ b/packages/addons/drizzle/index.ts
@@ -193,7 +193,7 @@ export default defineAddon({
 						dialect: "${options.sqlite === 'turso' ? 'turso' : options.database}",
 						dbCredentials: {
 							url: process.env.DATABASE_URL,
-							${options.sqlite === 'turso' ? 'authToken: process.env.DATABASE_AUTH_TOKEN' : undefined}
+							${options.sqlite === 'turso' ? 'authToken: process.env.DATABASE_AUTH_TOKEN' : ''}
 						},
 						verbose: true,
 						strict: true

--- a/packages/addons/drizzle/index.ts
+++ b/packages/addons/drizzle/index.ts
@@ -192,8 +192,8 @@ export default defineAddon({
 						schema: "./src/lib/server/db/schema.${typescript ? 'ts' : 'js'}",
 						dialect: "${options.sqlite === 'turso' ? 'turso' : options.database}",
 						dbCredentials: {
-							url: process.env.DATABASE_URL,
-							${options.sqlite === 'turso' ? 'authToken: process.env.DATABASE_AUTH_TOKEN' : ''}
+							${options.sqlite === 'turso' ? 'authToken: process.env.DATABASE_AUTH_TOKEN,' : ''}
+							url: process.env.DATABASE_URL
 						},
 						verbose: true,
 						strict: true

--- a/packages/core/tests/js/common/expression-from-string/output.ts
+++ b/packages/core/tests/js/common/expression-from-string/output.ts
@@ -1,0 +1,1 @@
+export default defineConfig({ path: 'some/string/as/path.js', valid: true });

--- a/packages/core/tests/js/common/expression-from-string/run.ts
+++ b/packages/core/tests/js/common/expression-from-string/run.ts
@@ -1,0 +1,13 @@
+import { common, exports, type AstTypes } from '@sveltejs/cli-core/js';
+
+export function run(ast: AstTypes.Program): void {
+	exports.defaultExport(
+		ast,
+		common.expressionFromString(`
+			defineConfig({
+				path: "some/string/as/path.js",
+				valid: true
+			})
+		`)
+	);
+}

--- a/packages/core/tests/js/index.ts
+++ b/packages/core/tests/js/index.ts
@@ -7,10 +7,6 @@ import { parseScript, serializeScript } from '../../tooling/index.ts';
 const baseDir = resolve(fileURLToPath(import.meta.url), '..');
 const categoryDirectories = getDirectoryNames(baseDir);
 
-const prettierConfig = await prettier.resolveConfig(import.meta.url);
-if (!prettierConfig) throw new Error('Failed to resolve prettier config');
-prettierConfig.filepath = 'output.ts';
-
 for (const categoryDirectory of categoryDirectories) {
 	describe(categoryDirectory, () => {
 		const testNames = getDirectoryNames(join(baseDir, categoryDirectory));

--- a/packages/core/tests/js/index.ts
+++ b/packages/core/tests/js/index.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import prettier from 'prettier';
 import { describe, expect, test } from 'vitest';
 import { parseScript, serializeScript } from '../../tooling/index.ts';
 
@@ -27,9 +26,9 @@ for (const categoryDirectory of categoryDirectories) {
 				const module = await import(`./${categoryDirectory}/${testName}/run.ts`);
 				module.run(ast);
 
-				const output = serializeScript(ast, input);
-				const formattedOutput = await prettier.format(output, prettierConfig);
-				await expect(formattedOutput).toMatchFileSnapshot(`${testDirectoryPath}/output.ts`);
+				let output = serializeScript(ast, input);
+				if (!output.endsWith('\n')) output += '\n';
+				await expect(output).toMatchFileSnapshot(`${testDirectoryPath}/output.ts`);
 			});
 		}
 	});

--- a/packages/core/tooling/js/common.ts
+++ b/packages/core/tooling/js/common.ts
@@ -115,6 +115,7 @@ export function addFromString(
 
 export function expressionFromString(value: string): AstTypes.Expression {
 	const program = parseScript(dedent(value));
+	stripAst(program, ['raw']);
 	const statement = program.body[0]!;
 	if (statement.type !== 'ExpressionStatement') {
 		throw new Error('value passed was not an expression');


### PR DESCRIPTION
A bit of the code here was unused. See https://github.com/sveltejs/cli/pull/555

~~I haven't gotten a chance to test this yet, but thought I'd share my progress before I have to run for the day. Manuel thought that we might need to tweak `expressionFromString` to delete the `Literal.raw property` so that it can pick the proper quote type. I've not checked that yet and assume we'll need to update it~~