### PR TITLE
fix: lucia require user redirect moved to auth guard function

### DIFF
--- a/.changeset/clever-chicken-compete.md
+++ b/.changeset/clever-chicken-compete.md
@@ -1,0 +1,5 @@
+---
+"sv": patch
+---
+
+fix: lucia require user redirect moved to auth guard function

--- a/packages/addons/lucia/index.ts
+++ b/packages/addons/lucia/index.ts
@@ -542,12 +542,11 @@ export default defineAddon({
 				return dedent`
 					import * as auth from '$lib/server/auth';
 					import { fail, redirect } from '@sveltejs/kit';
+					import { getRequestEvent } from '$app/server';
 					${ts("import type { Actions, PageServerLoad } from './$types';\n")}
-					export const load${ts(': PageServerLoad')} = async (event) => {
-						if (!event.locals.user) {
-							return redirect(302, '/demo/lucia/login');
-						}
-						return { user: event.locals.user };
+					export const load${ts(': PageServerLoad')} = async () => {
+						const user = requireLogin()
+						return { user };
 					};
 
 					export const actions${ts(': Actions')} = {
@@ -561,6 +560,16 @@ export default defineAddon({
 							return redirect(302, '/demo/lucia/login');
 						},
 					};
+
+					function requireLogin() {
+					  const { locals } = getRequestEvent();
+
+					  if (!locals.user) {
+					    return redirect(302, "/demo/lucia/login");
+					  }
+
+					  return locals.user;
+					}
 				`;
 			});
 


### PR DESCRIPTION
closes: #493 

Updated to use pattern similar to login utilities. This pattern matches the SvelteKit docs and allows people to see it in use straight away when adding the lucia addon. 
