### PR TITLE
chore: update link for `AGENTS.md` in `ai-tools` repo

### DIFF
--- a/scripts/update-dependencies.js
+++ b/scripts/update-dependencies.js
@@ -150,7 +150,7 @@ await updatePackageFiles('packages/sv/src/create/shared', 'package.json', 'share
 
 // Fetch the latest AGENTS.md from the MCP repo
 const agents_response = await fetch(
-	'https://raw.githubusercontent.com/sveltejs/mcp/refs/heads/main/instructions/AGENTS.md'
+	'https://raw.githubusercontent.com/sveltejs/ai-tools/refs/heads/main/tools/instructions/AGENTS.md'
 );
 fs.writeFileSync(
 	path.resolve('packages', 'sv', 'src', 'create', 'shared', '+mcp', 'AGENTS.md'),


### PR DESCRIPTION
Updates the link to fetch the `AGENTS.md`...we need to merge this after https://github.com/sveltejs/ai-tools/pull/170