### PR TITLE
fix(sv): scope @deprecated tag to legacy create(cwd, options) overload

### DIFF
--- a/.changeset/fix-create-deprecation-scope.md
+++ b/.changeset/fix-create-deprecation-scope.md
@@ -1,13 +1,5 @@
 ---
-"sv": patch
+'sv': patch
 ---
 
-fix: scope `@deprecated` tag to the legacy `create(cwd, options)` overload
-
-The JSDoc `@deprecated` on the first overload signature caused editors to
-mark the entire `create` export as deprecated, including the supported
-`create({ cwd, ...options })` call. Reorder the overloads so the
-non-deprecated signature comes first; editors now only strike through the
-legacy positional form.
-
-Closes #1063
+fix(sv): scope `@deprecated` tag to the legacy `create(cwd, options)` overload only

--- a/.changeset/fix-create-deprecation-scope.md
+++ b/.changeset/fix-create-deprecation-scope.md
@@ -1,0 +1,13 @@
+---
+"sv": patch
+---
+
+fix: scope `@deprecated` tag to the legacy `create(cwd, options)` overload
+
+The JSDoc `@deprecated` on the first overload signature caused editors to
+mark the entire `create` export as deprecated, including the supported
+`create({ cwd, ...options })` call. Reorder the overloads so the
+non-deprecated signature comes first; editors now only strike through the
+legacy positional form.
+
+Closes #1063

--- a/packages/sv/api-surface.md
+++ b/packages/sv/api-surface.md
@@ -21,9 +21,9 @@ type FileType = {
 	condition?: ConditionDefinition;
 	content: (editor: FileEditor) => string;
 };
+declare function create(options: Options): void;
 /** @deprecated use `create({ cwd, ...options })` instead. */
 declare function create(cwd: string, options: Omit<Options, 'cwd'>): void;
-declare function create(options: Options): void;
 export {
 	type Addon,
 	type AddonDefinition,

--- a/packages/sv/src/index.ts
+++ b/packages/sv/src/index.ts
@@ -3,9 +3,9 @@ import { create as _create, type Options as CreateOptions } from './create/index
 
 export type { TemplateType, LanguageType } from './create/index.ts';
 
+export function create(options: CreateOptions): void;
 /** @deprecated use `create({ cwd, ...options })` instead. */
 export function create(cwd: string, options: Omit<CreateOptions, 'cwd'>): void;
-export function create(options: CreateOptions): void;
 export function create(
 	cwdOrOptions: string | CreateOptions,
 	legacyOptions?: Omit<CreateOptions, 'cwd'>


### PR DESCRIPTION
Closes #1063

## Problem

The `@deprecated` JSDoc tag added in #1046 was intended to mark only the legacy `create(cwd, options)` positional form, but in practice editors strike through every reference to the `create` export — including correct calls like `import { create } from 'sv'`.

That happens because VS Code and tsserver resolve a symbol's JSDoc from the **first** overload in source order. Since the deprecated overload was listed first, its `@deprecated` tag became the canonical documentation for the symbol itself.

## Fix

Reorder the overloads so the non-deprecated `create(options)` signature is declared first. The `@deprecated` tag now annotates only the legacy `create(cwd, options)` overload, matching the original intent of #1046.

Before:
- `import { create }` → shown as deprecated
- `create({ cwd, ... })` → shown as deprecated
- `create('./', { ... })` → shown as deprecated

After:
- `import { create }` → not deprecated
- `create({ cwd, ... })` → not deprecated
- `create('./', { ... })` → deprecated (as intended)

## Testing

- `pnpm build` regenerates `packages/sv/api-surface.md` with the overload order swapped (included in the diff)
- `pnpm check` passes
- `pnpm lint` passes

Changeset (`patch`) included.
