### PR TITLE
chore: bump `globals` as major version increment does not impact us

### DIFF
--- a/.changeset/soft-cameras-cough.md
+++ b/.changeset/soft-cameras-cough.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+chore: bump `globals` as major version increment does not impact us

--- a/packages/sv/lib/addons/eslint.ts
+++ b/packages/sv/lib/addons/eslint.ts
@@ -13,7 +13,7 @@ export default defineAddon({
 		sv.devDependency('eslint', '^9.39.1');
 		sv.devDependency('@eslint/compat', '^1.4.0');
 		sv.devDependency('eslint-plugin-svelte', '^3.13.1');
-		sv.devDependency('globals', '^16.5.0');
+		sv.devDependency('globals', '^17.1.0');
 		sv.devDependency('@eslint/js', '^9.39.1');
 		sv.devDependency('@types/node', getNodeTypesVersion());
 

--- a/packages/sv/lib/cli/tests/snapshots/create-with-all-addons/package.json
+++ b/packages/sv/lib/cli/tests/snapshots/create-with-all-addons/package.json
@@ -40,7 +40,7 @@
 		"eslint": "^9.39.1",
 		"eslint-config-prettier": "^10.1.8",
 		"eslint-plugin-svelte": "^3.13.1",
-		"globals": "^16.5.0",
+		"globals": "^17.1.0",
 		"mdsvex": "^0.12.6",
 		"playwright": "^1.57.0",
 		"prettier": "^3.7.4",


### PR DESCRIPTION
`globals` 16 -> 17 only changes `audioWorklet`, which `sv` doesn't use anywhere.

Closes #885 
