### PR TITLE
fix(vitest): unpin to ^3.2.3 after it fixed a regression

### DIFF
--- a/.changeset/social-paws-wash.md
+++ b/.changeset/social-paws-wash.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix(vitest): unpin vitest to ^3.2.3 after it fixed a regression

--- a/packages/addons/vitest-addon/index.ts
+++ b/packages/addons/vitest-addon/index.ts
@@ -141,7 +141,7 @@ export default defineAddon({
 			const vitestConfig = functions.argumentByIndex(defineWorkspaceCall, 0, object.createEmpty());
 			const testObject = object.property(vitestConfig, 'test', object.createEmpty());
 
-			const workspaceArray = object.property(testObject, 'workspace', array.createEmpty());
+			const workspaceArray = object.property(testObject, 'projects', array.createEmpty());
 			array.push(workspaceArray, clientObjectExpression);
 			array.push(workspaceArray, serverObjectExpression);
 

--- a/packages/addons/vitest-addon/index.ts
+++ b/packages/addons/vitest-addon/index.ts
@@ -10,7 +10,7 @@ export default defineAddon({
 	run: ({ sv, typescript, kit }) => {
 		const ext = typescript ? 'ts' : 'js';
 
-		sv.devDependency('vitest', '3.1.4');
+		sv.devDependency('vitest', '^3.2.3');
 		sv.devDependency('@testing-library/svelte', '^5.2.4');
 		sv.devDependency('@testing-library/jest-dom', '^6.6.3');
 		sv.devDependency('jsdom', '^26.0.0');


### PR DESCRIPTION
 see https://github.com/sveltejs/cli/pull/584 and https://github.com/vitest-dev/vitest/issues/8120