### PR TITLE
fix: respect `isType` in `js.imports.addNamed` when merging imports

### DIFF
--- a/.changeset/fix-named-import-type.md
+++ b/.changeset/fix-named-import-type.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/sv-utils': patch
+---
+
+fix: `js.imports.addNamed` now respects `isType` when merging into an existing import declaration

--- a/packages/sv-utils/src/tests/js/imports/named-import-type-merging/input.ts
+++ b/packages/sv-utils/src/tests/js/imports/named-import-type-merging/input.ts
@@ -1,0 +1,1 @@
+import type { Foo } from 'package';

--- a/packages/sv-utils/src/tests/js/imports/named-import-type-merging/output.ts
+++ b/packages/sv-utils/src/tests/js/imports/named-import-type-merging/output.ts
@@ -1,0 +1,1 @@
+import type { Foo, Bar } from 'package';

--- a/packages/sv-utils/src/tests/js/imports/named-import-type-merging/run.ts
+++ b/packages/sv-utils/src/tests/js/imports/named-import-type-merging/run.ts
@@ -1,0 +1,6 @@
+import type { AstTypes } from '../../../../tooling/index.ts';
+import { imports } from '../../../../tooling/js/index.ts';
+
+export function run(ast: AstTypes.Program): void {
+	imports.addNamed(ast, { from: 'package', imports: ['Bar'], isType: true });
+}

--- a/packages/sv-utils/src/tests/js/imports/named-import-type-mixing/input.ts
+++ b/packages/sv-utils/src/tests/js/imports/named-import-type-mixing/input.ts
@@ -1,0 +1,1 @@
+import { Foo } from 'package';

--- a/packages/sv-utils/src/tests/js/imports/named-import-type-mixing/output.ts
+++ b/packages/sv-utils/src/tests/js/imports/named-import-type-mixing/output.ts
@@ -1,0 +1,2 @@
+import type { Bar } from 'package';
+import { Foo, Baz } from 'package';

--- a/packages/sv-utils/src/tests/js/imports/named-import-type-mixing/run.ts
+++ b/packages/sv-utils/src/tests/js/imports/named-import-type-mixing/run.ts
@@ -1,0 +1,7 @@
+import type { AstTypes } from '../../../../tooling/index.ts';
+import { imports } from '../../../../tooling/js/index.ts';
+
+export function run(ast: AstTypes.Program): void {
+	imports.addNamed(ast, { from: 'package', imports: ['Bar'], isType: true });
+	imports.addNamed(ast, { from: 'package', imports: ['Baz'] });
+}

--- a/packages/sv-utils/src/tests/js/imports/named-import-type/output.ts
+++ b/packages/sv-utils/src/tests/js/imports/named-import-type/output.ts
@@ -1,0 +1,1 @@
+import type { Foo } from 'package';

--- a/packages/sv-utils/src/tests/js/imports/named-import-type/run.ts
+++ b/packages/sv-utils/src/tests/js/imports/named-import-type/run.ts
@@ -1,0 +1,6 @@
+import type { AstTypes } from '../../../../tooling/index.ts';
+import { imports } from '../../../../tooling/js/index.ts';
+
+export function run(ast: AstTypes.Program): void {
+	imports.addNamed(ast, { from: 'package', imports: ['Foo'], isType: true });
+}

--- a/packages/sv-utils/src/tooling/js/imports.ts
+++ b/packages/sv-utils/src/tooling/js/imports.ts
@@ -89,11 +89,16 @@ export function addNamed(
 		return specifier;
 	});
 
+	const expectedImportKind = options.isType ? 'type' : 'value';
 	let importDecl: AstTypes.ImportDeclaration | undefined;
 
 	Walker.walk(node as AstTypes.Node, null, {
 		ImportDeclaration(declaration) {
-			if (declaration.source.value === options.from && declaration.specifiers) {
+			if (
+				declaration.source.value === options.from &&
+				declaration.specifiers &&
+				declaration.importKind === expectedImportKind
+			) {
 				importDecl = declaration;
 			}
 		}
@@ -125,7 +130,7 @@ export function addNamed(
 		},
 		specifiers,
 		attributes: [],
-		importKind: options.isType ? 'type' : 'value'
+		importKind: expectedImportKind
 	};
 
 	node.body.unshift(expectedImportDeclaration);


### PR DESCRIPTION
Closes #1077

### Description

`js.imports.addNamed` was merging into any existing `ImportDeclaration` matching `from`, ignoring its `importKind`. Calling it with both `isType: true` and `isType: false` for the same source therefore produced incorrect output: depending on call order, the `type` modifier ended up on the wrong declaration (applied to value imports or stripped from type-only imports).

Fix: only merge into a declaration whose `importKind` matches the requested kind. Value and type imports from the same module are kept as separate declarations.

```ts
// before (called addNamed with isType:false, then isType:true on same `from`)
import type { A, B } from 'foo'; // ❌ A was a value import

// after
import { A } from 'foo';
import type { B } from 'foo';
```

Tests added:
- `named-import-type/` - type-only addition
- `named-import-type-merging/` - merging into existing type import
- `named-import-type-mixing/` - value + type from same source coexist

### Checklist

- Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)
- Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable) ✅ `.changeset/fix-named-import-type.md`
- Allow maintainers to edit this PR
- I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)