### PR TITLE
fix(cli): deprecated file warnings no longer trigger on object spread

### DIFF
--- a/.changeset/flat-flowers-vanish.md
+++ b/.changeset/flat-flowers-vanish.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix(cli): deprecated file warnings no longer trigger on object spread

--- a/packages/sv/src/core/deprecated.ts
+++ b/packages/sv/src/core/deprecated.ts
@@ -1,8 +1,13 @@
+import { color } from '@sveltejs/sv-utils';
+
 const warned = new Set<string>();
 
 /** Emit a one-time deprecation warning. */
 export function svDeprecated(message: string): void {
 	if (warned.has(message)) return;
 	warned.add(message);
-	console.warn(`[sv] Deprecated: ${message}`);
+	console.warn();
+	console.warn(`   ${color.dim('[sv] Deprecated:')} ${message}`);
+	console.warn(`       Still works. ${color.warning("Warn add-on's author about it.")}`);
+	console.warn();
 }

--- a/packages/sv/src/core/workspace.ts
+++ b/packages/sv/src/core/workspace.ts
@@ -79,6 +79,35 @@ type CreateWorkspaceOptions = {
 		dependencies: Record<string, string>;
 	};
 };
+const deprecatedFiles = {
+	prettierignore: '.prettierignore',
+	prettierrc: '.prettierrc',
+	eslintConfig: 'eslint.config.js',
+	vscodeSettings: '.vscode/settings.json',
+	vscodeExtensions: '.vscode/extensions.json'
+} as const;
+
+/** 
+ * Adds deprecated file properties as non-enumerable getters so they don't trigger on spread
+ * Once we remove these deprecatedFiles, we can get rid of addDeprecatedFileProperties
+ */
+function addDeprecatedFileProperties(
+	file: Omit<Workspace['file'], keyof typeof deprecatedFiles>
+): Workspace['file'] {
+	for (const [key, value] of Object.entries(deprecatedFiles)) {
+		Object.defineProperty(file, key, {
+			get() {
+				svDeprecated(
+					`use the string \`${value}\` instead of \`file.${key}\``
+				);
+				return value;
+			},
+			enumerable: false
+		});
+	}
+	return file as Workspace['file'];
+}
+
 export async function createWorkspace({
 	cwd,
 	packageManager,
@@ -144,48 +173,13 @@ export async function createWorkspace({
 		cwd: resolvedCwd,
 		packageManager: packageManager ?? (await detectPackageManager(cwd)),
 		language: typescript ? 'ts' : 'js',
-		file: {
+		file: addDeprecatedFileProperties({
 			viteConfig,
 			svelteConfig,
 			typeConfig,
 			stylesheet,
 			package: 'package.json',
 			gitignore: '.gitignore',
-			/** @deprecated */
-			get prettierignore() {
-				svDeprecated(
-					'`workspace.file.prettierignore` is deprecated, use the string `.prettierignore` isntead.'
-				);
-				return '.prettierignore' as const;
-			},
-			/** @deprecated */
-			get prettierrc() {
-				svDeprecated(
-					'`workspace.file.prettierrc` is deprecated, use the string `.prettierrc` isntead.'
-				);
-				return '.prettierrc' as const;
-			},
-			/** @deprecated */
-			get eslintConfig() {
-				svDeprecated(
-					'`workspace.file.eslintConfig` is deprecated, use the string `eslint.config.js` isntead.'
-				);
-				return 'eslint.config.js' as const;
-			},
-			/** @deprecated */
-			get vscodeSettings() {
-				svDeprecated(
-					'`workspace.file.vscodeSettings` is deprecated, use the string `.vscode/settings.json` isntead.'
-				);
-				return '.vscode/settings.json' as const;
-			},
-			/** @deprecated */
-			get vscodeExtensions() {
-				svDeprecated(
-					'`workspace.file.vscodeExtensions` is deprecated, use the string `.vscode/extensions.json` isntead.'
-				);
-				return '.vscode/extensions.json' as const;
-			},
 			getRelative({ from, to }) {
 				from = from ?? '';
 				let relativePath = path.posix.relative(path.posix.dirname(from), to);
@@ -204,7 +198,7 @@ export async function createWorkspace({
 				}
 				return path.relative(resolvedCwd, found);
 			}
-		},
+		}),
 		isKit,
 		directory,
 		dependencyVersion: (pkg) => dependencies[pkg]

--- a/packages/sv/src/core/workspace.ts
+++ b/packages/sv/src/core/workspace.ts
@@ -98,7 +98,7 @@ function addDeprecatedFileProperties(
 		Object.defineProperty(file, key, {
 			get() {
 				svDeprecated(
-					`use the string \`${value}\` instead of \`file.${key}\``
+					`use the string \`"${value}"\` instead of \`file.${key}\``
 				);
 				return value;
 			},

--- a/packages/sv/src/core/workspace.ts
+++ b/packages/sv/src/core/workspace.ts
@@ -87,7 +87,7 @@ const deprecatedFiles = {
 	vscodeExtensions: '.vscode/extensions.json'
 } as const;
 
-/** 
+/**
  * Adds deprecated file properties as non-enumerable getters so they don't trigger on spread
  * Once we remove these deprecatedFiles, we can get rid of addDeprecatedFileProperties
  */
@@ -97,9 +97,7 @@ function addDeprecatedFileProperties(
 	for (const [key, value] of Object.entries(deprecatedFiles)) {
 		Object.defineProperty(file, key, {
 			get() {
-				svDeprecated(
-					`use the string \`"${value}"\` instead of \`file.${key}\``
-				);
+				svDeprecated(`use the string \`"${value}"\` instead of \`file.${key}\``);
 				return value;
 			},
 			enumerable: false


### PR DESCRIPTION
Closes #1059

### Description

message was showing because of internal spread: `...workspace`, now showing only on usage!

### Checklist

- Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)
- Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable)
- Allow maintainers to edit this PR
- I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)
