### PR TITLE
chore: improved storybook prefetching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,4 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm exec playwright install chromium
       - run: pnpm build
-      # prefetch the storybook cli to reduce fetching errors in tests
-      - run: pnpx create-storybook@latest --version
       - run: pnpm test

--- a/packages/addons/_tests/storybook/test.ts
+++ b/packages/addons/_tests/storybook/test.ts
@@ -12,8 +12,10 @@ const { test, variants, prepareServer } = setupTest({ storybook, eslint });
 let port = 6006;
 
 beforeAll(() => {
-	// prefetch the storybook cli to reduce fetching errors in tests
-	execSync('pnpx create-storybook@latest --version');
+	if (process.env.CI) {
+		// prefetch the storybook cli during ci to reduce fetching errors in tests
+		execSync('pnpx create-storybook@latest --version');
+	}
 });
 
 test.for(variants)(

--- a/packages/addons/_tests/storybook/test.ts
+++ b/packages/addons/_tests/storybook/test.ts
@@ -1,5 +1,7 @@
 import process from 'node:process';
+import { execSync } from 'node:child_process';
 import { expect } from '@playwright/test';
+import { beforeAll } from 'vitest';
 import { setupTest } from '../_setup/suite.ts';
 import storybook from '../../storybook/index.ts';
 import eslint from '../../eslint/index.ts';
@@ -8,6 +10,11 @@ import eslint from '../../eslint/index.ts';
 const { test, variants, prepareServer } = setupTest({ storybook, eslint });
 
 let port = 6006;
+
+beforeAll(() => {
+	// prefetch the storybook cli to reduce fetching errors in tests
+	execSync('pnpx create-storybook@latest --version');
+});
 
 test.for(variants)(
 	'storybook loaded - %s',


### PR DESCRIPTION
Relates https://github.com/sveltejs/cli/pull/622
Relates https://github.com/sveltejs/svelte-ecosystem-ci/pull/32

In direct comparison to #622 this has the disadvantage, that this also run's locally. We could check via the `CI` env variable, but I don't think that would help to reproduce pipeline failures locally.  On the other hand, this is an improvement in comparison to #622 because it allows our tests to be run everywhere, without requiring explicit setup. This is in example the case in `svelte-ecosystem-ci` (https://github.com/sveltejs/svelte-ecosystem-ci/pull/32)

If this works the way I think it should (I will check in the pipeline), I would personally consider this as a slight improvement.