### PR TITLE
fix(adapter-cloudflare): wrangler types in check/build scripts

### DIFF
--- a/.changeset/brave-clouds-check.md
+++ b/.changeset/brave-clouds-check.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix(adapter-cloudflare): use `--check` flag for wrangler types in check/build scripts

--- a/packages/sv/src/addons/sveltekit-adapter.ts
+++ b/packages/sv/src/addons/sveltekit-adapter.ts
@@ -178,21 +178,13 @@ export default defineAddon({
 			);
 
 			if (file.typeConfig) {
-				sv.file(
-					file.gitignore,
-					transforms.text(({ content }) => {
-						if (content.length === 0) return false;
-						return text.upsert(content, '/worker-configuration.d.ts', {
-							comment: 'Cloudflare Types'
-						});
-					})
-				);
-
-				// Setup wrangler types command
+				// Setup wrangler types command and prepend to check/build
 				sv.file(
 					file.package,
 					transforms.json(({ data, json }) => {
 						json.packageScriptsUpsert(data, 'gen', 'wrangler types');
+						json.packageScriptsUpsert(data, 'check', 'wrangler types --check', { mode: 'prepend' });
+						json.packageScriptsUpsert(data, 'build', 'wrangler types --check', { mode: 'prepend' });
 					})
 				);
 

--- a/packages/sv/src/addons/sveltekit-adapter.ts
+++ b/packages/sv/src/addons/sveltekit-adapter.ts
@@ -1,6 +1,5 @@
 import {
 	color,
-	text,
 	transforms,
 	resolveCommandArray,
 	fileExists,


### PR DESCRIPTION
Closes #872

### Description

-  wrangler types are no more gitignored
- use `--check` flag for wrangler types in check/build scripts

### Checklist

- Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)
- Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable)
- Allow maintainers to edit this PR
- I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)
