### PR TITLE
fix drizzle & D1 & !adapter-cloudflare

### DIFF
--- a/.changeset/fifty-rats-smile.md
+++ b/.changeset/fifty-rats-smile.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix(drizzle): don't cancel if `D1` is selected without `@sveltejs/adapter-cloudflare`, but add info to next steps

--- a/.changeset/fix-cancel-propagation.md
+++ b/.changeset/fix-cancel-propagation.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix(sv): skip add-ons when a `dependsOn` dependency cancels

--- a/packages/sv/src/addons/drizzle.ts
+++ b/packages/sv/src/addons/drizzle.ts
@@ -101,9 +101,6 @@ export default defineAddon({
 		file,
 		packageManager
 	}) => {
-		if (options.database === 'd1' && !dependencyVersion('@sveltejs/adapter-cloudflare')) {
-			return cancel('Cloudflare D1 requires @sveltejs/adapter-cloudflare - add the adapter first');
-		}
 
 		const [ts] = createPrinter(language === 'ts');
 		const baseDBPath = path.resolve(cwd, directory.lib, 'server', 'db');
@@ -508,9 +505,14 @@ export default defineAddon({
 		);
 	},
 
-	nextSteps: ({ options, packageManager, cwd }) => {
+	nextSteps: ({ options, packageManager, cwd, dependencyVersion }) => {
 		const steps: string[] = [];
 		if (options.database === 'd1') {
+			if (!dependencyVersion('@sveltejs/adapter-cloudflare')) {
+				steps.push(
+					`Cloudflare D1 requires ${color.addon('@sveltejs/adapter-cloudflare')}. Run ${color.command(resolveCommandArray(packageManager, 'execute', ['sv', 'add', 'sveltekit-adapter=adapter:cloudflare']))} to add it`
+				);
+			}
 			const ext = fileExists(cwd, 'wrangler.toml') ? 'toml' : 'jsonc';
 			steps.push(
 				`Add your ${color.env('CLOUDFLARE_ACCOUNT_ID')}, ${color.env('CLOUDFLARE_DATABASE_ID')}, and ${color.env('CLOUDFLARE_D1_TOKEN')} to ${color.path('.env')}`

--- a/packages/sv/src/addons/drizzle.ts
+++ b/packages/sv/src/addons/drizzle.ts
@@ -101,7 +101,6 @@ export default defineAddon({
 		file,
 		packageManager
 	}) => {
-
 		const [ts] = createPrinter(language === 'ts');
 		const baseDBPath = path.resolve(cwd, directory.lib, 'server', 'db');
 		const paths = {

--- a/packages/sv/src/cli/add.ts
+++ b/packages/sv/src/cli/add.ts
@@ -697,8 +697,14 @@ export async function runAddonsApply({
 	const successfulAddons = loadedAddons.filter((a) => !canceledAddonIds.includes(a.addon.id));
 
 	if (addonSuccess.length === 0) {
-		p.cancel('All selected add-ons were canceled.');
-		process.exit(1);
+		// `create` already scaffolded the project on disk - exiting here would hide
+		// the "Project created" success and the next-steps. Just warn instead.
+		if (fromCommand === 'create') {
+			p.log.warn('All selected add-ons were canceled.');
+		} else {
+			p.cancel('All selected add-ons were canceled.');
+			process.exit(1);
+		}
 	} else {
 		p.log.success(
 			`Successfully setup add-ons: ${addonSuccess.map((c) => color.addon(c)).join(', ')}`

--- a/packages/sv/src/core/engine.ts
+++ b/packages/sv/src/core/engine.ts
@@ -125,9 +125,7 @@ export async function applyAddons({
 		const canceledDeps = dependsOn.filter((dep) => canceledAddons.has(dep));
 		if (canceledDeps.length > 0) {
 			canceledAddons.add(addon.id);
-			status[addon.id] = canceledDeps.map(
-				(dep) => `Because dependency '${dep}' was canceled`
-			);
+			status[addon.id] = canceledDeps.map((dep) => `Because dependency '${dep}' was canceled`);
 			continue;
 		}
 

--- a/packages/sv/src/core/engine.ts
+++ b/packages/sv/src/core/engine.ts
@@ -111,6 +111,7 @@ export async function applyAddons({
 }> {
 	const filesToFormat = new Set<string>();
 	const status: Record<string, string[] | 'success'> = {};
+	const canceledAddons = new Set<string>();
 
 	const addonDefs = loadedAddons.map((l) => l.addon);
 	const ordered = orderAddons(addonDefs, setupResults);
@@ -118,6 +119,18 @@ export async function applyAddons({
 	let hasFormatter = false;
 
 	for (const addon of ordered) {
+		// Skip addons whose `dependsOn` dependency was canceled. Running them would
+		// fail with misleading errors since they expect state from the canceled addon.
+		const dependsOn = setupResults[addon.id]?.dependsOn ?? [];
+		const canceledDeps = dependsOn.filter((dep) => canceledAddons.has(dep));
+		if (canceledDeps.length > 0) {
+			canceledAddons.add(addon.id);
+			status[addon.id] = canceledDeps.map(
+				(dep) => `Because dependency '${dep}' was canceled`
+			);
+			continue;
+		}
+
 		const loaded = loadedAddons.find((l) => l.addon.id === addon.id)!;
 		const workspaceOptions = options[addon.id] || {};
 
@@ -141,6 +154,7 @@ export async function applyAddons({
 		if (cancels.length === 0) {
 			status[addon.id] = 'success';
 		} else {
+			canceledAddons.add(addon.id);
 			status[addon.id] = cancels;
 		}
 	}

--- a/packages/sv/src/core/tests/engine.ts
+++ b/packages/sv/src/core/tests/engine.ts
@@ -1,0 +1,65 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { defineAddon, defineAddonOptions, type LoadedAddon } from '../config.ts';
+import { applyAddons, setupAddons } from '../engine.ts';
+import { createWorkspace } from '../workspace.ts';
+
+function makeWorkspace() {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'sv-engine-'));
+	fs.writeFileSync(path.join(cwd, 'package.json'), '{"name":"t","private":true}');
+	return cwd;
+}
+const loaded = (a: ReturnType<typeof defineAddon<any, any>>): LoadedAddon => ({
+	reference: { specifier: a.id, options: [], source: { kind: 'official', id: a.id } },
+	addon: a
+});
+const dep = defineAddon({
+	id: 'dep',
+	options: defineAddonOptions().build(),
+	run: ({ cancel }) => cancel('nope')
+});
+
+describe('applyAddons cancel propagation', () => {
+	it("skips addons whose 'dependsOn' was canceled", async () => {
+		const child = defineAddon({
+			id: 'child',
+			options: defineAddonOptions().build(),
+			setup: ({ dependsOn }) => dependsOn('dep' as never),
+			run: () => expect.fail('child should not have run')
+		});
+		const workspace = await createWorkspace({ cwd: makeWorkspace() });
+		const addons = [loaded(dep), loaded(child)];
+		const { status } = await applyAddons({
+			loadedAddons: addons,
+			workspace,
+			setupResults: setupAddons(addons, workspace),
+			options: { dep: {}, child: {} }
+		});
+		expect(status.dep).toEqual(['nope']);
+		expect(status.child).toEqual(["Because dependency 'dep' was canceled"]);
+	});
+
+	it("does not skip addons that only 'runsAfter' a canceled addon", async () => {
+		let ran = false;
+		const child = defineAddon({
+			id: 'child',
+			options: defineAddonOptions().build(),
+			setup: ({ runsAfter }) => runsAfter('dep' as never),
+			run: () => {
+				ran = true;
+			}
+		});
+		const workspace = await createWorkspace({ cwd: makeWorkspace() });
+		const addons = [loaded(dep), loaded(child)];
+		const { status } = await applyAddons({
+			loadedAddons: addons,
+			workspace,
+			setupResults: setupAddons(addons, workspace),
+			options: { dep: {}, child: {} }
+		});
+		expect(status.child).toBe('success');
+		expect(ran).toBe(true);
+	});
+});


### PR DESCRIPTION
Closes #1067

### Description

- [x] skip add-ons when a `dependsOn` dependency cancels
- [x] don't cancel if `D1` is selected without `@sveltejs/adapter-cloudflare`, but add info to next steps

### Checklist

- Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)
- Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable)
- Allow maintainers to edit this PR
- I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)
