### PR TITLE
fix: use correct file association for tailwind css

### DIFF
--- a/packages/addons/tailwindcss/index.ts
+++ b/packages/addons/tailwindcss/index.ts
@@ -134,7 +134,7 @@ export default defineAddon({
 			const { data, generateCode } = parseJson(content);
 
 			data['files.associations'] ??= {};
-			data['files.associations']['*.css'] = 'tailwind';
+			data['files.associations']['*.css'] = 'tailwindcss';
 
 			return generateCode();
 		});


### PR DESCRIPTION
The correct language id for tailwind css is `tailwindcss`, not `tailwind`. This PR corrects that. 

The language id is specified by the tailwindcss-intellisense`plugin
https://github.com/tailwindlabs/tailwindcss-intellisense/blob/072a6c96e8067805e4b9b916e7b382d30e2ec0d7/packages/vscode-tailwindcss/package.json#L47