### PR TITLE
chore: use `create-storybook` instead of `storybook init`

### DIFF
--- a/.changeset/dull-items-sort.md
+++ b/.changeset/dull-items-sort.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+chore: use `create-storybook` instead of `storybook init`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,5 +54,5 @@ jobs:
       - run: pnpm exec playwright install chromium
       - run: pnpm build
       # prefetch the storybook cli to reduce fetching errors in tests
-      - run: pnpx storybook@latest --version
+      - run: pnpx create-storybook@latest --version
       - run: pnpm test

--- a/packages/addons/storybook/index.ts
+++ b/packages/addons/storybook/index.ts
@@ -12,7 +12,7 @@ export default defineAddon({
 		runsAfter('eslint');
 	},
 	run: async ({ sv }) => {
-		const args = ['storybook@latest', 'init', '--skip-install', '--no-dev'];
+		const args = ['create-storybook@latest', '--skip-install', '--no-dev'];
 
 		// skips the onboarding prompt during tests
 		if (process.env.NODE_ENV?.toLowerCase() === 'test') args.push('--yes');


### PR DESCRIPTION
According to Jeppe this is the correct way to do it. As of now, `storybook init` is just calling `create-storybook` according to him.