### PR TITLE
chore: update lucia template

### DIFF
--- a/.changeset/shiny-chairs-slide.md
+++ b/.changeset/shiny-chairs-slide.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+chore: update lucia template

--- a/packages/addons/lucia/index.ts
+++ b/packages/addons/lucia/index.ts
@@ -367,7 +367,7 @@ export default defineAddon({
 
 		sv.file(`src/hooks.server.${ext}`, (content) => {
 			const { ast, generateCode } = parseScript(content);
-			js.imports.addNamespace(ast, '$lib/server/auth.js', 'auth');
+			js.imports.addNamespace(ast, '$lib/server/auth', 'auth');
 			js.kit.addHooksHandle(ast, typescript, 'handleAuth', getAuthHandleContent());
 			return generateCode();
 		});
@@ -467,7 +467,7 @@ export default defineAddon({
 								const sessionToken = auth.generateSessionToken();
 								const session = await auth.createSession(sessionToken, userId);
 								auth.setSessionTokenCookie(event, sessionToken, session.expiresAt);
-							} catch (e) {
+							} catch {
 								return fail(500, { message: 'An error has occurred' });
 							}
 							return redirect(302, '/demo/lucia');


### PR DESCRIPTION
1. Removed trailing `.js` in import to match `module: esnext`.
2. Removed unused `e` in `try-catch` which caused ESLint error.