### PR TITLE
fix: resolve-conditions-for-client

### DIFF
--- a/.changeset/breezy-clowns-brush.md
+++ b/.changeset/breezy-clowns-brush.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix:addon vitest remove the deprecated `workspace` property in favor of `projects`.

--- a/.changeset/seven-radios-run.md
+++ b/.changeset/seven-radios-run.md
@@ -1,0 +1,9 @@
+---
+'sv': patch
+---
+
+fix:addon vitest add resolve.condition.browser to the client
+It's fixing the error:
+```
+`mount(...)` is not available on the server
+```

--- a/packages/addons/vitest-addon/index.ts
+++ b/packages/addons/vitest-addon/index.ts
@@ -120,6 +120,9 @@ export default defineAddon({
 					include: common.expressionFromString("['src/**/*.svelte.{test,spec}.{js,ts}']"),
 					exclude: common.expressionFromString("['src/lib/server/**']"),
 					setupFiles: common.expressionFromString(`['./vitest-setup-client.${ext}']`)
+				}),
+				resolve: object.create({
+					conditions: common.expressionFromString('["browser"]')
 				})
 			});
 			const serverObjectExpression = object.create({
@@ -141,9 +144,9 @@ export default defineAddon({
 			const vitestConfig = functions.argumentByIndex(defineWorkspaceCall, 0, object.createEmpty());
 			const testObject = object.property(vitestConfig, 'test', object.createEmpty());
 
-			const workspaceArray = object.property(testObject, 'workspace', array.createEmpty());
-			array.push(workspaceArray, clientObjectExpression);
-			array.push(workspaceArray, serverObjectExpression);
+			const projectsArray = object.property(testObject, 'projects', array.createEmpty());
+			array.push(projectsArray, clientObjectExpression);
+			array.push(projectsArray, serverObjectExpression);
 
 			return generateCode();
 		});


### PR DESCRIPTION
Linked with https://github.com/sveltejs/svelte/issues/11394

---

Today `sv` with `vitest` addon is failing with this error: 
```
`mount(...)` is not available on the server
```

This PR is fixing the issue (and fixing main branch)

🚨 I guess that this one is kinda "urgent" 🚨