### PR TITLE
fix: use spawnSync with timeout in vitest addon test

### DIFF
--- a/packages/sv/src/addons/tests/vitest/test.ts
+++ b/packages/sv/src/addons/tests/vitest/test.ts
@@ -1,10 +1,8 @@
-import { execSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import vitest from '../../vitest-addon.ts';
 import { setupTest } from '../_setup/suite.ts';
-
-const TWO_MINUTES = 2 * 60 * 1000;
 
 const { test, testCases } = setupTest(
 	{ vitest },
@@ -14,11 +12,18 @@ const { test, testCases } = setupTest(
 test.concurrent.for(testCases)('vitest $variant', (testCase, { expect, ...ctx }) => {
 	const cwd = ctx.cwd(testCase);
 
-	expect(() =>
-		execSync('pnpm exec playwright install chromium', { cwd, stdio: 'pipe', timeout: TWO_MINUTES })
-	).not.toThrow();
+	expect(
+		spawnSync('pnpm exec playwright install chromium', {
+			cwd,
+			stdio: 'pipe',
+			shell: true,
+			timeout: 2 * 60_000
+		}).status
+	).toBe(0);
 
-	expect(() => execSync('pnpm test', { cwd, stdio: 'pipe', timeout: TWO_MINUTES })).not.toThrow();
+	expect(
+		spawnSync('pnpm test', { cwd, stdio: 'pipe', shell: true, timeout: 2 * 60_000 }).status
+	).toBe(0);
 
 	const language = testCase.variant.includes('ts') ? 'ts' : 'js';
 	const viteFile = path.resolve(cwd, `vite.config.${language}`);

--- a/packages/sv/src/cli/tests/cli.ts
+++ b/packages/sv/src/cli/tests/cli.ts
@@ -45,7 +45,7 @@ describe('cli', () => {
 
 	it.for(testCases)(
 		'should create a new project with name $projectName',
-		{ timeout: 57_000 },
+		{ timeout: 67_000 },
 		async (testCase) => {
 			const { projectName, args, template = 'minimal' } = testCase;
 


### PR DESCRIPTION
## Summary
- Replace `execSync` with `spawnSync` + 2 min timeout in vitest addon test
- `execSync` blocks the event loop — when the inner vitest+chromium hangs, the outer vitest timeout can't abort it
- This has been causing the `sv` job to hang for 30min in [ecosystem-ci](https://github.com/sveltejs/svelte-ecosystem-ci/actions/runs/23230632898/job/67523179878) since ~Jan 2026