### PR TITLE
chore: drop direct deps on `acorn` and `@sveltejs/acorn-typescript`

### DIFF
--- a/packages/sv/lib/core/tooling/index.ts
+++ b/packages/sv/lib/core/tooling/index.ts
@@ -3,12 +3,11 @@ import type { TsEstree } from './js/ts-estree.ts';
 import * as fleece from 'silver-fleece';
 import { print as esrapPrint } from 'esrap';
 import ts from 'esrap/languages/ts';
-import * as acorn from 'acorn';
-import { tsPlugin } from '@sveltejs/acorn-typescript';
 import { parse as svelteParse, type AST as SvelteAst, print as sveltePrint } from 'svelte/compiler';
 import * as yaml from 'yaml';
 import type { BaseNode } from 'estree';
 import * as toml from 'smol-toml';
+import { ensureScript } from './svelte/index.ts';
 
 export {
 	// ast walker
@@ -23,45 +22,21 @@ export type {
 	TsEstree as AstTypes
 };
 
-/**
- * Parses as string to an AST. Code below is taken from `esrap` to ensure compatibilty.
- * https://github.com/sveltejs/esrap/blob/920491535d31484ac5fae2327c7826839d851aed/test/common.js#L14
- */
 export function parseScript(content: string): {
 	ast: TsEstree.Program;
 	comments: Comments;
 } {
-	const acornTs = acorn.Parser.extend(tsPlugin());
+	const svelteAst = parseSvelte(`<script lang="ts">${content}</script>`);
+	const ast = ensureScript(svelteAst);
+
 	const comments = new Comments();
 	const internal = transformToInternal(comments);
+	internal.original.push(...svelteAst.comments);
 
-	const ast = acornTs.parse(content, {
-		ecmaVersion: 'latest',
-		sourceType: 'module',
-		locations: true,
-		onComment: (block, value, start, end, startLoc, endLoc) => {
-			if (block && /\n/.test(value)) {
-				let a = start;
-				while (a > 0 && content[a - 1] !== '\n') a -= 1;
-
-				let b = a;
-				while (/[ \t]/.test(content[b])) b += 1;
-
-				const indentation = content.slice(a, b);
-				value = value.replace(new RegExp(`^${indentation}`, 'gm'), '');
-			}
-
-			internal.original.push({
-				type: block ? 'Block' : 'Line',
-				value,
-				start,
-				end,
-				loc: { start: startLoc as TsEstree.Position, end: endLoc as TsEstree.Position }
-			});
-		}
-	}) as TsEstree.Program;
-
-	return { ast, comments };
+	return {
+		ast,
+		comments
+	};
 }
 
 export function serializeScript(
@@ -69,6 +44,9 @@ export function serializeScript(
 	comments?: Comments,
 	previousContent?: string
 ): string {
+	// we could theoretically use `printSvelte` here, but esrap gives us more control over the output
+	// and `svelte` is using `esrap` under the hood anyway.
+
 	const internal = transformToInternal(comments);
 	const { code } = esrapPrint(
 		// @ts-expect-error we are still using `estree` while `esrap` is using `@typescript-eslint/types`
@@ -246,7 +224,7 @@ export function serializeYaml(data: ReturnType<typeof yaml.parseDocument>): stri
 export type CommentType = { type: 'Line' | 'Block'; value: string };
 
 export class Comments {
-	private original: TsEstree.Comment[];
+	private original: SvelteAst.JSComment[];
 	private leading: WeakMap<BaseNode, CommentType[]>;
 	private trailing: WeakMap<BaseNode, CommentType[]>;
 

--- a/packages/sv/package.json
+++ b/packages/sv/package.json
@@ -35,12 +35,10 @@
 	},
 	"devDependencies": {
 		"@clack/prompts": "1.0.0-alpha.1",
-		"@sveltejs/acorn-typescript": "^1.0.8",
 		"@types/degit": "^2.8.6",
 		"@types/estree": "^1.0.8",
 		"@types/gitignore-parser": "^0.0.3",
 		"@types/ps-tree": "^1.1.6",
-		"acorn": "^8.15.0",
 		"commander": "^14.0.2",
 		"decircular": "^1.0.0",
 		"dedent": "^1.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,9 +130,6 @@ importers:
       '@clack/prompts':
         specifier: 1.0.0-alpha.1
         version: 1.0.0-alpha.1
-      '@sveltejs/acorn-typescript':
-        specifier: ^1.0.8
-        version: 1.0.8(acorn@8.15.0)
       '@types/degit':
         specifier: ^2.8.6
         version: 2.8.6
@@ -145,9 +142,6 @@ importers:
       '@types/ps-tree':
         specifier: ^1.1.6
         version: 1.1.6
-      acorn:
-        specifier: ^8.15.0
-        version: 8.15.0
       commander:
         specifier: ^14.0.2
         version: 14.0.2


### PR DESCRIPTION
Relates #828 

This is more or less only a maintainability change. `svelte` under the hood still uses `acorn` and `@sveltejs/acorn-typescript`, but this makes us independent of this implementation detail.