### PR TITLE
fix: `js.object.create` corrupts AST when value has `type` property

### DIFF
--- a/.changeset/fix-object-create-type-property.md
+++ b/.changeset/fix-object-create-type-property.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/sv-utils': patch
+---
+
+fix: `js.object.create` no longer corrupts the AST when an object value contains a `type` property

--- a/packages/sv-utils/src/tests/js/object/create/output.ts
+++ b/packages/sv-utils/src/tests/js/object/create/output.ts
@@ -7,3 +7,9 @@ const created2 = {
 	object: { foo: 'hello', nested: { bar: 'world' } },
 	array: [123, 'hello', { foo: 'bar', bool: true }, [456, '789']]
 };
+
+const created3 = {
+	type: '123',
+	nested: { type: 'something', value: 'inside' },
+	array: [{ type: 'item', id: 1 }]
+};

--- a/packages/sv-utils/src/tests/js/object/create/run.ts
+++ b/packages/sv-utils/src/tests/js/object/create/run.ts
@@ -39,4 +39,20 @@ export function run(ast: AstTypes.Program): void {
 		value: createdObject2
 	});
 	ast.body.push(createdVariable2);
+
+	// objects with a `type` property must not be mistaken for AST nodes
+	const createdObject3 = object.create({
+		type: '123',
+		nested: {
+			type: 'something',
+			value: 'inside'
+		},
+		array: [{ type: 'item', id: 1 }]
+	});
+	const createdVariable3 = variables.declaration(ast, {
+		kind: 'const',
+		name: 'created3',
+		value: createdObject3
+	});
+	ast.body.push(createdVariable3);
 }

--- a/packages/sv-utils/src/tooling/js/object.ts
+++ b/packages/sv-utils/src/tooling/js/object.ts
@@ -6,6 +6,38 @@ type ObjectPrimitiveValues = string | number | boolean | undefined | null;
 type ObjectValues = ObjectPrimitiveValues | Record<string, any> | ObjectValues[];
 type ObjectMap = Record<string, ObjectValues | AstTypes.Expression>;
 
+// Used to disambiguate user-supplied objects (which may have a `type` property)
+// from actual AST Expression nodes when populating an ObjectExpression.
+const AST_EXPRESSION_TYPES = new Set([
+	'ArrayExpression',
+	'ArrowFunctionExpression',
+	'AssignmentExpression',
+	'AwaitExpression',
+	'BinaryExpression',
+	'CallExpression',
+	'ChainExpression',
+	'ClassExpression',
+	'ConditionalExpression',
+	'FunctionExpression',
+	'Identifier',
+	'ImportExpression',
+	'Literal',
+	'LogicalExpression',
+	'MemberExpression',
+	'MetaProperty',
+	'NewExpression',
+	'ObjectExpression',
+	'SequenceExpression',
+	'TaggedTemplateExpression',
+	'TemplateLiteral',
+	'ThisExpression',
+	'UnaryExpression',
+	'UpdateExpression',
+	'YieldExpression',
+	'TSAsExpression',
+	'TSSatisfiesExpression'
+]);
+
 export function property<T extends AstTypes.Expression | AstTypes.Identifier>(
 	node: AstTypes.ObjectExpression,
 	options: { name: string; fallback: T }
@@ -105,8 +137,9 @@ function populateObjectExpression(options: {
 				array.append(expression, getExpression(v));
 			}
 		} else if (typeof value === 'object' && value !== null) {
-			// if the type property is defined, we assume it's an AST type
-			if (value.type !== undefined) {
+			// only treat as an AST node if `type` matches a known AST expression type,
+			// so plain objects like `{ type: 'foo' }` are still serialized as data
+			if (typeof value.type === 'string' && AST_EXPRESSION_TYPES.has(value.type)) {
 				expression = value as AstTypes.Expression;
 			} else {
 				// If we're overriding and there's an existing object expression, merge with it


### PR DESCRIPTION
Closes #1079

### Description

`js.object.create` treated any object value with a `type` property as a raw AST node, corrupting output for plain data like `{ type: 'select' }`. Now only known estree Expression types are treated as AST nodes.

### Checklist

- Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)
- Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable)
- Allow maintainers to edit this PR
- I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)