### PR TITLE
chore(cli): correct package path in metadata

### DIFF
--- a/packages/sv/package.json
+++ b/packages/sv/package.json
@@ -7,7 +7,7 @@
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/sveltejs/cli.git",
-		"directory": "packages/cli"
+		"directory": "packages/sv"
 	},
 	"homepage": "https://svelte.dev",
 	"scripts": {


### PR DESCRIPTION
PR #838 moved the directories for packages, but accidentally left the now-invalid path in `sv`'s package.json.
This produces a minor issue on the npm website https://www.npmjs.com/package/sv?activeTab=readme
Where relative links like CHANGELOG in the rendered README still point to the now-invalid `/packages/cli` path.

No changeset is required for this PR as it is purely metadata which does not (to my knowledge) impact functionality, and it can be bundled with whatever changes are set for the next release.