### PR TITLE
fix(cli): `+layout.svelte` doesn't use optional chaining now

### DIFF
--- a/.changeset/tired-stars-lose.md
+++ b/.changeset/tired-stars-lose.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix(cli): `+layout.svelte` doesn't use optional chaining now

--- a/packages/create/shared/+playground/src/lib/PlaygroundLayout.svelte
+++ b/packages/create/shared/+playground/src/lib/PlaygroundLayout.svelte
@@ -64,7 +64,7 @@
 	</nav>
 
 	<main class="content">
-		{@render children?.()}
+		{@render children()}
 	</main>
 </div>
 

--- a/packages/create/templates/minimal/src/routes/+layout.svelte
+++ b/packages/create/templates/minimal/src/routes/+layout.svelte
@@ -8,4 +8,4 @@
 	<link rel="icon" href={favicon} />
 </svelte:head>
 
-{@render children?.()}
+{@render children()}


### PR DESCRIPTION
Closes: #752