### PR TITLE
chore(create): recommend the `kit.typescript.config` setting instead of copying from the generated config

### DIFF
--- a/.changeset/hot-roses-call.md
+++ b/.changeset/hot-roses-call.md
@@ -1,0 +1,5 @@
+---
+"sv": patch
+---
+
+chore(create): recommend the `kit.typescript.config` setting instead of copying from the generated config

--- a/packages/create/shared/+typescript/tsconfig.json
+++ b/packages/create/shared/+typescript/tsconfig.json
@@ -16,5 +16,5 @@
 	//
 	// To make changes to top-level options such as include and exclude, we recommend extending
 	// the generated config; see the `kit.typescript.config` setting for more details.
-	// https://svelte.dev/docs/kit/project-structure#Project-files-tsconfig.json
+	// https://svelte.dev/docs/kit/configuration#typescript
 }

--- a/packages/create/shared/+typescript/tsconfig.json
+++ b/packages/create/shared/+typescript/tsconfig.json
@@ -15,6 +15,5 @@
 	// except $lib which is handled by https://svelte.dev/docs/kit/configuration#files
 	//
 	// To make changes to top-level options such as include and exclude, we recommend extending
-	// the generated config; see the `kit.typescript.config` setting for more details.
-	// https://svelte.dev/docs/kit/configuration#typescript
+	// the generated config; see https://svelte.dev/docs/kit/configuration#typescript
 }

--- a/packages/create/shared/+typescript/tsconfig.json
+++ b/packages/create/shared/+typescript/tsconfig.json
@@ -14,6 +14,7 @@
 	// Path aliases are handled by https://svelte.dev/docs/kit/configuration#alias
 	// except $lib which is handled by https://svelte.dev/docs/kit/configuration#files
 	//
-	// If you want to overwrite includes/excludes, make sure to copy over the relevant includes/excludes
-	// from the referenced tsconfig.json - TypeScript does not merge them in
+	// To make changes to top-level options such as include and exclude, we recommend extending
+	// the generated config; see the `kit.typescript.config` setting for more details.
+	// https://svelte.dev/docs/kit/project-structure#Project-files-tsconfig.json
 }


### PR DESCRIPTION
Accompanying https://github.com/sveltejs/kit/pull/14026

This PR changes the comment in the create template's tsconfig.json file to prefer the kit config setting for extending the tsconfig file instead of overriding the includes and excludes settings.

Open to a better explanation/wording of why the setting should be used.