### PR TITLE
Fix type error in generated Paraglide hook

### DIFF
--- a/packages/addons/paraglide/index.ts
+++ b/packages/addons/paraglide/index.ts
@@ -111,7 +111,7 @@ export default defineAddon({
 				});
 			}
 
-			const expression = common.parseExpression(`(request) => deLocalizeUrl(request.url).pathname`);
+			const expression = common.parseExpression('(request) => deLocalizeUrl(request.url).pathname');
 			const rerouteIdentifier = variables.declaration(ast, {
 				kind: 'const',
 				name: 'reroute',

--- a/packages/addons/paraglide/index.ts
+++ b/packages/addons/paraglide/index.ts
@@ -103,13 +103,25 @@ export default defineAddon({
 				from: '$lib/paraglide/runtime',
 				imports: ['deLocalizeUrl']
 			});
+			if (typescript) {
+				imports.addNamed(ast, {
+					from: '@sveltejs/kit',
+					imports: ['Reroute'],
+					isType: true
+				});
+			}
 
-			const expression = common.parseExpression('(request) => deLocalizeUrl(request.url).pathname');
+			const expression = common.parseExpression(`(request) => deLocalizeUrl(request.url).pathname`);
 			const rerouteIdentifier = variables.declaration(ast, {
 				kind: 'const',
 				name: 'reroute',
 				value: expression
 			});
+			if (typescript) {
+				variables.typeAnnotateDeclarator(rerouteIdentifier.declarations[0], {
+					typeName: 'Reroute'
+				});
+			}
 
 			const existingExport = exports.createNamed(ast, {
 				name: 'reroute',


### PR DESCRIPTION
# Motivation

When creating a new project with Paraglide and TS, the generated src/hooks.ts file has a type error:
<img width="749" height="251" alt="screenshot of VS Code where there's a type error underlining the request param" src="https://github.com/user-attachments/assets/90411540-6fcf-4784-8382-a729515c6d16" />


I was able to fix it in my own project by following the [Paraglide docs](https://inlang.com/m/gerre34r/library-inlang-paraglideJs/sveltekit) to add the `reroute: Reroute` type

# Change

This change checks for TS and conditionally imports and adds the type

# Testing

Creating a new project using the locally built dist/bin.js with TS and Paraglide generates a hooks.ts file equivalent to the Paraglide doc with no type error:
```ts
import type { Reroute } from '@sveltejs/kit';
import { deLocalizeUrl } from '$lib/paraglide/runtime';

export const reroute: Reroute = (request) => deLocalizeUrl(request.url).pathname;
```

Creating a new project with Paraglide in JS keeps the existing behavior:
```js
import { deLocalizeUrl } from '$lib/paraglide/runtime';

export const reroute = (request) => deLocalizeUrl(request.url).pathname;
```

Running the Paraglide test passes:
```bash
➜  cli-sfirrin-fork git:(fix/add-type-to-paraglide-reroute) pnpm vitest run packages/addons/_tests/paraglide/test.ts

 RUN  v4.0.0-beta.6 /Users/swf/projects/sveltejs/cli-sfirrin-fork

 ✓  addons  _tests/paraglide/test.ts (2 tests) 11810ms
   ✓ core - kit-js  11571ms
   ✓ core - kit-ts  10964ms

 Test Files  1 passed (1)
      Tests  2 passed (2)
   Start at  10:46:22
   Duration  14.19s (transform 957ms, setup 0ms, collect 1.31s, tests 11.81s, environment 0ms, prepare 73ms)
```

Please let me know if there's anything more to test