### PR TITLE
support addon for unjs/fontless

### DIFF
--- a/.changeset/loose-tires-melt.md
+++ b/.changeset/loose-tires-melt.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+feat(add): add `fontless` addon

--- a/documentation/docs/30-add-ons/51-fontless.md
+++ b/documentation/docs/30-add-ons/51-fontless.md
@@ -1,0 +1,15 @@
+---
+title: fontless
+---
+
+[Fontless](https://github.com/unjs/fontaine/tree/main/packages/fontless) is a build-time plug-and-play font optimization tool.
+
+## Usage
+
+```sh
+npx sv add fontless
+```
+
+## What you get
+
+- `fontless` vite plugin installed in your `vite.config.{js,ts}` with the default configuration.

--- a/packages/sv/src/addons/fontless.ts
+++ b/packages/sv/src/addons/fontless.ts
@@ -1,0 +1,71 @@
+import { transforms, color } from '@sveltejs/sv-utils';
+import fs from 'node:fs';
+import { join } from 'node:path';
+import { defineAddon } from '../core/config.ts';
+
+export default defineAddon({
+	id: 'fontless',
+	shortDescription: 'font management',
+	homepage: 'https://github.com/unjs/fontaine/tree/main/packages/fontless',
+	options: {},
+	run: ({ sv, file }) => {
+		sv.devDependency('fontless', '^0.2.1');
+		sv.file(
+			file.viteConfig,
+			transforms.script(({ ast, js }) => {
+				const vitePluginName = 'fontless';
+				js.imports.addNamed(ast, { imports: [vitePluginName], from: 'fontless' });
+				js.vite.addPlugin(ast, {
+					code: `${vitePluginName}()`
+				});
+			})
+		);
+	},
+	nextSteps: ({ file, directory }) => {
+		const steps = [
+			`Your font-family should be ${color.success('automatically detected')} by fontless!`
+		];
+
+		const hasFontSourceImported =
+			fs.existsSync(file.stylesheet) &&
+			fs.readFileSync(file.stylesheet, 'utf-8').includes('@fontsource');
+		if (hasFontSourceImported) {
+			steps.push(
+				`${color.warning(
+					`${color.path(file.stylesheet)} has some @fontsource usage and may no longer be necessary.`
+				)}`
+			);
+		} else {
+			const hasFontSourceInstalled = fs.readFileSync(file.package, 'utf-8').includes('@fontsource');
+			if (hasFontSourceInstalled) {
+				steps.push(
+					`${color.warning(
+						`@fontsource is installed as a dependency and may no longer be necessary.`
+					)}`
+				);
+			}
+		}
+
+		const googleFontsDomain = 'fonts.googleapis.com';
+		const entryFiles = [join(directory.src, 'app.html'), join(directory.src, 'App.svelte')];
+		let fileUsingGoogleFont: string | null = null;
+		for (const file of entryFiles) {
+			if (fs.existsSync(file) && fs.readFileSync(file, 'utf-8').includes(googleFontsDomain)) {
+				fileUsingGoogleFont = file;
+			}
+		}
+
+		if (fileUsingGoogleFont) {
+			steps.push(
+				`${color.warning(
+					`${color.path(fileUsingGoogleFont)} contains some ${color.website(googleFontsDomain)} references and may no longer be necessary`
+				)}`
+			);
+		}
+
+		steps.push(
+			`Visit ${color.website('https://github.com/unjs/fontaine/tree/main/packages/fontless')} for more configuration options.`
+		);
+		return steps;
+	}
+});

--- a/packages/sv/src/addons/index.ts
+++ b/packages/sv/src/addons/index.ts
@@ -2,6 +2,7 @@ import type { Addon, AddonDefinition } from '../core/config.ts';
 import betterAuth from './better-auth.ts';
 import drizzle from './drizzle.ts';
 import eslint from './eslint.ts';
+import fontless from './fontless.ts';
 import mcp from './mcp.ts';
 import mdsvex from './mdsvex.ts';
 import paraglide from './paraglide.ts';
@@ -25,6 +26,7 @@ type OfficialAddons = {
 	paraglide: Addon<any>;
 	storybook: Addon<any>;
 	mcp: Addon<any>;
+	fontless: Addon<any>;
 };
 
 // The order of addons here determines the order they are displayed inside the CLI
@@ -41,7 +43,8 @@ export const officialAddons: OfficialAddons = {
 	mdsvex,
 	paraglide,
 	storybook,
-	mcp
+	mcp,
+	fontless
 };
 
 export function getAddonDetails(id: string): AddonDefinition {

--- a/packages/sv/src/addons/tests/fontless/test.ts
+++ b/packages/sv/src/addons/tests/fontless/test.ts
@@ -1,0 +1,20 @@
+import { expect } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import fontless from '../../fontless.ts';
+import { setupTest } from '../_setup/suite.ts';
+
+const { test, testCases } = setupTest(
+	{ fontless },
+	{
+		kinds: [{ type: 'default', options: { fontless: {} } }],
+		browser: false
+	}
+);
+
+test.concurrent.for(testCases)('fontless $variant', (testCase, { ...ctx }) => {
+	const cwd = ctx.cwd(testCase);
+
+	const ext = testCase.variant.split('-')[1];
+	expect(readFileSync(join(cwd, `vite.config.${ext}`), 'utf8')).toMatch('fontless');
+});


### PR DESCRIPTION
### Description

The PR supports a [fontless](https://github.com/unjs/fontaine/tree/main/packages/fontless) addon from the UnJS team. Not sure what the threshold or requirements are for a tool to be supported as an official addon, but I thought I'd give this a try. The weekly download on [npmx](https://npmx.dev/package/fontless) or [npmjs](https://www.npmjs.com/package/fontless) sits at ~345k at the time of this writing, increasing in trend. 

Personally, I find fontless to be a great addition to the Svelte/Kit ecosystem; it should reduce significantly the maintenance effort around common font setup.

I've been keeping an eye on fontless since it's first public release back in 2025. As of now, it works well with the latest Svelte+Vite or SvelteKit setup. See https://github.com/unjs/fontaine/issues/558 for some more information.

### Testing

The test simply checks if the vite config file contains the str "fontless". It's not that helpful and I'm happy to remove it if necessary. We don't need any other assertion at this time imo.

#### Documentation

I didn't see any instructions on how to index the markdown docs file and decided to name it `51-fontless.md` to stay closet to `tailwind` which hopefully groups them in the same CSS related category.

#### Changeset

I flag this change as a `patch` after looking at the release history for similar addon additions. I would usually give something like this a `minor` - new feature. Let me know if any adjustment is needed.

### Checklist

- ~~[ ] Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)~~ not applicable
- [x] Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable)
- [x] Allow maintainers to edit this PR
- [x] I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)
