### PR TITLE
chore: update sv package description

### DIFF
--- a/packages/sv/package.json
+++ b/packages/sv/package.json
@@ -2,7 +2,7 @@
 	"name": "sv",
 	"version": "0.10.8",
 	"type": "module",
-	"description": "A CLI for creating and updating SvelteKit projects",
+	"description": "A command line interface (CLI) for creating and maintaining Svelte applications",
 	"license": "MIT",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
I noticed this is a little outdated since it only references SvelteKit, so I updated it with the same line from the sv README.md

https://github.com/sveltejs/cli/blob/88d5c9d244a9ae6ece582b6437be00fac9beee86/packages/sv/README.md?plain=1#L3