### PR TITLE
Add configurable prettier options

### DIFF
--- a/.changeset/solid-walls-sort.md
+++ b/.changeset/solid-walls-sort.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+Expose `useTabs`, `singleQuote`, `trailingComma`, and `printWidth` as addon options so users can customize prettier defaults via CLI or interactive prompts. Add descriptive hints to trailingComma select options and reorder them (none, es5, all) for clarity.

--- a/documentation/docs/30-add-ons/35-prettier.md
+++ b/documentation/docs/30-add-ons/35-prettier.md
@@ -15,3 +15,49 @@ npx sv add prettier
 - scripts in your `package.json`
 - `.prettierignore` and `.prettierrc` files
 - updates to your eslint config if you're using that package
+
+## Options
+
+### useTabs
+
+Whether to use tabs for indentation. Default: `yes`
+
+```sh
+npx sv add prettier="useTabs:no"
+```
+
+### singleQuote
+
+Whether to use single quotes instead of double quotes. Default: `yes`
+
+```sh
+npx sv add prettier="singleQuote:no"
+```
+
+### trailingComma
+
+Which trailing comma style to use:
+
+- `none` — no trailing commas
+- `es5` — where valid in ES5 (objects, arrays)
+- `all` — wherever possible
+
+Default: `none`
+
+```sh
+npx sv add prettier="trailingComma:es5"
+```
+
+### printWidth
+
+The line width at which the printer will wrap. Default: `100`
+
+```sh
+npx sv add prettier="printWidth:120"
+```
+
+Multiple options can be combined with `+`:
+
+```sh
+npx sv add prettier="useTabs:no+singleQuote:no+trailingComma:es5+printWidth:80"
+```

--- a/packages/sv/src/addons/prettier.ts
+++ b/packages/sv/src/addons/prettier.ts
@@ -1,14 +1,46 @@
 import { log } from '@clack/prompts';
 import { color, dedent, parse, json } from '@sveltejs/sv-utils';
-import { defineAddon } from '../core/config.ts';
+import { defineAddon, defineAddonOptions } from '../core/config.ts';
 import { addEslintConfigPrettier } from './common.ts';
+
+const options = defineAddonOptions()
+	.add('useTabs', {
+		type: 'boolean',
+		question: 'Would you like to use tabs for indentation?',
+		default: true,
+		required: false
+	})
+	.add('singleQuote', {
+		type: 'boolean',
+		question: 'Would you like to use single quotes?',
+		default: true,
+		required: false
+	})
+	.add('trailingComma', {
+		type: 'select',
+		question: 'Which trailing comma option would you like to use?',
+		default: 'none',
+		options: [
+			{ value: 'none', label: 'none', hint: 'no trailing commas' },
+			{ value: 'es5', label: 'es5', hint: 'where valid in ES5 (objects, arrays)' },
+			{ value: 'all', label: 'all', hint: 'wherever possible' }
+		],
+		required: false
+	})
+	.add('printWidth', {
+		type: 'number',
+		question: 'What print width would you like to use?',
+		default: 100,
+		required: false
+	})
+	.build();
 
 export default defineAddon({
 	id: 'prettier',
 	shortDescription: 'formatter',
 	homepage: 'https://prettier.io',
-	options: {},
-	run: ({ sv, dependencyVersion, files }) => {
+	options,
+	run: ({ sv, dependencyVersion, files, options }) => {
 		const tailwindcssInstalled = Boolean(dependencyVersion('tailwindcss'));
 		if (tailwindcssInstalled) sv.devDependency('prettier-plugin-tailwindcss', '^0.7.2');
 
@@ -42,10 +74,10 @@ export default defineAddon({
 			}
 			if (Object.keys(data).length === 0) {
 				// we'll only set these defaults if there is no pre-existing config
-				data.useTabs = true;
-				data.singleQuote = true;
-				data.trailingComma = 'none';
-				data.printWidth = 100;
+				data.useTabs = options.useTabs;
+				data.singleQuote = options.singleQuote;
+				data.trailingComma = options.trailingComma;
+				data.printWidth = options.printWidth;
 			}
 
 			json.arrayUpsert(data, 'plugins', 'prettier-plugin-svelte');


### PR DESCRIPTION
Expose `useTabs`, `singleQuote`, `trailingComma`, and `printWidth` as addon options so users can customize prettier defaults via CLI or interactive prompts.