### PR TITLE
chore(internal): helping ecosystem-ci

### DIFF
--- a/packages/sv/src/addons/tests/mdsvex/test.ts
+++ b/packages/sv/src/addons/tests/mdsvex/test.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { js, svelte, parse } from '@sveltejs/sv-utils';
+import { transforms } from '@sveltejs/sv-utils';
 import fs from 'node:fs';
 import path from 'node:path';
 import mdsvex from '../../mdsvex.ts';
@@ -26,6 +26,24 @@ test.concurrent.for(testCases)('mdsvex $variant', async (testCase, { page, ...ct
 	expect(page.locator('.mdsvex p')).toBeTruthy();
 });
 
+const addMarkup = transforms.svelteScript({ language: 'js' }, ({ ast, svelte, js }) => {
+	const alreadyAdded = ast.fragment.nodes.some(
+		(node) =>
+			node.type === 'RegularElement' &&
+			node.attributes.some(
+				(attr) =>
+					attr.type === 'Attribute' &&
+					attr.name === 'class' &&
+					Array.isArray(attr.value) &&
+					attr.value.some((v) => v.type === 'Text' && v.data === 'mdsvex')
+			)
+	);
+	if (alreadyAdded) return false;
+
+	js.imports.addDefault(ast.instance.content, { from: './Demo.svx', as: 'Demo' });
+	svelte.addFragment(ast, '<div class="mdsvex"><Demo /></div>');
+});
+
 function addFixture(cwd: string, variant: string) {
 	let page;
 	let svx;
@@ -38,14 +56,6 @@ function addFixture(cwd: string, variant: string) {
 	}
 
 	const src = fs.readFileSync(page, 'utf8');
-	const { ast, generateCode } = parse.svelte(src);
-	svelte.ensureScript(ast);
-	js.imports.addDefault(ast.instance.content, { from: './Demo.svx', as: 'Demo' });
-
-	svelte.addFragment(ast, '<div class="mdsvex"><Demo /></div>');
-
-	const content = generateCode();
-
-	fs.writeFileSync(page, content, 'utf8');
+	fs.writeFileSync(page, addMarkup(src), 'utf8');
 	fs.writeFileSync(svx, svxFile, 'utf8');
 }

--- a/packages/sv/src/addons/tests/tailwindcss/fixtures.ts
+++ b/packages/sv/src/addons/tests/tailwindcss/fixtures.ts
@@ -1,3 +1,4 @@
+import { transforms } from '@sveltejs/sv-utils';
 import fs from 'node:fs';
 import path from 'node:path';
 
@@ -7,13 +8,28 @@ const markup = `
 </div>
 `;
 
+const addMarkup = transforms.svelte(({ ast, svelte }) => {
+	const alreadyAdded = ast.fragment.nodes.some(
+		(node) =>
+			node.type === 'RegularElement' &&
+			node.attributes.some(
+				(attr) =>
+					attr.type === 'Attribute' &&
+					attr.name === 'data-testid' &&
+					Array.isArray(attr.value) &&
+					attr.value.some((v) => v.type === 'Text' && v.data === 'base')
+			)
+	);
+	if (alreadyAdded) return false;
+
+	svelte.addFragment(ast, markup);
+});
+
 export function addFixture(cwd: string, variant: string) {
-	let page;
-	if (variant.startsWith('kit')) {
-		page = path.resolve(cwd, 'src', 'routes', '+page.svelte');
-	} else {
-		page = path.resolve(cwd, 'src', 'App.svelte');
-	}
-	const content = fs.readFileSync(page, 'utf8') + markup;
-	fs.writeFileSync(page, content, 'utf8');
+	const page = variant.startsWith('kit')
+		? path.resolve(cwd, 'src', 'routes', '+page.svelte')
+		: path.resolve(cwd, 'src', 'App.svelte');
+
+	const content = fs.readFileSync(page, 'utf8');
+	fs.writeFileSync(page, addMarkup(content), 'utf8');
 }

--- a/packages/sv/src/addons/vitest.config.ts
+++ b/packages/sv/src/addons/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineProject({
 		testTimeout: ONE_MINUTE * (isWindows ? 5 : 3),
 		hookTimeout: ONE_MINUTE * (isWindows ? 5 : 3),
 		retry: env.CI ? 3 : 0,
+		maxConcurrency: 4,
 		expect: {
 			requireAssertions: true
 		}


### PR DESCRIPTION
### Description

Test fixtures in `tailwindcss` and `mdsvex` addon tests appended markup without checking for prior insertion. With `retry: 3` in CI, a flaky first attempt would compound: each retry duplicated the fixture nodes, turning recoverable flakes into hard `strict mode violation` failures (e.g. [this run](https://github.com/sveltejs/svelte-ecosystem-ci/actions/runs/25539099855/job/74961005928)).

Both fixtures now use `transforms.svelte` / `transforms.svelteScript` from `sv-utils` and short-circuit via `return false` when a marker node is already present (same pattern as `addToDemoPage` in `addons/common.ts`).

### Checklist

- Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)
- Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable) - n/a, internal test infra only
- Allow maintainers to edit this PR
- I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)