### PR TITLE
fix(better-auth): import User/Session types from better-auth

### DIFF
--- a/.changeset/better-auth-fix-types.md
+++ b/.changeset/better-auth-fix-types.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix(better-auth): import `User`/`Session` types from `better-auth` instead of `better-auth/minimal`

--- a/packages/sv/src/addons/better-auth.ts
+++ b/packages/sv/src/addons/better-auth.ts
@@ -209,7 +209,7 @@ export default defineAddon({
 				if (d1) js.imports.addNamed(ast, { imports: ['createAuth'], from: '$lib/server/auth' });
 				js.imports.addNamed(ast, {
 					imports: ['User', 'Session'],
-					from: 'better-auth/minimal',
+					from: 'better-auth',
 					isType: true
 				});
 

--- a/packages/sv/src/cli/tests/snapshots/create-with-all-addons/src/app.d.ts
+++ b/packages/sv/src/cli/tests/snapshots/create-with-all-addons/src/app.d.ts
@@ -1,4 +1,4 @@
-import type { User, Session } from 'better-auth/minimal';
+import type { User, Session } from 'better-auth';
 
 // See https://svelte.dev/docs/kit/types#app.d.ts
 // for information about these interfaces


### PR DESCRIPTION
Closes #1099

### Description

The `better-auth/minimal` entry point only exports `betterAuth`/`BetterAuthOptions`, not `User`/`Session`. Those types now resolve from the main `better-auth` entry. The runtime `betterAuth` import stays on `/minimal` (type-only change, no bundle/dependency impact).

### Checklist

- [x] Update snapshots (if applicable)
- [x] Add a changeset (if applicable)
- [x] Allow maintainers to edit this PR
- [x] I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)
