### PR TITLE
chore(cli): speedup internal tests v2

### DIFF
--- a/.changeset/lazy-windows-repeat.md
+++ b/.changeset/lazy-windows-repeat.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+chore(cli): speedup internal tests v2

--- a/packages/addons/_tests/_setup/suite.ts
+++ b/packages/addons/_tests/_setup/suite.ts
@@ -124,7 +124,7 @@ export function setupTest<Addons extends AddonMap>(
 		};
 	});
 
-	return { test, variants, prepareServer, flavors };
+	return { test, flavors, prepareServer };
 }
 
 type PrepareServerOptions = {

--- a/packages/addons/_tests/_setup/suite.ts
+++ b/packages/addons/_tests/_setup/suite.ts
@@ -139,9 +139,9 @@ async function prepareServer(
 	{
 		cwd,
 		page,
-		previewCommand = 'npm run preview',
-		buildCommand = 'npm run build',
-		installCommand
+		installCommand,
+		buildCommand = 'pnpm build',
+		previewCommand = 'pnpm preview'
 	}: PrepareServerOptions,
 	afterInstall?: () => Promise<any> | any
 ) {

--- a/packages/addons/_tests/all-addons/test.ts
+++ b/packages/addons/_tests/all-addons/test.ts
@@ -17,7 +17,8 @@ const defaultOptions = officialAddons.reduce<OptionMap<typeof addons>>((options,
 }, {});
 
 const { test, flavors, prepareServer } = setupTest(addons, {
-	kinds: [{ type: 'default', options: defaultOptions }]
+	kinds: [{ type: 'default', options: defaultOptions }],
+	filter: (flavor) => flavor.variant.startsWith('kit')
 });
 
 test.concurrent.for(flavors)('run all addons - $variant', async (flavor, { page, ...ctx }) => {

--- a/packages/addons/_tests/all-addons/test.ts
+++ b/packages/addons/_tests/all-addons/test.ts
@@ -16,11 +16,12 @@ const defaultOptions = officialAddons.reduce<OptionMap<typeof addons>>((options,
 	return options;
 }, {});
 
-const { test, variants, prepareServer } = setupTest(addons);
+const { test, flavors, prepareServer } = setupTest(addons, {
+	kinds: [{ type: 'default', options: defaultOptions }]
+});
 
-const kitOnly = variants.filter((v) => v.startsWith('kit'));
-test.concurrent.for(kitOnly)('run all addons - %s', async (variant, { page, ...ctx }) => {
-	const cwd = await ctx.run(variant, defaultOptions);
+test.concurrent.for(flavors)('run all addons - $variant', async (flavor, { page, ...ctx }) => {
+	const cwd = ctx.run(flavor);
 
 	const { close } = await prepareServer({ cwd, page });
 	// kill server process when we're done

--- a/packages/addons/_tests/devtools-json/test.ts
+++ b/packages/addons/_tests/devtools-json/test.ts
@@ -4,12 +4,15 @@ import devtoolsJson from '../../devtools-json/index.ts';
 import fs from 'node:fs';
 import path from 'node:path';
 
-const { test, variants } = setupTest({ devtoolsJson }, { browser: false });
+const { test, flavors } = setupTest(
+	{ devtoolsJson },
+	{ kinds: [{ type: 'default', options: { devtoolsJson: {} } }], browser: false }
+);
 
-test.concurrent.for(variants)('default - %s', async (variant, ctx) => {
-	const cwd = await ctx.run(variant, { devtoolsJson: {} });
+test.concurrent.for(flavors)('devtools-json $variant', (flavor, ctx) => {
+	const cwd = ctx.run(flavor);
 
-	const ext = variant.includes('ts') ? 'ts' : 'js';
+	const ext = flavor.variant.includes('ts') ? 'ts' : 'js';
 	const viteFile = path.resolve(cwd, `vite.config.${ext}`);
 	const viteContent = fs.readFileSync(viteFile, 'utf8');
 

--- a/packages/addons/_tests/eslint/test.ts
+++ b/packages/addons/_tests/eslint/test.ts
@@ -4,15 +4,16 @@ import { execSync } from 'node:child_process';
 import { setupTest } from '../_setup/suite.ts';
 import eslint from '../../eslint/index.ts';
 
-const { test, variants } = setupTest({ eslint }, { browser: false });
+const { test, flavors } = setupTest(
+	{ eslint },
+	{ kinds: [{ type: 'default', options: { eslint: {} } }], browser: false }
+);
 
-test.concurrent.for(variants)('core - %s', async (variant, { expect, ...ctx }) => {
-	const cwd = await ctx.run(variant, { eslint: {} });
+test.concurrent.for(flavors)('eslint $variant', (flavor, { expect, ...ctx }) => {
+	const cwd = ctx.run(flavor);
 
 	const unlintedFile = 'let foo = "";\nif (Boolean(foo)) {\n//\n}';
 	fs.writeFileSync(path.resolve(cwd, 'src/lib/foo.js'), unlintedFile, 'utf8');
-
-	expect(() => execSync('pnpm install', { cwd, stdio: 'pipe' })).not.toThrow();
 
 	expect(() => execSync('pnpm lint', { cwd, stdio: 'pipe' })).toThrow();
 

--- a/packages/addons/_tests/lucia/test.ts
+++ b/packages/addons/_tests/lucia/test.ts
@@ -2,19 +2,31 @@ import { expect } from '@playwright/test';
 import { setupTest } from '../_setup/suite.ts';
 import lucia from '../../lucia/index.ts';
 import drizzle from '../../drizzle/index.ts';
+import path from 'node:path';
+import fs from 'node:fs';
 
-const { test, variants, prepareServer } = setupTest({ drizzle, lucia });
+const { test, flavors, prepareServer } = setupTest(
+	{ drizzle, lucia },
+	{
+		kinds: [
+			{
+				type: 'default',
+				options: { drizzle: { database: 'sqlite', sqlite: 'libsql' }, lucia: { demo: true } }
+			}
+		],
+		filter: (flavor) => flavor.variant.includes('kit')
+	}
+);
 
-const kitOnly = variants.filter((v) => v.includes('kit'));
-test.concurrent.for(kitOnly)('core - %s', async (variant, { page, ...ctx }) => {
-	const cwd = await ctx.run(variant, {
-		drizzle: { database: 'sqlite', sqlite: 'libsql' },
-		lucia: { demo: true }
-	});
+test.concurrent.for(flavors)('lucia $variant', async (flavor, { page, ...ctx }) => {
+	const cwd = ctx.run(flavor);
 
 	const { close } = await prepareServer({ cwd, page });
 	// kill server process when we're done
 	ctx.onTestFinished(async () => await close());
 
-	expect(true).toBe(true);
+	const ext = flavor.variant.includes('ts') ? 'ts' : 'js';
+	const filePath = path.resolve(cwd, `src/routes/demo/lucia/+page.server.${ext}`);
+	const fileContent = fs.readFileSync(filePath, 'utf8');
+	expect(fileContent).toContain(`export const actions`);
 });

--- a/packages/addons/_tests/mdsvex/test.ts
+++ b/packages/addons/_tests/mdsvex/test.ts
@@ -8,13 +8,16 @@ import { setupTest } from '../_setup/suite.ts';
 import { svxFile } from './fixtures.ts';
 import mdsvex from '../../mdsvex/index.ts';
 
-const { test, variants, prepareServer } = setupTest({ mdsvex });
+const { test, flavors, prepareServer } = setupTest(
+	{ mdsvex },
+	{ kinds: [{ type: 'default', options: { mdsvex: {} } }] }
+);
 
-test.concurrent.for(variants)('core - %s', async (variant, { page, ...ctx }) => {
-	const cwd = await ctx.run(variant, { mdsvex: {} });
+test.concurrent.for(flavors)('mdsvex $variant', async (flavor, { page, ...ctx }) => {
+	const cwd = ctx.run(flavor);
 
 	// ...add test files
-	addFixture(cwd, variant);
+	addFixture(cwd, flavor.variant);
 
 	const { close } = await prepareServer({ cwd, page });
 	// kill server process when we're done

--- a/packages/addons/_tests/paraglide/test.ts
+++ b/packages/addons/_tests/paraglide/test.ts
@@ -1,16 +1,31 @@
 import { expect } from '@playwright/test';
 import { setupTest } from '../_setup/suite.ts';
 import paraglide from '../../paraglide/index.ts';
+import fs from 'node:fs';
+import path from 'node:path';
 
-const { test, variants, prepareServer } = setupTest({ paraglide });
+const langs = ['en', 'fr', 'hu'];
 
-const kitOnly = variants.filter((v) => v.includes('kit'));
-test.concurrent.for(kitOnly)('core - %s', async (variant, { page, ...ctx }) => {
-	const cwd = await ctx.run(variant, { paraglide: { demo: true, languageTags: 'en' } });
+const { test, flavors, prepareServer } = setupTest(
+	{ paraglide },
+	{
+		kinds: [
+			{ type: 'default', options: { paraglide: { demo: true, languageTags: langs.join(',') } } }
+		],
+		filter: (flavor) => flavor.variant.includes('kit')
+	}
+);
+
+test.concurrent.for(flavors)('paraglide $variant', async (flavor, { page, ...ctx }) => {
+	const cwd = ctx.run(flavor);
 
 	const { close } = await prepareServer({ cwd, page });
 	// kill server process when we're done
 	ctx.onTestFinished(async () => await close());
 
-	expect(true).toBe(true);
+	for (const lang of langs) {
+		const filePath = path.resolve(cwd, `src/lib/paraglide/messages/${lang}.js`);
+		const fileContent = fs.readFileSync(filePath, 'utf8');
+		expect(fileContent).toContain(`hello_world`);
+	}
 });

--- a/packages/addons/_tests/playwright/test.ts
+++ b/packages/addons/_tests/playwright/test.ts
@@ -3,12 +3,15 @@ import path from 'node:path';
 import { setupTest } from '../_setup/suite.ts';
 import playwright from '../../playwright/index.ts';
 
-const { test, variants } = setupTest({ playwright }, { browser: false });
+const { test, flavors } = setupTest(
+	{ playwright },
+	{ kinds: [{ type: 'default', options: { playwright: {} } }], browser: false }
+);
 
-test.concurrent.for(variants)('core - %s', async (variant, { expect, ...ctx }) => {
-	const cwd = await ctx.run(variant, { playwright: {} });
+test.concurrent.for(flavors)('playwright $variant', (flavor, { expect, ...ctx }) => {
+	const cwd = ctx.run(flavor);
 
-	const ext = variant.includes('ts') ? 'ts' : 'js';
+	const ext = flavor.variant.includes('ts') ? 'ts' : 'js';
 	const playwrightConfig = path.resolve(cwd, `playwright.config.${ext}`);
 	const configContent = fs.readFileSync(playwrightConfig, 'utf8');
 

--- a/packages/addons/_tests/prettier/test.ts
+++ b/packages/addons/_tests/prettier/test.ts
@@ -9,7 +9,7 @@ const { test, flavors } = setupTest(
 	{ kinds: [{ type: 'default', options: { prettier: {} } }], browser: false }
 );
 
-test.concurrent.for(flavors)('core - %variant', (flavor, { expect, ...ctx }) => {
+test.concurrent.for(flavors)('prettier $variant', (flavor, { expect, ...ctx }) => {
 	const cwd = ctx.run(flavor);
 
 	const unformattedFile = 'const foo = "bar"';

--- a/packages/addons/_tests/prettier/test.ts
+++ b/packages/addons/_tests/prettier/test.ts
@@ -4,15 +4,16 @@ import { execSync } from 'node:child_process';
 import { setupTest } from '../_setup/suite.ts';
 import prettier from '../../prettier/index.ts';
 
-const { test, variants } = setupTest({ prettier }, { browser: false });
+const { test, flavors } = setupTest(
+	{ prettier },
+	{ kinds: [{ type: 'default', options: { prettier: {} } }], browser: false }
+);
 
-test.concurrent.for(variants)('core - %s', async (variant, { expect, ...ctx }) => {
-	const cwd = await ctx.run(variant, { prettier: {} });
+test.concurrent.for(flavors)('core - %variant', (flavor, { expect, ...ctx }) => {
+	const cwd = ctx.run(flavor);
 
 	const unformattedFile = 'const foo = "bar"';
 	fs.writeFileSync(path.resolve(cwd, 'src/lib/foo.js'), unformattedFile, 'utf8');
-
-	expect(() => execSync('pnpm install', { cwd, stdio: 'pipe' })).not.toThrow();
 
 	expect(() => execSync('pnpm lint', { cwd, stdio: 'pipe' })).toThrow();
 

--- a/packages/addons/_tests/storybook/test.ts
+++ b/packages/addons/_tests/storybook/test.ts
@@ -7,7 +7,10 @@ import storybook from '../../storybook/index.ts';
 import eslint from '../../eslint/index.ts';
 
 // we're including the `eslint` add-on to prevent `storybook` from modifying this repo's `eslint.config.js`
-const { test, variants, prepareServer } = setupTest({ storybook, eslint });
+const { test, flavors, prepareServer } = setupTest(
+	{ storybook, eslint },
+	{ kinds: [{ type: 'default', options: { storybook: {}, eslint: {} } }] }
+);
 
 let port = 6006;
 const CI = Boolean(process.env.CI);
@@ -19,22 +22,18 @@ beforeAll(() => {
 	}
 });
 
-test.for(variants)(
-	'storybook loaded - %s',
-	{ concurrent: !CI },
-	async (variant, { page, ...ctx }) => {
-		const cwd = await ctx.run(variant, { storybook: {}, eslint: {} });
+test.for(flavors)('storybook $variant', { concurrent: !CI }, async (flavor, { page, ...ctx }) => {
+	const cwd = ctx.run(flavor);
 
-		const { close } = await prepareServer({
-			cwd,
-			page,
-			previewCommand: `pnpm storybook -p ${++port} --ci`,
-			buildCommand: ''
-		});
-		// kill server process when we're done
-		ctx.onTestFinished(async () => await close());
+	const { close } = await prepareServer({
+		cwd,
+		page,
+		previewCommand: `pnpm storybook -p ${++port} --ci`,
+		buildCommand: ''
+	});
+	// kill server process when we're done
+	ctx.onTestFinished(async () => await close());
 
-		expect(page.locator('main .sb-bar')).toBeTruthy();
-		expect(page.locator('#storybook-preview-wrapper')).toBeTruthy();
-	}
-);
+	expect(page.locator('main .sb-bar')).toBeTruthy();
+	expect(page.locator('#storybook-preview-wrapper')).toBeTruthy();
+});

--- a/packages/addons/_tests/sveltekit-adapter/test.ts
+++ b/packages/addons/_tests/sveltekit-adapter/test.ts
@@ -5,31 +5,33 @@ import sveltekitAdapter from '../../sveltekit-adapter/index.ts';
 import { setupTest } from '../_setup/suite.ts';
 
 const addonId = sveltekitAdapter.id;
-const { test, variants, prepareServer } = setupTest({ [addonId]: sveltekitAdapter });
+const { test, flavors, prepareServer } = setupTest(
+	{ [addonId]: sveltekitAdapter },
+	{
+		kinds: [
+			{ type: 'node', options: { [addonId]: { adapter: 'node' } } },
+			{ type: 'auto', options: { [addonId]: { adapter: 'auto' } } }
+		],
+		filter: (flavor) => flavor.variant.includes('kit')
+	}
+);
 
-const kitOnly = variants.filter((v) => v.includes('kit'));
-test.concurrent.for(kitOnly)('core - %s', async (variant, { page, ...ctx }) => {
-	const cwd = await ctx.run(variant, { [addonId]: { adapter: 'node' } });
-
-	const { close } = await prepareServer({ cwd, page });
-	// kill server process when we're done
-	ctx.onTestFinished(async () => await close());
-
-	expect(await readFile(join(cwd, 'svelte.config.js'), 'utf8')).not.toMatch('adapter-auto');
-	expect(await readFile(join(cwd, 'svelte.config.js'), 'utf8')).not.toMatch(
-		'adapter-auto only supports some environments'
-	);
-});
-
-test.concurrent.for(kitOnly)('core - %s', async (variant, { page, ...ctx }) => {
-	const cwd = await ctx.run(variant, { [addonId]: { adapter: 'auto' } });
+test.concurrent.for(flavors)('adapter $kind.type $variant', async (flavor, { page, ...ctx }) => {
+	const cwd = ctx.run(flavor);
 
 	const { close } = await prepareServer({ cwd, page });
 	// kill server process when we're done
 	ctx.onTestFinished(async () => await close());
 
-	expect(await readFile(join(cwd, 'svelte.config.js'), 'utf8')).toMatch('adapter-auto');
-	expect(await readFile(join(cwd, 'svelte.config.js'), 'utf8')).toMatch(
-		'adapter-auto only supports some environments'
-	);
+	if (flavor.kind.type === 'node') {
+		expect(await readFile(join(cwd, 'svelte.config.js'), 'utf8')).not.toMatch('adapter-auto');
+		expect(await readFile(join(cwd, 'svelte.config.js'), 'utf8')).not.toMatch(
+			'adapter-auto only supports some environments'
+		);
+	} else if (flavor.kind.type === 'auto') {
+		expect(await readFile(join(cwd, 'svelte.config.js'), 'utf8')).toMatch('adapter-auto');
+		expect(await readFile(join(cwd, 'svelte.config.js'), 'utf8')).toMatch(
+			'adapter-auto only supports some environments'
+		);
+	}
 });

--- a/packages/addons/_tests/tailwindcss/test.ts
+++ b/packages/addons/_tests/tailwindcss/test.ts
@@ -3,38 +3,40 @@ import { setupTest } from '../_setup/suite.ts';
 import { addFixture } from './fixtures.ts';
 import tailwindcss from '../../tailwindcss/index.ts';
 
-const { test, variants, prepareServer } = setupTest({ tailwindcss });
+const { test, prepareServer, flavors } = setupTest(
+	{ tailwindcss },
+	{
+		kinds: [
+			{ type: 'none', options: { tailwindcss: { plugins: [] } } },
+			{ type: 'typography', options: { tailwindcss: { plugins: ['typography'] } } }
+		]
+	}
+);
 
-test.concurrent.for(variants)('none - %s', async (variant, { page, ...ctx }) => {
-	const cwd = await ctx.run(variant, { tailwindcss: { plugins: [] } });
+test.concurrent.for(flavors)(
+	'tailwindcss $kind.type $variant ',
+	async (flavor, { page, ...ctx }) => {
+		const cwd = ctx.run(flavor);
 
-	// ...add test files
-	addFixture(cwd, variant);
+		// ...add test files
+		addFixture(cwd, flavor.variant);
 
-	const { close } = await prepareServer({ cwd, page });
-	// kill server process when we're done
-	ctx.onTestFinished(async () => await close());
+		const { close } = await prepareServer({ cwd, page });
+		// kill server process when we're done
+		ctx.onTestFinished(async () => await close());
 
-	const el = page.getByTestId('base');
-	await expect(el).toHaveCSS('background-color', 'oklch(0.446 0.043 257.281)');
-	await expect(el).toHaveCSS('border-color', 'oklch(0.985 0.002 247.839)');
-	await expect(el).toHaveCSS('border-width', '4px');
-	await expect(el).toHaveCSS('margin-top', '4px');
-});
-
-test.concurrent.for(variants)('typography - %s', async (variant, { page, ...ctx }) => {
-	const cwd = await ctx.run(variant, { tailwindcss: { plugins: ['typography'] } });
-
-	// ...add files
-	addFixture(cwd, variant);
-
-	const { close } = await prepareServer({ cwd, page });
-	// kill server process when we're done
-	ctx.onTestFinished(async () => await close());
-
-	const el = page.getByTestId('typography');
-	await expect(el).toHaveCSS('font-size', '18px');
-	await expect(el).toHaveCSS('line-height', '28px');
-	await expect(el).toHaveCSS('text-align', 'right');
-	await expect(el).toHaveCSS('text-decoration-line', 'line-through');
-});
+		if (flavor.kind.type === 'none') {
+			const el = page.getByTestId('base');
+			await expect(el).toHaveCSS('background-color', 'oklch(0.446 0.043 257.281)');
+			await expect(el).toHaveCSS('border-color', 'oklch(0.985 0.002 247.839)');
+			await expect(el).toHaveCSS('border-width', '4px');
+			await expect(el).toHaveCSS('margin-top', '4px');
+		} else if (flavor.kind.type === 'typography') {
+			const el = page.getByTestId('typography');
+			await expect(el).toHaveCSS('font-size', '18px');
+			await expect(el).toHaveCSS('line-height', '28px');
+			await expect(el).toHaveCSS('text-align', 'right');
+			await expect(el).toHaveCSS('text-decoration-line', 'line-through');
+		}
+	}
+);

--- a/packages/addons/_tests/tailwindcss/test.ts
+++ b/packages/addons/_tests/tailwindcss/test.ts
@@ -14,7 +14,7 @@ const { test, prepareServer, flavors } = setupTest(
 );
 
 test.concurrent.for(flavors)(
-	'tailwindcss $kind.type $variant ',
+	'tailwindcss $kind.type $variant',
 	async (flavor, { page, ...ctx }) => {
 		const cwd = ctx.run(flavor);
 

--- a/packages/addons/_tests/vitest/test.ts
+++ b/packages/addons/_tests/vitest/test.ts
@@ -2,10 +2,13 @@ import { execSync } from 'node:child_process';
 import { setupTest } from '../_setup/suite.ts';
 import vitest from '../../vitest-addon/index.ts';
 
-const { test, variants } = setupTest({ vitest }, { browser: false });
+const { test, flavors } = setupTest(
+	{ vitest },
+	{ kinds: [{ type: 'default', options: { vitest: {} } }], browser: false }
+);
 
-test.concurrent.for(variants)('core - %s', async (variant, { expect, ...ctx }) => {
-	const cwd = await ctx.run(variant, { vitest: {} });
+test.concurrent.for(flavors)('vitest %variant', (flavor, { expect, ...ctx }) => {
+	const cwd = ctx.run(flavor);
 
 	expect(() => execSync('pnpm install', { cwd, stdio: 'pipe' })).not.toThrow();
 

--- a/packages/addons/_tests/vitest/test.ts
+++ b/packages/addons/_tests/vitest/test.ts
@@ -7,7 +7,7 @@ const { test, flavors } = setupTest(
 	{ kinds: [{ type: 'default', options: { vitest: {} } }], browser: false }
 );
 
-test.concurrent.for(flavors)('vitest %variant', (flavor, { expect, ...ctx }) => {
+test.concurrent.for(flavors)('vitest $variant', (flavor, { expect, ...ctx }) => {
 	const cwd = ctx.run(flavor);
 
 	expect(() => execSync('pnpm install', { cwd, stdio: 'pipe' })).not.toThrow();

--- a/packages/addons/tailwindcss/index.ts
+++ b/packages/addons/tailwindcss/index.ts
@@ -37,7 +37,6 @@ export default defineAddon({
 
 		sv.devDependency('tailwindcss', '^4.0.0');
 		sv.devDependency('@tailwindcss/vite', '^4.0.0');
-		sv.pnpmBuildDependency('@tailwindcss/oxide');
 
 		if (prettierInstalled) sv.devDependency('prettier-plugin-tailwindcss', '^0.6.11');
 

--- a/packages/addons/tailwindcss/index.ts
+++ b/packages/addons/tailwindcss/index.ts
@@ -37,6 +37,7 @@ export default defineAddon({
 
 		sv.devDependency('tailwindcss', '^4.0.0');
 		sv.devDependency('@tailwindcss/vite', '^4.0.0');
+		sv.pnpmBuildDependency('@tailwindcss/oxide');
 
 		if (prettierInstalled) sv.devDependency('prettier-plugin-tailwindcss', '^0.6.11');
 

--- a/packages/cli/lib/testing.ts
+++ b/packages/cli/lib/testing.ts
@@ -4,7 +4,6 @@ import process from 'node:process';
 import degit from 'degit';
 import { exec } from 'tinyexec';
 import { create } from '@sveltejs/create';
-import pstree, { type PS } from 'ps-tree';
 
 export { addPnpmBuildDependencies } from '../utils/package-manager.ts';
 export type ProjectVariant = 'kit-js' | 'kit-ts' | 'vite-js' | 'vite-ts';
@@ -122,31 +121,18 @@ export async function startPreview({
 	});
 }
 
-async function getProcessTree(pid: number) {
-	return new Promise<readonly PS[]>((res, rej) => {
-		pstree(pid, (err, children) => {
-			if (err) rej(err);
-			res(children);
-		});
-	});
-}
-
 async function terminate(pid: number) {
-	const children = await getProcessTree(pid);
-	// the process tree is ordered from parents -> children,
-	// so we'll iterate in the reverse order to terminate the children first
-	for (let i = children.length - 1; i >= 0; i--) {
-		const child = children[i];
-		const pid = Number(child.PID);
-		kill(pid);
-	}
-	kill(pid);
-}
-
-function kill(pid: number) {
 	try {
-		process.kill(pid);
+		if (process.platform === 'win32') {
+			await exec(`taskkill /pid ${pid} /T /F`); // on windows, use taskkill to terminate the process tree
+		} else {
+			process.kill(-pid, 'SIGTERM'); // Kill the process group
+		}
 	} catch {
-		// this can happen if a process has been automatically terminated.
+		try {
+			process.kill(pid, 'SIGTERM'); // Kill just the process
+		} catch {
+			// Process might already be terminated
+		}
 	}
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,13 +35,11 @@
 		"@sveltejs/cli-core": "workspace:*",
 		"@sveltejs/create": "workspace:*",
 		"@types/degit": "^2.8.6",
-		"@types/ps-tree": "^1.1.6",
 		"commander": "^13.1.0",
 		"degit": "^2.8.4",
 		"empathic": "^1.1.0",
 		"package-manager-detector": "^0.2.11",
 		"picocolors": "^1.1.1",
-		"ps-tree": "^1.2.0",
 		"tinyexec": "^0.3.2",
 		"valibot": "^0.41.0"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,9 +112,6 @@ importers:
       '@types/degit':
         specifier: ^2.8.6
         version: 2.8.6
-      '@types/ps-tree':
-        specifier: ^1.1.6
-        version: 1.1.6
       commander:
         specifier: ^13.1.0
         version: 13.1.0
@@ -130,9 +127,6 @@ importers:
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
-      ps-tree:
-        specifier: ^1.2.0
-        version: 1.2.0
       tinyexec:
         specifier: ^0.3.2
         version: 0.3.2
@@ -889,9 +883,6 @@ packages:
   '@types/prompts@2.4.9':
     resolution: {integrity: sha512-qTxFi6Buiu8+50/+3DGIWLHM6QuWsEKugJnnP6iv2Mc4ncxE4A/OJkjuVOA+5X0X1S/nq5VJRa8Lu+nwcvbrKA==}
 
-  '@types/ps-tree@1.1.6':
-    resolution: {integrity: sha512-PtrlVaOaI44/3pl3cvnlK+GxOM3re2526TJvPvh7W+keHIXdV4TE0ylpPBAcvFQCbGitaTXwL9u+RF7qtVeazQ==}
-
   '@types/semver@7.7.0':
     resolution: {integrity: sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==}
 
@@ -1189,9 +1180,6 @@ packages:
     resolution: {integrity: sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==}
     engines: {node: '>=12'}
 
-  duplexer@0.1.2:
-    resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
-
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -1322,9 +1310,6 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
-  event-stream@3.3.4:
-    resolution: {integrity: sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g==}
-
   expect-type@1.2.2:
     resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
     engines: {node: '>=12.0.0'}
@@ -1389,9 +1374,6 @@ packages:
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
-
-  from@0.1.7:
-    resolution: {integrity: sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==}
 
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
@@ -1602,9 +1584,6 @@ packages:
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
-  map-stream@0.1.0:
-    resolution: {integrity: sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==}
-
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -1737,9 +1716,6 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
-  pause-stream@0.0.11:
-    resolution: {integrity: sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==}
-
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1831,11 +1807,6 @@ packages:
   prettier@3.5.3:
     resolution: {integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==}
     engines: {node: '>=14'}
-    hasBin: true
-
-  ps-tree@1.2.0:
-    resolution: {integrity: sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==}
-    engines: {node: '>= 0.10'}
     hasBin: true
 
   punycode@2.3.1:
@@ -1935,9 +1906,6 @@ packages:
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
 
-  split@0.3.3:
-    resolution: {integrity: sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==}
-
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
@@ -1946,9 +1914,6 @@ packages:
 
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
-
-  stream-combiner@0.0.4:
-    resolution: {integrity: sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -2017,9 +1982,6 @@ packages:
 
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
-
-  through@2.3.8:
-    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
   tiny-glob@0.2.9:
     resolution: {integrity: sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==}
@@ -2840,8 +2802,6 @@ snapshots:
       '@types/node': 18.19.112
       kleur: 3.0.3
 
-  '@types/ps-tree@1.1.6': {}
-
   '@types/semver@7.7.0': {}
 
   '@typescript-eslint/eslint-plugin@8.34.1(@typescript-eslint/parser@8.34.1(eslint@9.29.0)(typescript@5.8.3))(eslint@9.29.0)(typescript@5.8.3)':
@@ -3138,8 +3098,6 @@ snapshots:
 
   dotenv@16.5.0: {}
 
-  duplexer@0.1.2: {}
-
   eastasianwidth@0.2.0: {}
 
   emoji-regex@8.0.0: {}
@@ -3320,16 +3278,6 @@ snapshots:
 
   esutils@2.0.3: {}
 
-  event-stream@3.3.4:
-    dependencies:
-      duplexer: 0.1.2
-      from: 0.1.7
-      map-stream: 0.1.0
-      pause-stream: 0.0.11
-      split: 0.3.3
-      stream-combiner: 0.0.4
-      through: 2.3.8
-
   expect-type@1.2.2: {}
 
   extendable-error@0.1.7: {}
@@ -3397,8 +3345,6 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
-
-  from@0.1.7: {}
 
   fs-extra@7.0.1:
     dependencies:
@@ -3584,8 +3530,6 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  map-stream@0.1.0: {}
-
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
@@ -3702,10 +3646,6 @@ snapshots:
 
   pathval@2.0.1: {}
 
-  pause-stream@0.0.11:
-    dependencies:
-      through: 2.3.8
-
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -3769,10 +3709,6 @@ snapshots:
   prettier@2.8.8: {}
 
   prettier@3.5.3: {}
-
-  ps-tree@1.2.0:
-    dependencies:
-      event-stream: 3.3.4
 
   punycode@2.3.1: {}
 
@@ -3888,19 +3824,11 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  split@0.3.3:
-    dependencies:
-      through: 2.3.8
-
   sprintf-js@1.0.3: {}
 
   stackback@0.0.2: {}
 
   std-env@3.9.0: {}
-
-  stream-combiner@0.0.4:
-    dependencies:
-      duplexer: 0.1.2
 
   string-width@4.2.3:
     dependencies:
@@ -3987,8 +3915,6 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
-
-  through@2.3.8: {}
 
   tiny-glob@0.2.9:
     dependencies:


### PR DESCRIPTION
Proposal to change how tests are organized _(to speedup tests again ^^)_

- `variant` + `kind` = `flavor`
- `setupTest` prepare the test mono repo with all flavors and only one install is needed
- remote `ps-tree` dep