### PR TITLE
fix(`vitest`): add `resolve.conditions` to `client` test config

### DIFF
--- a/.changeset/smart-adults-shop.md
+++ b/.changeset/smart-adults-shop.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix: add `resolve.conditions` to the `client` test config for the `vitest` add-on

--- a/packages/addons/vitest-addon/index.ts
+++ b/packages/addons/vitest-addon/index.ts
@@ -141,7 +141,7 @@ export default defineAddon({
 			const vitestConfig = functions.argumentByIndex(defineWorkspaceCall, 0, object.createEmpty());
 			const testObject = object.property(vitestConfig, 'test', object.createEmpty());
 
-			const workspaceArray = object.property(testObject, 'workspace', array.createEmpty());
+			const workspaceArray = object.property(testObject, 'projects', array.createEmpty());
 			array.push(workspaceArray, clientObjectExpression);
 			array.push(workspaceArray, serverObjectExpression);
 

--- a/packages/addons/vitest-addon/index.ts
+++ b/packages/addons/vitest-addon/index.ts
@@ -113,6 +113,7 @@ export default defineAddon({
 			const clientObjectExpression = object.create({
 				extends: common.createLiteral(`./vite.config.${ext}`),
 				plugins: common.expressionFromString('[svelteTesting()]'),
+				resolve: object.create({ conditions: common.expressionFromString("['browser']") }),
 				test: object.create({
 					name: common.createLiteral('client'),
 					environment: common.createLiteral('jsdom'),


### PR DESCRIPTION
closes #579

It looks like our default config broke in `vitest@3.2.0`. Adding `resolve.conditions` to the client test config seemingly fixes it (as mentioned in the related issue), though I'm unsure if it's the _right_ fix. 

cc @dominikg @manuel3108 

```diff
export default defineConfig({
	// ...
	test: {
		projects: [
			{
				extends: './vite.config.ts',
				plugins: [svelteTesting()],
+				resolve: { conditions: ['browser'] },
				test: {
					name: 'client',
					environment: 'jsdom',
					clearMocks: true,
					include: ['src/**/*.svelte.{test,spec}.{js,ts}'],
					exclude: ['src/lib/server/**'],
					setupFiles: ['./vitest-setup-client.ts']
				}
			},
			{
				extends: './vite.config.ts',
				test: {
					name: 'server',
					environment: 'node',
					include: ['src/**/*.{test,spec}.{js,ts}'],
					exclude: ['src/**/*.svelte.{test,spec}.{js,ts}']
				}
			}
		]
	}
});
```