### PR TITLE
fix: `appendFromString` mis-attaches comments on repeated calls

### DIFF
--- a/.changeset/fix-append-from-string-multiline-comments.md
+++ b/.changeset/fix-append-from-string-multiline-comments.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/sv-utils': patch
+---
+
+fix: `js.common.appendFromString` no longer corrupts the output when called multiple times with comments

--- a/packages/sv-utils/src/tests/js/common/append-from-string/output.ts
+++ b/packages/sv-utils/src/tests/js/common/append-from-string/output.ts
@@ -1,0 +1,11 @@
+/**
+ * First multiline comment
+ * second line
+ */
+export const foo = 1;
+
+/**
+ * Second multiline comment
+ * second line
+ */
+export const bar = 2;

--- a/packages/sv-utils/src/tests/js/common/append-from-string/run.ts
+++ b/packages/sv-utils/src/tests/js/common/append-from-string/run.ts
@@ -1,0 +1,26 @@
+import type { AstTypes, Comments } from '../../../../tooling/index.ts';
+import { common } from '../../../../tooling/js/index.ts';
+
+export function run(ast: AstTypes.Program, comments: Comments): void {
+	common.appendFromString(ast, {
+		comments,
+		code: `
+			/**
+			 * First multiline comment
+			 * second line
+			 */
+			export const foo = 1;
+		`
+	});
+
+	common.appendFromString(ast, {
+		comments,
+		code: `
+			/**
+			 * Second multiline comment
+			 * second line
+			 */
+			export const bar = 2;
+		`
+	});
+}

--- a/packages/sv-utils/src/tooling/index.ts
+++ b/packages/sv-utils/src/tooling/index.ts
@@ -248,13 +248,13 @@ export class Comments {
 	}
 }
 
-interface CommentsInternal {
+export interface CommentsInternal {
 	original: TsEstree.Comment[];
 	leading: WeakMap<BaseNode, CommentType[]>;
 	trailing: WeakMap<BaseNode, CommentType[]>;
 }
 
-function transformToInternal(comments: Comments | undefined): CommentsInternal {
+export function transformToInternal(comments: Comments | undefined): CommentsInternal {
 	return (comments ?? new Comments()) as unknown as CommentsInternal;
 }
 

--- a/packages/sv-utils/src/tooling/js/common.ts
+++ b/packages/sv-utils/src/tooling/js/common.ts
@@ -1,7 +1,14 @@
 import decircular from 'decircular';
 import dedent from 'dedent';
 import * as Walker from 'zimmerframe';
-import { type AstTypes, type Comments, parseScript, serializeScript, stripAst } from '../index.ts';
+import {
+	type AstTypes,
+	type Comments,
+	parseScript,
+	serializeScript,
+	stripAst,
+	transformToInternal
+} from '../index.ts';
 
 export function addJsDocTypeComment(
 	node: AstTypes.Node,
@@ -115,25 +122,33 @@ export function appendFromString(
 	node: AstTypes.BlockStatement | AstTypes.Program,
 	options: { code: string; comments?: Comments }
 ): void {
-	const parsed = parseScript(dedent(options.code));
+	const target = options.comments && transformToInternal(options.comments);
 
-	// Merge comments if provided
-	if (options.comments) {
-		const parsedInternal = parsed.comments as unknown as {
-			original: AstTypes.Comment[];
-			leading: WeakMap<AstTypes.Node, AstTypes.Comment[]>;
-			trailing: WeakMap<AstTypes.Node, AstTypes.Comment[]>;
-		};
-		const targetInternal = options.comments as unknown as {
-			original: AstTypes.Comment[];
-		};
-		targetInternal.original.push(...parsedInternal.original);
-	}
+	// Esrap binds comments to nodes by source `loc`. Each parse starts at line 1,
+	// so repeated calls collide; pad the source so the parser emits fresh lines.
+	let source = dedent(options.code);
+	if (target) source = '\n'.repeat(maxLine(node, target.original)) + source;
+
+	const parsed = parseScript(source);
+
+	if (target) target.original.push(...transformToInternal(parsed.comments).original);
 
 	for (const childNode of parsed.ast.body) {
 		// @ts-expect-error
 		node.body.push(childNode);
 	}
+}
+
+function maxLine(node: AstTypes.Node, comments: AstTypes.Comment[]): number {
+	let max = 0;
+	Walker.walk(node, null, {
+		_(n, { next }) {
+			if (n.loc && n.loc.end.line > max) max = n.loc.end.line;
+			next();
+		}
+	});
+	for (const c of comments) if (c.loc && c.loc.end.line > max) max = c.loc.end.line;
+	return max;
 }
 
 export function parseExpression(code: string): AstTypes.Expression {


### PR DESCRIPTION
Closes #1078

### Description

Each parse starts at line 1, so repeated `appendFromString` calls produce overlapping `loc`s and esrap binds comments to the wrong nodes. Pad the source with blank lines so the parser emits fresh line numbers.

### Checklist

- Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)
- Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable)
- Allow maintainers to edit this PR
- I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)