### PR TITLE
chore: prefetch storybook cli during CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,4 +55,5 @@ jobs:
       - run: pnpm build
       # prefetch the storybook cli to reduce fetching errors in tests
       - run: pnpx storybook@latest
+        continue-on-error: true
       - run: pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,5 @@ jobs:
       - run: pnpm exec playwright install chromium
       - run: pnpm build
       # prefetch the storybook cli to reduce fetching errors in tests
-      - run: pnpx storybook@latest
-        continue-on-error: true
+      - run: pnpx storybook@latest --version
       - run: pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,4 +53,6 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm exec playwright install chromium
       - run: pnpm build
+      # prefetch the storybook cli to reduce fetching errors in tests
+      - run: pnpx storybook@latest
       - run: pnpm test


### PR DESCRIPTION
The vast majority of our flakiness when we run tests in CI is due to some weird storybook cli error related to fetching (_i think_). 

This PR serves as a quick test to see if we can at least alleviate some of the flakiness by prefetching the CLI before we run our test suite so it's stored in pnpm's cache.

edit:
This seems to work. Rerunning the tests in CI has yielded no errors and is 10/11 on successful runs (one of the runs failed because of a vitest `onTaskUpdate` error with mdsvex, so it's unrelated).