### PR TITLE
chore(drizzle): cleanup docker containers when the process is aborted

### DIFF
--- a/packages/addons/_tests/drizzle/test.ts
+++ b/packages/addons/_tests/drizzle/test.ts
@@ -19,6 +19,11 @@ vitest.beforeAll(() => {
 	const cwd = path.dirname(fileURLToPath(import.meta.url));
 	execSync('docker compose up --detach', { cwd, stdio: 'pipe' });
 
+	// cleans up the containers on interrupts (ctrl+c)
+	process.addListener('SIGINT', () => {
+		execSync('docker compose down --volumes', { cwd, stdio: 'pipe' });
+	});
+
 	return () => {
 		execSync('docker compose down --volumes', { cwd, stdio: 'pipe' });
 	};


### PR DESCRIPTION
If the `drizzle` test is aborted using `ctrl+c`, we'll want to cleanup any remaining running containers.