### PR TITLE
feat(sv): improve `vitest` v3 detection

### DIFF
--- a/.changeset/tangy-pears-unite.md
+++ b/.changeset/tangy-pears-unite.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+feat(sv): improve `vitest` v3 detection

--- a/packages/sv/src/addons/vitest-addon.ts
+++ b/packages/sv/src/addons/vitest-addon.ts
@@ -1,4 +1,4 @@
-import { color, createPrinter, dedent, transforms } from '@sveltejs/sv-utils';
+import { coerceVersion, color, createPrinter, dedent, transforms } from '@sveltejs/sv-utils';
 import { defineAddon, defineAddonOptions } from '../core/config.ts';
 
 const options = defineAddonOptions()
@@ -27,10 +27,10 @@ export default defineAddon({
 		const unitTesting = options.usages.includes('unit');
 		const componentTesting = options.usages.includes('component');
 
-		vitestV3Installed = (dependencyVersion('vitest') ?? '')
-			.replaceAll('^', '')
-			.replaceAll('~', '')
-			?.startsWith('3.');
+		const vitestVersion = dependencyVersion('vitest');
+		if (vitestVersion) {
+			vitestV3Installed = coerceVersion(vitestVersion).major === 3;
+		}
 
 		sv.devDependency('vitest', '^4.1.3');
 


### PR DESCRIPTION
### Description

Using the new utility introduced in #1069, we can make the check if `vitest` version 3 is installed much more robust.

### Checklist

- [X] Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)
- [X] Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable)
- [X] Allow maintainers to edit this PR
- [X] I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)
