### PR TITLE
fix(migrate): `npx sv migrate` fails to run

### DIFF
--- a/.changeset/major-moles-cut.md
+++ b/.changeset/major-moles-cut.md
@@ -2,4 +2,4 @@
 'sv': patch
 ---
 
-fix(migrate): `npx sv migrate` fails to run
+fix(migrate): allow `migrate` to run without specifying a migration arg

--- a/.changeset/major-moles-cut.md
+++ b/.changeset/major-moles-cut.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix(migrate): `npx sv migrate` fails to run

--- a/packages/cli/commands/migrate.ts
+++ b/packages/cli/commands/migrate.ts
@@ -7,15 +7,8 @@ import { forwardExitCode } from '../utils/common.js';
 
 export const migrate = new Command('migrate')
 	.description('a CLI for migrating Svelte(Kit) codebases')
-	.argument('<migration>', 'migration to run')
+	.argument('[migration]', 'migration to run')
 	.option('-C, --cwd <path>', 'path to working directory', process.cwd())
-	.configureHelp({
-		formatHelp() {
-			// we'll pass the responsibility of presenting the help menu over to `svelte-migrate`
-			runMigrate(process.cwd(), ['--help']);
-			return '';
-		}
-	})
 	.action((migration, options) => {
 		runMigrate(options.cwd, [migration]);
 	});


### PR DESCRIPTION
Closes #675 

This has been an oversight in one of the last pull requests for the migrate package