### PR TITLE
chore: use project service for typescript-eslint to auto-detect tsconfig.json

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,8 +12,7 @@ export default [
 	{
 		languageOptions: {
 			parserOptions: {
-				// use the nearest tsconfig from the source or fallback to the root
-				project: ['packages/**/tsconfig.json', 'tsconfig.json']
+				projectService: true
 			}
 		},
 		rules: {

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -5,5 +5,6 @@
 		"isolatedDeclarations": true,
 		"declaration": true
 	},
-	"include": ["*.ts", "tooling", "tests", "addon"]
+	"include": ["*.ts", "tooling", "tests", "addon"],
+	"exclude": ["vitest.config.ts", "tests/**/input.ts", "tests/**/output.ts"]
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -5,5 +5,5 @@
 		"isolatedDeclarations": true,
 		"declaration": true
 	},
-	"include": ["index.ts"]
+	"include": ["*.ts", "tooling", "tests", "addon"]
 }


### PR DESCRIPTION
This PR intends to remove the eslint errors that show up in the IDE about certain .ts files not being included by the tsconfig.json . An example of this is `packages/core/tests/utils.ts`.

More about project service replacing the project setting: https://typescript-eslint.io/packages/parser/#projectservice