### PR TITLE
fix: community add-on template imports `expect` from `vitest`

### DIFF
--- a/.changeset/spotty-trees-fix.md
+++ b/.changeset/spotty-trees-fix.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix: community add-on template imports `expect` from `vitest`

--- a/packages/sv/src/cli/tests/snapshots/@my-org/sv/tests/addon.test.js
+++ b/packages/sv/src/cli/tests/snapshots/@my-org/sv/tests/addon.test.js
@@ -1,6 +1,6 @@
-import { expect } from '@playwright/test';
 import fs from 'node:fs';
 import path from 'node:path';
+import { expect } from 'vitest';
 import addon from '../src/index.js';
 import { setupTest } from './setup/suite.js';
 

--- a/packages/sv/src/create/templates/addon/tests/addon.test.js
+++ b/packages/sv/src/create/templates/addon/tests/addon.test.js
@@ -1,6 +1,6 @@
-import { expect } from '@playwright/test';
 import fs from 'node:fs';
 import path from 'node:path';
+import { expect } from 'vitest';
 import addon from '../src/index.js';
 import { setupTest } from './setup/suite.js';
 


### PR DESCRIPTION
Closes https://github.com/sveltejs/svelte-ecosystem-ci/actions/runs/25781686887/job/75725574604 issue

### Description

We use `@playwright/test: ^1.59.1` and on npm i (in tests), it's taking the new https://github.com/microsoft/playwright/releases/tag/v1.60.0 . And the count of `expect` in vitest is not matching with this playwright change. Anyway, all our expects could be done via vitest, so let's switch to it

### Checklist

- Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)
- Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable)
- Allow maintainers to edit this PR
- I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)
