### PR TITLE
fix(sv): shift order of function signatures to avoid incorrect import-level deprecation

### DIFF
--- a/.changeset/lovely-hotels-yawn.md
+++ b/.changeset/lovely-hotels-yawn.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix(sv): declare non-deprecated function definition first to avoid import-level deprecation

--- a/packages/sv/api-surface.md
+++ b/packages/sv/api-surface.md
@@ -21,9 +21,9 @@ type FileType = {
 	condition?: ConditionDefinition;
 	content: (editor: FileEditor) => string;
 };
+declare function create(options: Options): void;
 /** @deprecated use `create({ cwd, ...options })` instead. */
 declare function create(cwd: string, options: Omit<Options, 'cwd'>): void;
-declare function create(options: Options): void;
 export {
 	type Addon,
 	type AddonDefinition,

--- a/packages/sv/src/index.ts
+++ b/packages/sv/src/index.ts
@@ -3,9 +3,9 @@ import { create as _create, type Options as CreateOptions } from './create/index
 
 export type { TemplateType, LanguageType } from './create/index.ts';
 
+export function create(options: CreateOptions): void;
 /** @deprecated use `create({ cwd, ...options })` instead. */
 export function create(cwd: string, options: Omit<CreateOptions, 'cwd'>): void;
-export function create(options: CreateOptions): void;
 export function create(
 	cwdOrOptions: string | CreateOptions,
 	legacyOptions?: Omit<CreateOptions, 'cwd'>


### PR DESCRIPTION
Closes #1063

### Description

VS Code's import strikethrough uses the first-found function declaration, so we just re-order to fix the issue.
Note this doesn't impact call-site strikethrough, which already do check that the arguments match.

### Checklist

- ~~Update snapshots~~ (not applicable)
- [x] Add a changeset
- [x] Allow maintainers to edit this PR
- [x] I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)
