### PR TITLE
fix: resolve to `task` instead of `run` in addon instructions for `deno`

### DIFF
--- a/.changeset/silent-timers-carry.md
+++ b/.changeset/silent-timers-carry.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/addons": patch
+---
+
+fix: resolve to `task` instead of `run` in addon instructions for `deno`

--- a/packages/addons/drizzle/index.ts
+++ b/packages/addons/drizzle/index.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { common, exports, functions, imports, object, variables } from '@sveltejs/cli-core/js';
 import { defineAddon, defineAddonOptions, dedent, type OptionValues } from '@sveltejs/cli-core';
 import { parseJson, parseScript } from '@sveltejs/cli-core/parsers';
+import { resolveCommand } from 'package-manager-detector/commands';
 import { getNodeTypesVersion } from '../common.ts';
 
 const PORTS = {
@@ -357,16 +358,18 @@ export default defineAddon({
 			`You will need to set ${highlighter.env('DATABASE_URL')} in your production environment`
 		];
 		if (options.docker) {
+			const { command, args } = resolveCommand(packageManager, 'run', ['db:start'])!;
 			steps.push(
-				`Run ${highlighter.command(`${packageManager} run db:start`)} to start the docker container`
+				`Run ${highlighter.command(`${command} ${args.join(' ')}`)} to start the docker container`
 			);
 		} else {
 			steps.push(
 				`Check ${highlighter.env('DATABASE_URL')} in ${highlighter.path('.env')} and adjust it to your needs`
 			);
 		}
+		const { command, args } = resolveCommand(packageManager, 'run', ['db:push'])!;
 		steps.push(
-			`Run ${highlighter.command(`${packageManager} run db:push`)} to update your database schema`
+			`Run ${highlighter.command(`${command} ${args.join(' ')}`)} to update your database schema`
 		);
 
 		return steps;

--- a/packages/addons/lucia/index.ts
+++ b/packages/addons/lucia/index.ts
@@ -11,6 +11,7 @@ import {
 import * as js from '@sveltejs/cli-core/js';
 import type { AstTypes } from '@sveltejs/cli-core/js';
 import { parseScript } from '@sveltejs/cli-core/parsers';
+import { resolveCommand } from 'package-manager-detector/commands';
 import { addToDemoPage } from '../common.ts';
 
 const TABLE_TYPE = {
@@ -618,8 +619,9 @@ export default defineAddon({
 		}
 	},
 	nextSteps: ({ highlighter, options, packageManager }) => {
+		const { command, args } = resolveCommand(packageManager, 'run', ['db:push'])!;
 		const steps = [
-			`Run ${highlighter.command(`${packageManager} run db:push`)} to update your database schema`
+			`Run ${highlighter.command(`${command} ${args.join(' ')}`)} to update your database schema`
 		];
 		if (options.demo) {
 			steps.push(`Visit ${highlighter.route('/demo/lucia')} route to view the demo`);

--- a/packages/addons/package.json
+++ b/packages/addons/package.json
@@ -13,5 +13,8 @@
 	"exports": "./index.ts",
 	"dependencies": {
 		"@sveltejs/cli-core": "workspace:*"
+	},
+	"devDependencies": {
+		"package-manager-detector": "^0.2.11"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,10 @@ importers:
       '@sveltejs/cli-core':
         specifier: workspace:*
         version: link:../core
+    devDependencies:
+      package-manager-detector:
+        specifier: ^0.2.11
+        version: 0.2.11
 
   packages/cli:
     devDependencies:


### PR DESCRIPTION
Set up a project earlier and it output:
> Run **deno run db:push** to update your database schema

...which is wrong for deno.

`package-manager-detector` seems to be used in other spots for this, so I added it here as well.
Tried to find all places using `run`, but only found it in `lucia` & `drizzle`.

---

Regarding changesets, I found this statement in `CONTRIBUTING.md` a bit confusing:

> Only publish a change set if it is in 'sv' or 'svelte-migrate' as all other packages are bundled.

The changes are in `addons` but it _affects_ `sv`...