### PR TITLE
fix(sv): pnpm 11 install no longer fails for cloudflare adapter

### DIFF
--- a/.changeset/fix-cloudflare-allow-builds.md
+++ b/.changeset/fix-cloudflare-allow-builds.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix(sveltekit-adapter): register `workerd` and `sharp` as pnpm allow-builds when the cloudflare adapter is selected

--- a/.changeset/fix-pm-resolve-before-addons.md
+++ b/.changeset/fix-pm-resolve-before-addons.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix(sv): resolve package manager before applying add-ons so pnpm-only logic in add-ons (drizzle, tailwindcss, sveltekit-adapter) actually runs. Also soften pnpm `ERR_PNPM_IGNORED_BUILDS` to a warning instead of failing the install.

--- a/packages/sv/src/addons/sveltekit-adapter.ts
+++ b/packages/sv/src/addons/sveltekit-adapter.ts
@@ -4,7 +4,8 @@ import {
 	resolveCommandArray,
 	fileExists,
 	loadPackageJson,
-	sanitizeName
+	sanitizeName,
+	pnpm
 } from '@sveltejs/sv-utils';
 import { defineAddon, defineAddonOptions } from '../core/config.ts';
 
@@ -45,7 +46,7 @@ export default defineAddon({
 	setup: ({ isKit, unsupported }) => {
 		if (!isKit) unsupported('Requires SvelteKit');
 	},
-	run: ({ sv, options, file, cwd }) => {
+	run: ({ sv, options, packageManager, file, cwd }) => {
 		const adapter = adapters.find((a) => a.id === options.adapter)!;
 
 		// removes previously installed adapters
@@ -128,6 +129,10 @@ export default defineAddon({
 
 		if (adapter.package === '@sveltejs/adapter-cloudflare') {
 			sv.devDependency('wrangler', '^4.81.0');
+
+			if (packageManager === 'pnpm') {
+				sv.file(file.findUp('pnpm-workspace.yaml'), pnpm.allowBuilds('workerd', 'sharp'));
+			}
 
 			// default to jsonc
 			const ext = fileExists(cwd, 'wrangler.toml') ? 'toml' : 'jsonc';

--- a/packages/sv/src/cli/create.ts
+++ b/packages/sv/src/cli/create.ts
@@ -337,6 +337,18 @@ async function createProject(cwd: ProjectPath, options: Options) {
 
 	p.log.success('Project created');
 
+	// Resolve the package manager early in case it's used in an add-on.
+	const packageManager =
+		options.install === false
+			? null
+			: options.install === true
+				? await packageManagerPrompt(projectPath)
+				: options.install;
+
+	if (packageManager) {
+		workspace.packageManager = packageManager;
+	}
+
 	let argsFormattedAddons: string[] = [];
 	let addOnFilesToFormat: string[] = [];
 	let addOnSuccessfulAddons: LoadedAddon[] = [];
@@ -368,13 +380,6 @@ async function createProject(cwd: ProjectPath, options: Options) {
 		addonSetupResults = setupResults;
 	}
 
-	const packageManager =
-		options.install === false
-			? null
-			: options.install === true
-				? await packageManagerPrompt(projectPath)
-				: options.install;
-
 	// Build args for next time based on non-default options
 	const argsFormatted: string[] = [];
 
@@ -391,9 +396,6 @@ async function createProject(cwd: ProjectPath, options: Options) {
 
 	common.updateAgent(directory, language, packageManager ?? 'npm', loadedAddons);
 
-	if (packageManager) {
-		workspace.packageManager = packageManager;
-	}
 	const addOnNextSteps = getNextSteps(addOnSuccessfulAddons, workspace, answers, addonSetupResults);
 
 	addPnpmAllowBuilds(projectPath, packageManager, 'esbuild');

--- a/packages/sv/src/core/package-manager.ts
+++ b/packages/sv/src/core/package-manager.ts
@@ -56,25 +56,41 @@ export async function installDependencies(agent: AgentName, cwd: string): Promis
 		retainLog: true
 	});
 
+	const { command, args } = constructCommand(COMMANDS[agent].install, [])!;
+
+	const proc = exec(command, args, {
+		nodeOptions: { cwd, stdio: 'pipe' },
+		throwOnError: false
+	});
+
+	const output: string[] = [];
 	try {
-		const { command, args } = constructCommand(COMMANDS[agent].install, [])!;
-
-		const proc = exec(command, args, {
-			nodeOptions: { cwd, stdio: 'pipe' },
-			throwOnError: true
-		});
-
 		for await (const line of proc) {
 			// line will be from stderr/stdout in the order you'd see it in a term
+			output.push(line);
 			task.message(line);
 		}
-
-		task.success(`Successfully installed dependencies with ${color.command(agent)}`);
 	} catch {
-		task.error('Failed to install dependencies');
-		p.cancel('Operation failed.');
-		process.exit(2);
+		// fall through to exit-code handling below
 	}
+
+	const exitCode = proc.exitCode ?? 0;
+	if (exitCode === 0) {
+		task.success(`Successfully installed dependencies with ${color.command(agent)}`);
+		return;
+	}
+
+	if (agent === 'pnpm' && output.join('\n').includes('ERR_PNPM_IGNORED_BUILDS')) {
+		task.success(`Installed dependencies with ${color.command(agent)}`);
+		p.log.warn(
+			`Some build scripts were skipped. Run ${color.command(`${agent} approve-builds`)} to approve them.`
+		);
+		return;
+	}
+
+	task.error('Failed to install dependencies');
+	p.cancel('Operation failed.');
+	process.exit(2);
 }
 
 export async function detectPackageManager(cwd: string): Promise<AgentName> {


### PR DESCRIPTION
Closes _discord exchange 😅_

### Description

- `cli/create.ts`: resolve package manager before `runAddonsApply` so pnpm-only logic in add-ons (drizzle, tailwindcss, sveltekit-adapter) actually runs. Previously `workspace.packageManager` was still `'npm'` (default) when add-ons ran, silently skipping `if (packageManager === 'pnpm')` branches.
- `addons/sveltekit-adapter.ts`: register `workerd` and `sharp` as pnpm allow-builds when the cloudflare adapter is selected.
- `core/package-manager.ts`: on pnpm `ERR_PNPM_IGNORED_BUILDS`, don't crash. Surface a short warning pointing at `pnpm approve-builds` and continue.

### Checklist

- Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)
- Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable)
- Allow maintainers to edit this PR
- I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)