### PR TITLE
Default `projectService` to false in eslint adder

### DIFF
--- a/packages/addons/eslint/index.ts
+++ b/packages/addons/eslint/index.ts
@@ -111,7 +111,7 @@ export default defineAddon({
 					files: ['**/*.svelte', '**/*.svelte.ts', '**/*.svelte.js'],
 					languageOptions: {
 						parserOptions: {
-							projectService: true,
+							projectService: false,
 							extraFileExtensions: ['.svelte'],
 							parser: variables.createIdentifier('ts.parser'),
 							svelteConfig: variables.createIdentifier('svelteConfig')


### PR DESCRIPTION
In every single project I maintain I make sure this is off because if it's on I have seen linting take as long as 3 minutes, quickly increasing with the size of the project I feel like there is a pretty good case for having this off by default unless it catches something extra that is really important.

There has been an open issue for this for a while in `eslint-plugin-svelte` but it has kinda stagnated: https://github.com/sveltejs/eslint-plugin-svelte/issues/1084

