### PR TITLE
fix(add): add `static` folder to `.prettierignore`

### DIFF
--- a/.changeset/twenty-suits-listen.md
+++ b/.changeset/twenty-suits-listen.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix(add): add `static` folder to `.prettierignore`

--- a/packages/addons/prettier/index.ts
+++ b/packages/addons/prettier/index.ts
@@ -20,6 +20,9 @@ export default defineAddon({
 				yarn.lock
 				bun.lock
 				bun.lockb
+
+				# Miscellaneous
+				static/
 			`;
 		});
 


### PR DESCRIPTION
Closes #607 

This is probably debatable, but based on the presentation inside the docs, this does make sense in my opinion. I was currently unable to imagine any valid use-case where you would want to format your `static` folder.