### PR TITLE
fix push to `kit-template-default`

### DIFF
--- a/packages/create/scripts/update-template-repo-contents.js
+++ b/packages/create/scripts/update-template-repo-contents.js
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { create } from '../dist/index.js';
+import { create } from '../../cli/dist/lib/index.js';
 
 const repo = /** @type {string} */ (process.argv[2]);
 

--- a/packages/create/scripts/update-template-repo.sh
+++ b/packages/create/scripts/update-template-repo.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+echo "UPDATING TEMPLATE REPO: https://github.com/sveltejs/kit-template-default..."
+
 set -e
 
 get_abs_filename() {


### PR DESCRIPTION
Looking at https://github.com/sveltejs/cli/actions/runs/18222249563/job/51884670580 there is an issue with the new build. (it's internal thing)

I addapted the script. Should work now.

But looking https://github.com/sveltejs/kit-template-default last deployed was `0.8.21` ! _(the one after is `0.9`)_ Maybe an issue with the `bot` permissions?