### PR TITLE
chore(cli): remove `vitePreprocess` in all default templates

### DIFF
--- a/.changeset/jolly-dingos-boil.md
+++ b/.changeset/jolly-dingos-boil.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+chore(cli): remove `vitePreprocess` in all default templates

--- a/packages/sv/lib/cli/tests/snapshots/create-only/svelte.config.js
+++ b/packages/sv/lib/cli/tests/snapshots/create-only/svelte.config.js
@@ -1,12 +1,7 @@
 import adapter from '@sveltejs/adapter-auto';
-import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	// Consult https://svelte.dev/docs/kit/integrations
-	// for more information about preprocessors
-	preprocess: vitePreprocess(),
-
 	kit: {
 		// adapter-auto only supports some environments, see https://svelte.dev/docs/kit/adapter-auto for a list.
 		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.

--- a/packages/sv/lib/cli/tests/snapshots/create-with-all-addons/svelte.config.js
+++ b/packages/sv/lib/cli/tests/snapshots/create-with-all-addons/svelte.config.js
@@ -1,14 +1,10 @@
 import { mdsvex } from 'mdsvex';
 import adapter from '@sveltejs/adapter-node';
-import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	// Consult https://svelte.dev/docs/kit/integrations
-	// for more information about preprocessors
-	preprocess: [vitePreprocess(), mdsvex()],
-
 	kit: { adapter: adapter() },
+	preprocess: [mdsvex()],
 	extensions: ['.svelte', '.svx']
 };
 

--- a/packages/sv/lib/create/shared/+demo+checkjs/svelte.config.js
+++ b/packages/sv/lib/create/shared/+demo+checkjs/svelte.config.js
@@ -1,12 +1,7 @@
 import adapter from '@sveltejs/adapter-auto';
-import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	// Consult https://svelte.dev/docs/kit/integrations
-	// for more information about preprocessors
-	preprocess: vitePreprocess(),
-
 	kit: {
 		// adapter-auto only supports some environments, see https://svelte.dev/docs/kit/adapter-auto for a list.
 		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.

--- a/packages/sv/lib/create/shared/+demo+typescript/svelte.config.js
+++ b/packages/sv/lib/create/shared/+demo+typescript/svelte.config.js
@@ -1,12 +1,7 @@
 import adapter from '@sveltejs/adapter-auto';
-import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	// Consult https://svelte.dev/docs/kit/integrations
-	// for more information about preprocessors
-	preprocess: vitePreprocess(),
-
 	kit: {
 		// adapter-auto only supports some environments, see https://svelte.dev/docs/kit/adapter-auto for a list.
 		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.

--- a/packages/sv/lib/create/shared/+typescript/svelte.config.js
+++ b/packages/sv/lib/create/shared/+typescript/svelte.config.js
@@ -1,12 +1,7 @@
 import adapter from '@sveltejs/adapter-auto';
-import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	// Consult https://svelte.dev/docs/kit/integrations
-	// for more information about preprocessors
-	preprocess: vitePreprocess(),
-
 	kit: {
 		// adapter-auto only supports some environments, see https://svelte.dev/docs/kit/adapter-auto for a list.
 		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.

--- a/packages/sv/lib/create/templates/demo/svelte.config.js
+++ b/packages/sv/lib/create/templates/demo/svelte.config.js
@@ -1,14 +1,9 @@
 import adapter from '@sveltejs/adapter-auto';
-import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 // This config is ignored and replaced with one of the configs in the shared folder when a project is created.
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	// Consult https://svelte.dev/docs/kit/integrations
-	// for more information about preprocessors
-	preprocess: vitePreprocess(),
-
 	kit: {
 		adapter: adapter()
 	}


### PR DESCRIPTION
Closes: #210

Doc update: https://github.com/sveltejs/kit/pull/15185
I think that most of projects don't need it (I even use decorators in my project... But not in svelte files!)