### PR TITLE
fix: add `kit` check in `drizzle` add-on

### DIFF
--- a/.changeset/new-bats-dress.md
+++ b/.changeset/new-bats-dress.md
@@ -2,4 +2,4 @@
 'sv': patch
 ---
 
-fix: only execute the setups of selected add-ons
+fix: add null check for `kit` in the `drizzle` add-on's setup

--- a/.changeset/new-bats-dress.md
+++ b/.changeset/new-bats-dress.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix: only execute the setups of selected add-ons

--- a/packages/addons/drizzle/index.ts
+++ b/packages/addons/drizzle/index.ts
@@ -73,14 +73,17 @@ export default defineAddon({
 	options,
 	setup: ({ kit, unsupported, cwd, typescript }) => {
 		const ext = typescript ? 'ts' : 'js';
-		if (!kit) unsupported('Requires SvelteKit');
+		if (!kit) {
+			return unsupported('Requires SvelteKit');
+		}
 
-		const baseDBPath = path.resolve(kit!.libDirectory, 'server', 'db');
+		const baseDBPath = path.resolve(kit.libDirectory, 'server', 'db');
 		const paths = {
 			'drizzle config': path.relative(cwd, path.resolve(cwd, `drizzle.config.${ext}`)),
 			'database schema': path.relative(cwd, path.resolve(baseDBPath, `schema.${ext}`)),
 			database: path.relative(cwd, path.resolve(baseDBPath, `index.${ext}`))
 		};
+
 		for (const [fileType, filePath] of Object.entries(paths)) {
 			if (fs.existsSync(filePath)) {
 				unsupported(`Preexisting ${fileType} file at '${filePath}'`);

--- a/packages/cli/commands/add/index.ts
+++ b/packages/cli/commands/add/index.ts
@@ -387,7 +387,10 @@ export async function runAddCommand(
 
 	// prepare official addons
 	let workspace = await createWorkspace({ cwd: options.cwd });
-	const addonSetupResults = setupAddons(officialAddons, workspace);
+	const addonSetupResults = setupAddons(
+		selectedAddons.map((a) => a.addon),
+		workspace
+	);
 
 	// prompt which addons to apply
 	if (selectedAddons.length === 0) {

--- a/packages/cli/commands/add/index.ts
+++ b/packages/cli/commands/add/index.ts
@@ -387,10 +387,7 @@ export async function runAddCommand(
 
 	// prepare official addons
 	let workspace = await createWorkspace({ cwd: options.cwd });
-	const addonSetupResults = setupAddons(
-		selectedAddons.map((a) => a.addon),
-		workspace
-	);
+	const addonSetupResults = setupAddons(officialAddons, workspace);
 
 	// prompt which addons to apply
 	if (selectedAddons.length === 0) {

--- a/packages/cli/commands/add/index.ts
+++ b/packages/cli/commands/add/index.ts
@@ -387,7 +387,8 @@ export async function runAddCommand(
 
 	// prepare official addons
 	let workspace = await createWorkspace({ cwd: options.cwd });
-	const addonSetupResults = setupAddons(officialAddons, workspace);
+	const setups = selectedAddons.length ? selectedAddons.map(({ addon }) => addon) : officialAddons;
+	const addonSetupResults = setupAddons(setups, workspace);
 
 	// prompt which addons to apply
 	if (selectedAddons.length === 0) {


### PR DESCRIPTION
closes #573

since we iterate and execute all of the `setup` functions from every add-on (mainly to determine which add-ons to show in the add-on selection prompt, relative to the current environment), drizzle wasn't playing nice in non-sveltekit projects due to a non-null assertion (oops!).