### PR TITLE
test(cli): using `pnpm`

### DIFF
--- a/packages/sv/src/cli/tests/cli.ts
+++ b/packages/sv/src/cli/tests/cli.ts
@@ -158,16 +158,8 @@ describe('cli', () => {
 					['run', 'test']
 				];
 				for (const cmd of cmds) {
-					const res = await exec('npm', cmd, {
-						nodeOptions: {
-							stdio: 'pipe',
-							cwd: testOutputPath,
-							env: {
-								...process.env,
-								// Disable warning about npm instead of pnpm
-								COREPACK_ENABLE_STRICT: '0'
-							}
-						}
+					const res = await exec('pnpm', cmd, {
+						nodeOptions: { stdio: 'pipe', cwd: testOutputPath }
 					});
 					expect(
 						res.exitCode,

--- a/packages/sv/src/cli/tests/cli.ts
+++ b/packages/sv/src/cli/tests/cli.ts
@@ -158,8 +158,16 @@ describe('cli', () => {
 					['run', 'test']
 				];
 				for (const cmd of cmds) {
-					const res = await exec('pnpm', cmd, {
-						nodeOptions: { stdio: 'pipe', cwd: testOutputPath }
+					const res = await exec('npm', cmd, {
+						nodeOptions: {
+							stdio: 'pipe',
+							cwd: testOutputPath,
+							env: {
+								...process.env,
+								// Disable warning about npm instead of pnpm
+								COREPACK_ENABLE_STRICT: '0'
+							}
+						}
 					});
 					expect(
 						res.exitCode,

--- a/packages/sv/src/cli/tests/cli.ts
+++ b/packages/sv/src/cli/tests/cli.ts
@@ -158,7 +158,7 @@ describe('cli', () => {
 					['run', 'test']
 				];
 				for (const cmd of cmds) {
-					const res = await exec('npm', cmd, {
+					const res = await exec('pnpm', cmd, {
 						nodeOptions: { stdio: 'pipe', cwd: testOutputPath }
 					});
 					expect(

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - 'packages/*'
   - '!.test-tmp/**'
+  - '!**/.test-output/**'
 
 onlyBuiltDependencies:
   - esbuild


### PR DESCRIPTION
### Description

While working on #1069, I have noticed that the `pnpm test:ui --project cli` command fails with the following message, when you have [Node.js Corepack](https://github.com/nodejs/corepack) installed and enabled for `pnpm`:
```
 FAIL   cli  tests/cli.ts:46:19 > cli > should create a new project with name '@my-org/sv'
AssertionError: Error addon test: 'i' -> {
  "stderr": "This project is configured to use pnpm because /home/jonas/repos/_contrib/cli/package.json has a \"packageManager\" field\n",
  "stdout": "",
  "exitCode": 1
}: expected 1 to be +0 // Object.is equality

- Expected
+ Received

- 0
+ 1

 ❯ tests/cli.ts:167:8
    165|       res.exitCode,
    166|       `Error addon test: '${cmd}' -> ${JSON.stringify(res, null, 2)}`
    167|      ).toBe(0);
       |        ^
    168|     }
    169|    }
```

~~Since I can't find a good reason to use `npm` here, I just changed the commands to use `pnpm`, which fixes the problem and prevents the test from failing. A very simple PR.~~
__Edit:__ To fix this, I have now opted to instead just disable Corepack strict-mode by passing an `COREPACK_ENABLE_STRICT=0` environment variable when running commands with npm.


### Checklist

- [X] Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)
  > Note: I hope I did it correctly, since there were no changes shown in git?
- [X] Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable)
- [X] Allow maintainers to edit this PR
- [X] I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)
