### PR TITLE
chore: use rolldown-vite (testing-only)

### DIFF
--- a/packages/create/templates/demo/package.template.json
+++ b/packages/create/templates/demo/package.template.json
@@ -16,7 +16,7 @@
 		"@sveltejs/kit": "^2.9.0",
 		"@sveltejs/vite-plugin-svelte": "^6.0.0-next.0",
 		"svelte": "^5.25.0",
-		"vite": "^7.0.0-beta.0"
+		"vite": "^7.0.0"
 	},
 	"overrides": {
 		"vite": "npm:rolldown-vite@latest"

--- a/packages/create/templates/library/package.template.json
+++ b/packages/create/templates/library/package.template.json
@@ -8,8 +8,8 @@
 		"prepare": "svelte-kit sync || echo ''",
 		"prepack": "svelte-kit sync && svelte-package && publint"
 	},
-	"files": ["dist", "!dist/**/*.test.*", "!dist/**/*.spec.*"],
-	"sideEffects": ["**/*.css"],
+	"files": [ "dist", "!dist/**/*.test.*", "!dist/**/*.spec.*" ],
+	"sideEffects": [ "**/*.css" ],
 	"svelte": "./dist/index.js",
 	"types": "./dist/index.d.ts",
 	"type": "module",
@@ -30,10 +30,10 @@
 		"publint": "^0.3.2",
 		"svelte": "^5.0.0",
 		"typescript": "^5.3.2",
-		"vite": "^7.0.0-beta.0"
+		"vite": "^7.0.0"
 	},
 	"overrides": {
 		"vite": "npm:rolldown-vite@latest"
 	},
-	"keywords": ["svelte"]
+	"keywords": [ "svelte" ]
 }

--- a/packages/create/templates/minimal/package.template.json
+++ b/packages/create/templates/minimal/package.template.json
@@ -14,7 +14,7 @@
 		"@sveltejs/kit": "^2.16.0",
 		"@sveltejs/vite-plugin-svelte": "^6.0.0-next.0",
 		"svelte": "^5.0.0",
-		"vite": "^7.0.0-beta.0"
+		"vite": "^7.0.0"
 	},
 	"overrides": {
 		"vite": "npm:rolldown-vite@latest"


### PR DESCRIPTION
This is not meant to be merged or anything. Just trying to see if any of the integrations breaks with this, or if everything still works.