### PR TITLE
tweak --from-playground docs

### DIFF
--- a/documentation/docs/20-commands/10-sv-create.md
+++ b/documentation/docs/20-commands/10-sv-create.md
@@ -19,7 +19,7 @@ Create a SvelteKit project from a [playground](/playground) URL. This downloads 
 Example:
 
 ```sh
-npx sv create --from-playground=https://svelte.dev/playground/hello-world
+npx sv create --from-playground="https://svelte.dev/playground/hello-world"
 ```
 
 ### `--template <name>`


### PR DESCRIPTION
'Svelte Playground' sounds like branding, and we don't describe it that way elsewhere — it's always just 'the playground'. Adding a link eliminates any lingering ambiguity.

Incidentally, the first thing I tried was a URL with a hash fragment:

```bash
npx sv create --from-playground=https://svelte.dev/playground/hello-world?version=5.38.10#H4sIAAAAAAAAE22MwQrCMBBEf6XMSUEUr6EI3vwH8RDNFANrUprVKKX_7gY8OqeZN7szI_kH4XCiSO5qniR0K4aoDGtsMERhgTvP0M_Y7how_vs6juO2vCja2NUX_uO3nJRJbQb9fX-o2dTvzFmnfCucTk8uF0s-So0pwA1eCpcv0Qw8IZ4AAAA
```

This resulted in an error:

> zsh: no matches found: --from-playground=(url)

It works if you quote the URL, so I think we should do that in the example