### PR TITLE
chore: using `test.beforeAll` instead of `beforeAll`

### DIFF
--- a/packages/sv/lib/addons/_tests/_setup/suite.ts
+++ b/packages/sv/lib/addons/_tests/_setup/suite.ts
@@ -48,7 +48,7 @@ export function setupTest<Addons extends AddonMap>(
 		}
 	}
 	let testName: string;
-	beforeAll(async ({ name }) => {
+	test.beforeAll(async ({ name }) => {
 		testName = path.dirname(name).split('/').at(-1)!;
 
 		// constructs a builder to create test projects

--- a/packages/sv/lib/cli/tests/snapshots/@my-org/sv/tests/setup/suite.js
+++ b/packages/sv/lib/cli/tests/snapshots/@my-org/sv/tests/setup/suite.js
@@ -49,7 +49,7 @@ export function setupTest(addons, options) {
 	}
 	/** @type {string} */
 	let testName;
-	beforeAll(async ({ name }) => {
+	test.beforeAll(async ({ name }) => {
 		testName = path.dirname(name).split('/').at(-1) ?? '';
 
 		// constructs a builder to create test projects

--- a/packages/sv/lib/create/templates/addon/tests/setup/suite.js
+++ b/packages/sv/lib/create/templates/addon/tests/setup/suite.js
@@ -49,7 +49,7 @@ export function setupTest(addons, options) {
 	}
 	/** @type {string} */
 	let testName;
-	beforeAll(async ({ name }) => {
+	test.beforeAll(async ({ name }) => {
 		testName = path.dirname(name).split('/').at(-1) ?? '';
 
 		// constructs a builder to create test projects


### PR DESCRIPTION
Fixing https://github.com/vitest-dev/vitest-ecosystem-ci/actions/runs/21976562646/job/63489459956