### PR TITLE
fix: `js.exports.createNamed` fails if the AST contains a function declaration

### DIFF
--- a/.changeset/fix-create-named-function-decl.md
+++ b/.changeset/fix-create-named-function-decl.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/sv-utils': patch
+---
+
+fix: prevent `js.exports.createNamed` from crashing when the AST contains an exported function or class declaration

--- a/packages/sv-utils/src/tests/js/exports/named-export-with-existing-function/input.ts
+++ b/packages/sv-utils/src/tests/js/exports/named-export-with-existing-function/input.ts
@@ -1,0 +1,1 @@
+export function existing() {}

--- a/packages/sv-utils/src/tests/js/exports/named-export-with-existing-function/output.ts
+++ b/packages/sv-utils/src/tests/js/exports/named-export-with-existing-function/output.ts
@@ -1,0 +1,2 @@
+export function existing() {}
+export const variable = {};

--- a/packages/sv-utils/src/tests/js/exports/named-export-with-existing-function/run.ts
+++ b/packages/sv-utils/src/tests/js/exports/named-export-with-existing-function/run.ts
@@ -1,0 +1,15 @@
+import type { AstTypes } from '../../../../tooling/index.ts';
+import { variables, object, exports } from '../../../../tooling/js/index.ts';
+
+export function run(ast: AstTypes.Program): void {
+	const variableFallback = variables.declaration(ast, {
+		kind: 'const',
+		name: 'variable',
+		value: object.create({})
+	});
+
+	exports.createNamed(ast, {
+		name: 'named',
+		fallback: variableFallback
+	});
+}

--- a/packages/sv-utils/src/tooling/js/exports.ts
+++ b/packages/sv-utils/src/tooling/js/exports.ts
@@ -53,11 +53,14 @@ export function createNamed(
 ): AstTypes.ExportNamedDeclaration {
 	const namedExports = node.body.filter((item) => item.type === 'ExportNamedDeclaration');
 	let namedExport = namedExports.find((exportNode) => {
-		if (!exportNode.declaration) return false;
-		const variableDeclaration = exportNode.declaration as AstTypes.VariableDeclaration;
-		const variableDeclarator = variableDeclaration.declarations[0] as AstTypes.VariableDeclarator;
-		const identifier = variableDeclarator.id as AstTypes.Identifier;
-		return identifier.name === options.name;
+		const declaration = exportNode.declaration;
+		if (!declaration) return false;
+		if (declaration.type === 'VariableDeclaration') {
+			const variableDeclarator = declaration.declarations[0] as AstTypes.VariableDeclarator;
+			const identifier = variableDeclarator.id as AstTypes.Identifier;
+			return identifier.name === options.name;
+		}
+		return declaration.id?.name === options.name;
 	});
 
 	if (namedExport) return namedExport;


### PR DESCRIPTION
Closes #1083

### Description

`js.exports.createNamed` crashed with `TypeError: Cannot read properties of undefined (reading '0')` when the AST contained an exported function (or class) declaration. The lookup blindly cast the export's declaration to `VariableDeclaration`. Now it branches on declaration type and reads `id.name` for function/class declarations.

### Checklist

- Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)
- Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable)
- Allow maintainers to edit this PR
- I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)