### PR TITLE
feat(vitest): vitest browser mode

### DIFF
--- a/.changeset/evil-comics-cover.md
+++ b/.changeset/evil-comics-cover.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+feat(vitest): support vite browser mode

--- a/packages/addons/_tests/vitest/test.ts
+++ b/packages/addons/_tests/vitest/test.ts
@@ -10,6 +10,7 @@ test.concurrent.for(variants)('core - %s', async (variant, { page, ...ctx }) => 
 
 	const { close } = await prepareServer({ cwd, page });
 
+	execSync('pnpm exec playwright install chromium', { cwd, stdio: 'pipe' });
 	execSync('pnpm test', { cwd, stdio: 'pipe' });
 
 	// kill server process when we're done

--- a/packages/addons/tailwindcss/index.ts
+++ b/packages/addons/tailwindcss/index.ts
@@ -30,7 +30,8 @@ const options = defineAddonOptions({
 		type: 'multiselect',
 		question: 'Which plugins would you like to add?',
 		options: plugins.map((p) => ({ value: p.id, label: p.id, hint: p.package })),
-		default: []
+		default: [],
+		required: false
 	}
 });
 

--- a/packages/addons/vitest-addon/index.ts
+++ b/packages/addons/vitest-addon/index.ts
@@ -1,5 +1,5 @@
 import { dedent, defineAddon, defineAddonOptions, log } from '@sveltejs/cli-core';
-import { array, common, exports, functions, imports, object } from '@sveltejs/cli-core/js';
+import { array, exports, functions, object } from '@sveltejs/cli-core/js';
 import { parseJson, parseScript } from '@sveltejs/cli-core/parsers';
 
 const options = defineAddonOptions({
@@ -26,9 +26,12 @@ export default defineAddon({
 		const componentTesting = options.usages.includes('component');
 
 		sv.devDependency('vitest', '3.1.4');
-		sv.devDependency('@testing-library/svelte', '^5.2.4');
-		sv.devDependency('@testing-library/jest-dom', '^6.6.3');
-		sv.devDependency('jsdom', '^26.0.0');
+
+		if (componentTesting) {
+			sv.devDependency('@vitest/browser', '3.1.4');
+			sv.devDependency('vitest-browser-svelte', '^0.1.0');
+			sv.devDependency('playwright', '^1.0.0');
+		}
 
 		sv.file('package.json', (content) => {
 			const { data, generateCode } = parseJson(content);
@@ -60,66 +63,36 @@ export default defineAddon({
 		}
 
 		if (componentTesting) {
-			if (kit) {
-				sv.file(`${kit.routesDirectory}/page.svelte.test.${ext}`, (content) => {
-					if (content) return content;
+			const fileName = kit
+				? `${kit.routesDirectory}/page.svelte.test.${ext}`
+				: `src/App.svelte.test.${ext}`;
 
-					return dedent`
-						import { describe, test, expect } from 'vitest';
-						import '@testing-library/jest-dom/vitest';
-						import { render, screen } from '@testing-library/svelte';
-						import Page from './+page.svelte';
-	
-						describe('/+page.svelte', () => {
-							test('should render h1', () => {
-								render(Page);
-								expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
+			sv.file(fileName, (content) => {
+				if (content) return content;
+
+				return dedent`
+						import { page } from '@vitest/browser/context';
+						import { describe, expect, it } from 'vitest';
+						import { render } from 'vitest-browser-svelte';
+						${kit ? "import Page from './+page.svelte';" : "import App from './App.svelte';"}
+
+						describe('${kit ? '/+page.svelte' : 'App.svelte'}', () => {
+							it('should render h1', async () => {
+								render(${kit ? 'Page' : 'App'});
+								
+								const heading = page.getByRole('heading', { level: 1 });
+								await expect.element(heading).toBeInTheDocument();
 							});
 						});
 					`;
-				});
-			} else {
-				sv.file(`src/App.svelte.test.${ext}`, (content) => {
-					if (content) return content;
-
-					return dedent`
-						import { describe, test, expect } from 'vitest';
-						import '@testing-library/jest-dom/vitest';
-						import { render, screen } from '@testing-library/svelte';
-						import App from './App.svelte';
-	
-						describe('App.svelte', () => {
-							test('should render h1', () => {
-								render(App);
-								expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
-							});
-						});
-					`;
-				});
-			}
+			});
 
 			sv.file(`vitest-setup-client.${ext}`, (content) => {
 				if (content) return content;
 
 				return dedent`
-					import '@testing-library/jest-dom/vitest';
-					import { vi } from 'vitest';
-
-					// required for svelte5 + jsdom as jsdom does not support matchMedia
-					Object.defineProperty(window, 'matchMedia', {
-						writable: true,
-						enumerable: true,
-						value: vi.fn().mockImplementation(query => ({
-							matches: false,
-							media: query,
-							onchange: null,
-							addEventListener: vi.fn(),
-							removeEventListener: vi.fn(),
-							dispatchEvent: vi.fn(),
-						})),
-					})
-
-					// add more mocks here if you need them
+					/// <reference types="@vitest/browser/matchers" />
+					/// <reference types="@vitest/browser/providers/playwright" />
 				`;
 			});
 		}
@@ -127,28 +100,30 @@ export default defineAddon({
 		sv.file(`vite.config.${ext}`, (content) => {
 			const { ast, generateCode } = parseScript(content);
 
-			imports.addNamed(ast, '@testing-library/svelte/vite', { svelteTesting: 'svelteTesting' });
-
-			const clientObjectExpression = object.create({
-				extends: common.createLiteral(`./vite.config.${ext}`),
-				plugins: common.expressionFromString('[svelteTesting()]'),
-				test: object.create({
-					name: common.createLiteral('client'),
-					environment: common.createLiteral('jsdom'),
-					clearMocks: common.expressionFromString('true'),
-					include: common.expressionFromString("['src/**/*.svelte.{test,spec}.{js,ts}']"),
-					exclude: common.expressionFromString("['src/lib/server/**']"),
-					setupFiles: common.expressionFromString(`['./vitest-setup-client.${ext}']`)
-				})
+			const clientObjectExpression = object.createFromPrimitives({
+				extends: `./vite.config.${ext}`,
+				test: {
+					name: 'client',
+					environment: 'browser',
+					browser: {
+						enabled: true,
+						provider: 'playwright',
+						instances: [{ browser: 'chromium' }]
+					},
+					include: ['src/**/*.svelte.{test,spec}.{js,ts}'],
+					exclude: ['src/lib/server/**'],
+					setupFiles: [`./vitest-setup-client.${ext}`]
+				}
 			});
-			const serverObjectExpression = object.create({
-				extends: common.createLiteral(`./vite.config.${ext}`),
-				test: object.create({
-					name: common.createLiteral('server'),
-					environment: common.createLiteral('node'),
-					include: common.expressionFromString("['src/**/*.{test,spec}.{js,ts}']"),
-					exclude: common.expressionFromString("['src/**/*.svelte.{test,spec}.{js,ts}']")
-				})
+
+			const serverObjectExpression = object.createFromPrimitives({
+				extends: `./vite.config.${ext}`,
+				test: {
+					name: 'server',
+					environment: 'node',
+					include: ['src/**/*.{test,spec}.{js,ts}'],
+					exclude: ['src/**/*.svelte.{test,spec}.{js,ts}']
+				}
 			});
 
 			const defineConfigFallback = functions.call('defineConfig', []);
@@ -161,8 +136,9 @@ export default defineAddon({
 			const testObject = object.property(vitestConfig, 'test', object.createEmpty());
 
 			const workspaceArray = object.property(testObject, 'workspace', array.createEmpty());
-			array.push(workspaceArray, clientObjectExpression);
-			array.push(workspaceArray, serverObjectExpression);
+
+			if (componentTesting) array.push(workspaceArray, clientObjectExpression);
+			if (unitTesting) array.push(workspaceArray, serverObjectExpression);
 
 			return generateCode();
 		});

--- a/packages/addons/vitest-addon/index.ts
+++ b/packages/addons/vitest-addon/index.ts
@@ -30,7 +30,7 @@ export default defineAddon({
 		if (componentTesting) {
 			sv.devDependency('@vitest/browser', '^3.2.3');
 			sv.devDependency('vitest-browser-svelte', '^0.1.0');
-			sv.devDependency('playwright', '^1.0.0');
+			sv.devDependency('playwright', '^1.53.0');
 		}
 
 		sv.file('package.json', (content) => {

--- a/packages/cli/commands/add/index.ts
+++ b/packages/cli/commands/add/index.ts
@@ -508,7 +508,7 @@ export async function runAddCommand(
 				answer = await p.multiselect({
 					message,
 					initialValues: question.default,
-					required: false,
+					required: question.required,
 					options: question.options
 				});
 			}

--- a/packages/core/addon/options.ts
+++ b/packages/core/addon/options.ts
@@ -27,6 +27,7 @@ export type MultiSelectQuestion<Value = any> = {
 	type: 'multiselect';
 	default: Value[];
 	options: Array<{ value: Value; label?: string; hint?: string }>;
+	required: boolean;
 };
 
 export type BaseQuestion = {

--- a/packages/core/tests/js/object/create-from-primitives/output.ts
+++ b/packages/core/tests/js/object/create-from-primitives/output.ts
@@ -1,5 +1,6 @@
 const empty = {};
 
+// prettier-ignore
 const created = {
 	foo: 1,
 	bar: 'string',

--- a/packages/core/tests/js/object/create-from-primitives/output.ts
+++ b/packages/core/tests/js/object/create-from-primitives/output.ts
@@ -1,0 +1,13 @@
+const empty = {};
+
+const created = {
+	foo: 1,
+	bar: 'string',
+	object: { foo: 'hello', nested: { bar: 'world' } },
+	array: [
+		123,
+		'hello',
+		{ foo: 'bar', bool: true },
+		[456, '789']
+	]
+};

--- a/packages/core/tests/js/object/create-from-primitives/run.ts
+++ b/packages/core/tests/js/object/create-from-primitives/run.ts
@@ -1,0 +1,22 @@
+import { variables, object, type AstTypes } from '@sveltejs/cli-core/js';
+
+export function run(ast: AstTypes.Program): void {
+	const emptyObject = object.createFromPrimitives({});
+	const emptyVariable = variables.declaration(ast, 'const', 'empty', emptyObject);
+	ast.body.push(emptyVariable);
+
+	const createdObject = object.createFromPrimitives({
+		foo: 1,
+		bar: 'string',
+		baz: undefined,
+		object: {
+			foo: 'hello',
+			nested: {
+				bar: 'world'
+			}
+		},
+		array: [123, 'hello', { foo: 'bar', bool: true }, [456, '789']]
+	});
+	const createdVariable = variables.declaration(ast, 'const', 'created', createdObject);
+	ast.body.push(createdVariable);
+}

--- a/packages/core/tests/js/object/create-from-primitives/run.ts
+++ b/packages/core/tests/js/object/create-from-primitives/run.ts
@@ -18,5 +18,6 @@ export function run(ast: AstTypes.Program): void {
 		array: [123, 'hello', { foo: 'bar', bool: true }, [456, '789']]
 	});
 	const createdVariable = variables.declaration(ast, 'const', 'created', createdObject);
+	createdVariable.leadingComments = [{ type: 'Line', value: ' prettier-ignore' }];
 	ast.body.push(createdVariable);
 }

--- a/packages/core/tooling/js/object.ts
+++ b/packages/core/tooling/js/object.ts
@@ -109,6 +109,7 @@ type ObjectPrimitiveValues = string | number | boolean | undefined;
 type ObjectValues = ObjectPrimitiveValues | Object | ObjectValues[];
 type Object = { [property: string]: ObjectValues };
 
+// todo: potentially make this the default `create` method in the future
 export function createFromPrimitives(obj: Object): AstTypes.ObjectExpression {
 	const objExpression = createEmpty();
 

--- a/packages/core/tooling/js/object.ts
+++ b/packages/core/tooling/js/object.ts
@@ -106,11 +106,11 @@ export function create<T extends AstTypes.Expression>(
 }
 
 type ObjectPrimitiveValues = string | number | boolean | undefined;
-type ObjectValues = ObjectPrimitiveValues | Object | ObjectValues[];
-type Object = { [property: string]: ObjectValues };
+type ObjectValues = ObjectPrimitiveValues | ObjectMap | ObjectValues[];
+type ObjectMap = { [property: string]: ObjectValues };
 
 // todo: potentially make this the default `create` method in the future
-export function createFromPrimitives(obj: Object): AstTypes.ObjectExpression {
+export function createFromPrimitives(obj: ObjectMap): AstTypes.ObjectExpression {
 	const objExpression = createEmpty();
 
 	const getExpression = (value: ObjectValues) => {


### PR DESCRIPTION
Supports `vitest` browser mode. Makes the setup more flexible by asking the user to add component / unit testing.

Adds a new `object.createFromPrimitives` to core that should help us find the right balance for https://github.com/sveltejs/cli/issues/557. We should all `object.create` calls in the future and try to use this wherever possible.

todo:
- [x] test in non kit project
- [x] check if error / warning for `The following Vite config options will be overridden by SvelteKit:  - root` is accurate and how to avoid it => accurate, not something we control
