### PR TITLE
feat(sv): improve `svelte` version detection

### DIFF
--- a/.changeset/sharp-pets-do.md
+++ b/.changeset/sharp-pets-do.md
@@ -1,0 +1,6 @@
+---
+'@sveltejs/sv-utils': patch
+'sv': patch
+---
+
+feat(sv): improve `svelte` version detection

--- a/packages/sv-utils/src/tooling/svelte/index.ts
+++ b/packages/sv-utils/src/tooling/svelte/index.ts
@@ -1,3 +1,4 @@
+import { coerceVersion } from '../../semver.ts';
 import { parseScript, type SvelteAst } from '../index.ts';
 import { appendFromString } from '../js/common.ts';
 import { parseSvelte } from '../parsers.ts';
@@ -38,9 +39,8 @@ export function addSlot(
 	ast: SvelteAst.Root,
 	options: { svelteVersion: string; language?: 'ts' | 'js' }
 ): void {
-	const slotSyntax =
-		options.svelteVersion &&
-		(options.svelteVersion.startsWith('4') || options.svelteVersion.startsWith('3'));
+	const svelteVersionMajor = options.svelteVersion && coerceVersion(options.svelteVersion).major;
+	const slotSyntax = svelteVersionMajor === 4 || svelteVersionMajor === 3;
 
 	if (slotSyntax) {
 		// @ts-expect-error

--- a/packages/sv/src/addons/better-auth.ts
+++ b/packages/sv/src/addons/better-auth.ts
@@ -7,7 +7,8 @@ import {
 	transforms,
 	resolveCommandArray,
 	createPrinter,
-	type TransformFn
+	type TransformFn,
+	coerceVersion
 } from '@sveltejs/sv-utils';
 import crypto from 'node:crypto';
 import { defineAddon, defineAddonOptions } from '../core/config.ts';
@@ -41,7 +42,8 @@ export default defineAddon({
 		runsAfter('tailwindcss');
 	},
 	run: ({ sv, language, options, directory, dependencyVersion, file }) => {
-		const svelte5 = !!dependencyVersion('svelte')?.startsWith('5');
+		const svelteVersion = dependencyVersion('svelte');
+		const svelte5 = !!svelteVersion && coerceVersion(svelteVersion).major === 5;
 		const [ts, s5] = createPrinter(language === 'ts', svelte5);
 
 		const demoPassword = options.demo.includes('password');


### PR DESCRIPTION
### Description

Just like in #1073, we can make the `svelte` version checks much more robust using the new utility introduced in #1069.

### Checklist

- [X] Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)
- [X] Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable)
- [X] Allow maintainers to edit this PR
- [X] I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)
