### PR TITLE
chore: make `installAddon()` work

### DIFF
--- a/packages/cli/lib/index.ts
+++ b/packages/cli/lib/index.ts
@@ -1,3 +1,4 @@
 export { create } from '@sveltejs/create';
 export { installAddon } from './install.ts';
 export type { AddonMap, InstallOptions, OptionMap } from './install.ts';
+export { officialAddons } from '@sveltejs/addons';


### PR DESCRIPTION
We do have `create` that works flawlessly. But we do have `installAddon` that is unusable at this point in time, since it requires addons, that you can not export from anywhere. 

Since all of this is an undocumented api, im not too concerned. 