### PR TITLE
chore: add sv script from contributing.md

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 		"dev": "tsdown -w",
 		"format": "pnpm --parallel format",
 		"lint": "pnpm --parallel lint && eslint --cache --cache-location node_modules/.eslintcache",
+		"sv": "pnpm --filter sv run sv",
 		"test": "vitest run --silent",
 		"test:ui": "vitest --ui",
 		"update-deps": "node ./scripts/update-dependencies.js && pnpm format"

--- a/packages/sv/package.json
+++ b/packages/sv/package.json
@@ -13,7 +13,8 @@
 	"scripts": {
 		"check": "tsgo",
 		"format": "pnpm lint --write",
-		"lint": "prettier --check . --config ../../prettier.config.js --ignore-path ../../.gitignore --ignore-path .gitignore --ignore-path ../../.prettierignore"
+		"lint": "prettier --check . --config ../../prettier.config.js --ignore-path ../../.gitignore --ignore-path .gitignore --ignore-path ../../.prettierignore",
+		"sv": "node dist/bin.mjs"
 	},
 	"files": [
 		"dist"


### PR DESCRIPTION
The CONTRIBUTING.md mentions a `sv` script, which doesn't exist, so this adds it. I'm not 100% sure whether this ever actually existed, or if there was some behavior in pnpm that made running this in the `packages/sv` work without adding a script called `sv` (from what I can tell it doesn't, so the script is necessary).

https://github.com/sveltejs/cli/blob/88d5c9d244a9ae6ece582b6437be00fac9beee86/CONTRIBUTING.md?plain=1#L46-L50

The only alternative to this I can think would be to change the CONTRIBUTING.md to tell users to run `node dist/bin.mjs` in `packages/sv` themselves.