### PR TITLE
docs: add quotes to avoid error executing command with add-on options

### DIFF
--- a/documentation/docs/30-add-ons/05-drizzle.md
+++ b/documentation/docs/30-add-ons/05-drizzle.md
@@ -40,7 +40,7 @@ The SQL client to use, depends on `database`:
 - For `sqlite`: `better-sqlite3`, `libsql`, `turso`
 
 ```sh
-npx sv add drizzle=database:postgresql+client:postgres.js
+npx sv add drizzle="database:postgresql+client:postgres.js"
 ```
 
 Drizzle is compatible with well over a dozen database drivers. We just offer a few of the most common ones here for simplicity, but if you'd like to use another one you can choose one as a placeholder and swap it out for another after setup by choosing from [Drizzle's full list of compatible drivers](https://orm.drizzle.team/docs/connect-overview#next-steps).
@@ -50,5 +50,5 @@ Drizzle is compatible with well over a dozen database drivers. We just offer a f
 Whether to add Docker Compose configuration. Only available for [`database`](#Options-database) `postgresql` or `mysql`
 
 ```sh
-npx sv add drizzle=database:postgresql+client:postgres.js+docker:yes
+npx sv add drizzle="database:postgresql+client:postgres.js+docker:yes"
 ```

--- a/documentation/docs/30-add-ons/15-lucia.md
+++ b/documentation/docs/30-add-ons/15-lucia.md
@@ -22,5 +22,5 @@ npx sv add lucia
 Whether to include demo registration and login pages.
 
 ```sh
-npx sv add lucia=demo:yes
+npx sv add lucia="demo:yes"
 ```

--- a/documentation/docs/30-add-ons/45-sveltekit-adapter.md
+++ b/documentation/docs/30-add-ons/45-sveltekit-adapter.md
@@ -28,5 +28,5 @@ Which SvelteKit adapter to use:
 - `netlify` — [`@sveltejs/adapter-netlify`](/docs/kit/adapter-netlify) allows you to deploy to Netlify
 
 ```sh
-npx sv add sveltekit-adapter=adapter:node
+npx sv add sveltekit-adapter="adapter:node"
 ```


### PR DESCRIPTION
Example source code in documentation show command without quotes in add-on commands.

When running that example code in a Linux terminal, the command fails. Adding the quotes it runs ok.

To avoid developers trying to find the problem, this PR improves documentation.