### PR TITLE
fix: update build instruction from 'npm pack' to 'npm prepack'

### DIFF
--- a/packages/sv/lib/create/shared/+library/README.md
+++ b/packages/sv/lib/create/shared/+library/README.md
@@ -34,7 +34,7 @@ Everything inside `src/lib` is part of your library, everything inside `src/rout
 To build your library:
 
 ```sh
-npm pack
+npm prepack
 ```
 
 To create a production version of your showcase app:


### PR DESCRIPTION
Updates the build instruction in the library template's README from `npm pack` to `npm prepack`. 

The prepack script seems to be the correct command to prepare the library for distribution.