### PR TITLE
fix(vitest): `mount(...)` not available

### DIFF
--- a/.changeset/cuddly-rings-travel.md
+++ b/.changeset/cuddly-rings-travel.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix(vitest): `mount(...)` not available

--- a/packages/addons/vitest-addon/index.ts
+++ b/packages/addons/vitest-addon/index.ts
@@ -10,7 +10,7 @@ export default defineAddon({
 	run: ({ sv, typescript, kit }) => {
 		const ext = typescript ? 'ts' : 'js';
 
-		sv.devDependency('vitest', '^3.0.0');
+		sv.devDependency('vitest', '3.1.4');
 		sv.devDependency('@testing-library/svelte', '^5.2.4');
 		sv.devDependency('@testing-library/jest-dom', '^6.6.3');
 		sv.devDependency('jsdom', '^26.0.0');


### PR DESCRIPTION
closes #579 
alternative to #580 

As discussed in #580 this is a regression in `vitest`, so let's pin it for now: https://github.com/vitest-dev/vitest/issues/8120