### PR TITLE
Improve (ba)sh usage, mainly in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Please keep your pull requests focused to feature or issue. Focused smaller chan
 ## Preparing
 This is a monorepo, meaning the repo holds multiple packages. It requires the use of [pnpm](https://pnpm.io/). You can [install pnpm](https://pnpm.io/installation) with:
 
-```bash
+```sh
 npm i -g pnpm
 ```
 
@@ -25,7 +25,7 @@ Linux users, you will have to ensure 'sudo' is not required. See [docker post in
 
 `pnpm` commands run in the project's root directory will run on all sub-projects. You can checkout the code and install the dependencies with:
 
-```bash
+```sh
 cd cli
 pnpm install
 ```
@@ -33,19 +33,19 @@ pnpm install
 ## Build and run
 To build the project and all packages. Run the 'build' script:
 
-```bash
+```sh
 # from root of project
 pnpm build
 ```
 This outputs into /packages/PACKAGE/dist/.
 
 Run the 'cli' package:
-```bash
+```sh
 pnpm sv
 ```
 
 Run build with watch mode:
-```bash
+```sh
 pnpm dev
 ```
 
@@ -54,29 +54,29 @@ pnpm dev
 For each add-on we have integration tests setup. These install the deps, build the app, run the dev server and then run a few small snippets against the add-on to see if the changes introduced by the add-on are working as expected.
 
 Run all tests:
-```bash
+```sh
 # from root of project
 pnpm test
 ```
 
 Run tests with vitest ui:
-```bash
+```sh
 # from root of project
 pnpm test:ui
 ```
 
 Run package specific tests by specifying a project flag to the package and running the test command. Eg:
-```bash
+```sh
 pnpm test --project core # addons / create / migrate / etc.
 ```
 
 To run a individual test. `cd` into the package. Run the local `test` script to that package, with a path arg to the individual piece you want tested. Eg:
-```bash
+```sh
 pnpm test [path-to-test]
 ```
 
 To debug a failing test. A good starting point is to `cd` into the failing tests dir. Proceed to `build` it. Then `preview` it. From here you will have increased information to help in the debug process. Eg:
-```bash
+```sh
 # Each test is a standalone app
 cd .test-output/addons/[addon-test]/[test-id]
 pnpm build
@@ -91,24 +91,24 @@ There are a few guidelines we follow:
 
 - Ensure `pnpm lint` and `pnpm check` pass. You can run `pnpm format` to format the code
 - linting
-```bash
+```sh
 # from root of project
 pnpm lint
 ```
 - formatting
-```bash
+```sh
 # from root of project
 pnpm format
 ```
 - type checking
-```bash
+```sh
 # from root of project
 pnpm check
 ```
 
 ## svelte-migrate
 To run svelte-migrate locally:
-```bash
+```sh
 # from root of project
 node ./packages/migrate/bin.js 
 ```
@@ -116,7 +116,7 @@ node ./packages/migrate/bin.js
 ## Generating changelogs
 Only publish a change set if it is in 'sv' or 'svelte-migrate' as all other packages are bundled. 
 For changes to be reflected in package changelogs:
-```bash
+```sh
 # from root of project
 pnpm changeset:publish
 ```

--- a/documentation/docs/10-introduction/10-overview.md
+++ b/documentation/docs/10-introduction/10-overview.md
@@ -8,7 +8,7 @@ The command line interface (CLI), `sv`, is a toolkit for creating and maintainin
 
 The easiest way to run `sv` is with [`npx`](https://docs.npmjs.com/cli/v8/commands/npx) (or the equivalent command if you're using a different package manager — for example, `pnpx` if you're using [pnpm](https://pnpm.io/)):
 
-```bash
+```sh
 npx sv <command> <args>
 ```
 

--- a/documentation/docs/20-commands/10-sv-create.md
+++ b/documentation/docs/20-commands/10-sv-create.md
@@ -6,7 +6,7 @@ title: sv create
 
 ## Usage
 
-```bash
+```sh
 npx sv create [options] [path]
 ```
 

--- a/documentation/docs/20-commands/20-sv-add.md
+++ b/documentation/docs/20-commands/20-sv-add.md
@@ -6,11 +6,11 @@ title: sv add
 
 ## Usage
 
-```bash
+```sh
 npx sv add
 ```
 
-```bash
+```sh
 npx sv add [add-ons]
 ```
 

--- a/documentation/docs/20-commands/30-sv-check.md
+++ b/documentation/docs/20-commands/30-sv-check.md
@@ -14,13 +14,13 @@ Requires Node 16 or later.
 
 You will need to have the `svelte-check` package installed in your project:
 
-```bash
+```sh
 npm i -D svelte-check
 ```
 
 ## Usage
 
-```bash
+```sh
 npx sv check
 ```
 
@@ -59,7 +59,7 @@ Use this if you only want to check the Svelte files found in the current directo
 
 Files/folders to ignore, relative to workspace root. Paths should be comma-separated and quoted. Example:
 
-```bash
+```sh
 npx sv check --ignore "dist,build"
 ```
 
@@ -75,7 +75,7 @@ If provided, warnings will cause `sv check` to exit with an error code.
 
 A quoted, comma-separated list of `code:behaviour` pairs where `code` is a [compiler warning code](../svelte/compiler-warnings) and `behaviour` is either `ignore` or `error`:
 
-```bash
+```sh
 npx sv check --compiler-warnings "css_unused_selector:ignore,a11y_missing_attribute:error"
 ```
 
@@ -90,7 +90,7 @@ A quoted, comma-separated list of sources that should run diagnostics on your co
 
 Example:
 
-```bash
+```sh
 npx sv check --diagnostic-sources "js,svelte"
 ```
 

--- a/documentation/docs/20-commands/40-sv-migrate.md
+++ b/documentation/docs/20-commands/40-sv-migrate.md
@@ -8,12 +8,12 @@ Some migrations may annotate your codebase with tasks for completion that you ca
 
 ## Usage
 
-```bash
+```sh
 npx sv migrate
 ```
 
 You can also specify a migration directly via the CLI:
-```bash
+```sh
 npx sv migrate [migration]
 ```
 

--- a/documentation/docs/30-add-ons/03-devtools-json.md
+++ b/documentation/docs/30-add-ons/03-devtools-json.md
@@ -30,7 +30,7 @@ export function handle({ event, resolve }) {
 
 ## Usage
 
-```bash
+```sh
 npx sv add devtools-json
 ```
 

--- a/documentation/docs/30-add-ons/05-drizzle.md
+++ b/documentation/docs/30-add-ons/05-drizzle.md
@@ -6,7 +6,7 @@ title: drizzle
 
 ## Usage
 
-```bash
+```sh
 npx sv add drizzle
 ```
 
@@ -27,7 +27,7 @@ Which database variant to use:
 - `mysql` — another popular open source database
 - `sqlite` — file-based database not requiring a database server
 
-```bash
+```sh
 npx sv add drizzle=database:postgresql
 ```
 
@@ -39,7 +39,7 @@ The SQL client to use, depends on `database`:
 - For `mysql`: `mysql2`, `planetscale`
 - For `sqlite`: `better-sqlite3`, `libsql`, `turso`
 
-```bash
+```sh
 npx sv add drizzle=database:postgresql+client:postgres.js
 ```
 
@@ -49,6 +49,6 @@ Drizzle is compatible with well over a dozen database drivers. We just offer a f
 
 Whether to add Docker Compose configuration. Only available for [`database`](#Options-database) `postgresql` or `mysql`
 
-```bash
+```sh
 npx sv add drizzle=database:postgresql+client:postgres.js+docker:yes
 ```

--- a/documentation/docs/30-add-ons/10-eslint.md
+++ b/documentation/docs/30-add-ons/10-eslint.md
@@ -6,7 +6,7 @@ title: eslint
 
 ## Usage
 
-```bash
+```sh
 npx sv add eslint
 ```
 

--- a/documentation/docs/30-add-ons/15-lucia.md
+++ b/documentation/docs/30-add-ons/15-lucia.md
@@ -6,7 +6,7 @@ An auth setup following [the Lucia auth guide](https://lucia-auth.com/).
 
 ## Usage
 
-```bash
+```sh
 npx sv add lucia
 ```
 
@@ -21,6 +21,6 @@ npx sv add lucia
 
 Whether to include demo registration and login pages.
 
-```bash
+```sh
 npx sv add lucia=demo:yes
 ```

--- a/documentation/docs/30-add-ons/20-mdsvex.md
+++ b/documentation/docs/30-add-ons/20-mdsvex.md
@@ -6,7 +6,7 @@ title: mdsvex
 
 ## Usage
 
-```bash
+```sh
 npx sv add mdsvex
 ```
 

--- a/documentation/docs/30-add-ons/25-paraglide.md
+++ b/documentation/docs/30-add-ons/25-paraglide.md
@@ -6,7 +6,7 @@ title: paraglide
 
 ## Usage
 
-```bash
+```sh
 npx sv add paraglide
 ```
 
@@ -25,7 +25,7 @@ npx sv add paraglide
 
 The languages you'd like to support specified as IETF BCP 47 language tags.
 
-```bash
+```sh
 npx sv add paraglide="languageTags:en,es"
 ```
 
@@ -33,6 +33,6 @@ npx sv add paraglide="languageTags:en,es"
 
 Whether to generate an optional demo page showing how to use paraglide.
 
-```bash
+```sh
 npx sv add paraglide="demo:yes"
 ```

--- a/documentation/docs/30-add-ons/30-playwright.md
+++ b/documentation/docs/30-add-ons/30-playwright.md
@@ -6,7 +6,7 @@ title: playwright
 
 ## Usage
 
-```bash
+```sh
 npx sv add playwright
 ```
 

--- a/documentation/docs/30-add-ons/35-prettier.md
+++ b/documentation/docs/30-add-ons/35-prettier.md
@@ -6,7 +6,7 @@ title: prettier
 
 ## Usage
 
-```bash
+```sh
 npx sv add prettier
 ```
 

--- a/documentation/docs/30-add-ons/40-storybook.md
+++ b/documentation/docs/30-add-ons/40-storybook.md
@@ -6,7 +6,7 @@ title: storybook
 
 ## Usage
 
-```bash
+```sh
 npx sv add storybook
 ```
 

--- a/documentation/docs/30-add-ons/45-sveltekit-adapter.md
+++ b/documentation/docs/30-add-ons/45-sveltekit-adapter.md
@@ -6,7 +6,7 @@ title: sveltekit-adapter
 
 ## Usage
 
-```bash
+```sh
 npx sv add sveltekit-adapter
 ```
 
@@ -27,6 +27,6 @@ Which SvelteKit adapter to use:
 - `cloudflare` — [`@sveltejs/adapter-cloudflare`](/docs/kit/adapter-cloudflare) allows you to deploy to Cloudflare
 - `netlify` — [`@sveltejs/adapter-netlify`](/docs/kit/adapter-netlify) allows you to deploy to Netlify
 
-```bash
+```sh
 npx sv add sveltekit-adapter=adapter:node
 ```

--- a/documentation/docs/30-add-ons/50-tailwind.md
+++ b/documentation/docs/30-add-ons/50-tailwind.md
@@ -6,7 +6,7 @@ title: tailwindcss
 
 ## Usage
 
-```bash
+```sh
 npx sv add tailwindcss
 ```
 
@@ -26,6 +26,6 @@ Which plugin to use:
 - `typography` — [`@tailwindcss/typography`](https://github.com/tailwindlabs/tailwindcss-typography)
 - `forms` — [`@tailwindcss/forms`](https://github.com/tailwindlabs/tailwindcss-forms)
 
-```bash
+```sh
 npx sv add tailwindcss="plugins:typography"
 ```

--- a/documentation/docs/30-add-ons/55-vitest.md
+++ b/documentation/docs/30-add-ons/55-vitest.md
@@ -6,7 +6,7 @@ title: vitest
 
 ## Usage
 
-```bash
+```sh
 npx sv add vitest
 ```
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2,7 +2,7 @@
 
 A command line interface (CLI) for creating and maintaining [Svelte](https://svelte.dev) applications. Just run:
 
-```bash
+```sh
 npx sv
 ```
 

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -17,7 +17,7 @@
 		"format": "pnpm lint --write",
 		"lint": "prettier --check . --config ../../prettier.config.js --ignore-path ../../.gitignore --ignore-path .gitignore --ignore-path ../../.prettierignore",
 		"test": "vitest run",
-		"update-template-repo": "pnpm build:dist && echo \"Updating template repo\" && bash ./scripts/update-template-repo.sh"
+		"update-template-repo": "pnpm build:dist && echo \"Updating template repo\" && ./scripts/update-template-repo.sh"
 	},
 	"files": [
 		"dist"

--- a/packages/create/scripts/update-template-repo.sh
+++ b/packages/create/scripts/update-template-repo.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/packages/create/shared/+library/README.md
+++ b/packages/create/shared/+library/README.md
@@ -8,7 +8,7 @@ Read more about creating a library [in the docs](https://svelte.dev/docs/kit/pac
 
 If you're seeing this, you've probably already done this step. Congrats!
 
-```bash
+```sh
 # create a new project in the current directory
 npx sv create
 
@@ -20,7 +20,7 @@ npx sv create my-app
 
 Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
 
-```bash
+```sh
 npm run dev
 
 # or start the server and open the app in a new browser tab
@@ -33,13 +33,13 @@ Everything inside `src/lib` is part of your library, everything inside `src/rout
 
 To build your library:
 
-```bash
+```sh
 npm run package
 ```
 
 To create a production version of your showcase app:
 
-```bash
+```sh
 npm run build
 ```
 
@@ -53,6 +53,6 @@ Go into the `package.json` and give your package the desired name through the `"
 
 To publish your library to [npm](https://www.npmjs.com):
 
-```bash
+```sh
 npm publish
 ```

--- a/packages/create/shared/README.md
+++ b/packages/create/shared/README.md
@@ -6,7 +6,7 @@ Everything you need to build a Svelte project, powered by [`sv`](https://github.
 
 If you're seeing this, you've probably already done this step. Congrats!
 
-```bash
+```sh
 # create a new project in the current directory
 npx sv create
 
@@ -18,7 +18,7 @@ npx sv create my-app
 
 Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
 
-```bash
+```sh
 npm run dev
 
 # or start the server and open the app in a new browser tab
@@ -29,7 +29,7 @@ npm run dev -- --open
 
 To create a production version of your app:
 
-```bash
+```sh
 npm run build
 ```
 

--- a/packages/migrate/README.md
+++ b/packages/migrate/README.md
@@ -4,13 +4,13 @@ A CLI for migrating Svelte(Kit) codebases.
 
 Run it directly using:
 
-```bash
+```sh
 npx sv migrate
 ```
 
 You can also specify a migration directly via the CLI:
 
-```bash
+```sh
 npx sv migrate [migration]
 ```
 


### PR DESCRIPTION
Every time that I have read the default readme I did not like the fact that generic shell commands were labeled as bash and I have changed it. After the third time I have decided to fix it upstream.

Also there are some minor improvements that are bash-related.
Everything is explained in the commit messages.