### PR TITLE
fix(sv): community add-on template pins `sv` and `@sveltejs/sv-utils` versions

### DIFF
--- a/.changeset/sv-addon-peer-version.md
+++ b/.changeset/sv-addon-peer-version.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix(sv): community add-on template now pins `sv` and `@sveltejs/sv-utils` to a version range instead of `latest`

--- a/packages/sv/src/cli/tests/cli.ts
+++ b/packages/sv/src/cli/tests/cli.ts
@@ -102,6 +102,15 @@ describe('cli', () => {
 					const { data: generatedPackageJson } = parse.json(generated);
 					// remove @types/node from generated package.json as we test on different node versions
 					delete generatedPackageJson.devDependencies['@types/node'];
+					// Normalize workspace package versions to avoid snapshot drift on version bumps
+					for (const pkg of ['sv', '@sveltejs/sv-utils']) {
+						if (generatedPackageJson.peerDependencies?.[pkg]) {
+							generatedPackageJson.peerDependencies[pkg] = '^0.0.0';
+						}
+						if (generatedPackageJson.devDependencies?.[pkg]) {
+							generatedPackageJson.devDependencies[pkg] = '^0.0.0';
+						}
+					}
 					generated = JSON.stringify(generatedPackageJson, null, 3).replaceAll('   ', '\t');
 				}
 

--- a/packages/sv/src/cli/tests/snapshots/@my-org/sv/package.json
+++ b/packages/sv/src/cli/tests/snapshots/@my-org/sv/package.json
@@ -24,12 +24,12 @@
 		"access": "public"
 	},
 	"peerDependencies": {
-		"sv": "latest"
+		"sv": "^0.0.0"
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.59.1",
-		"@sveltejs/sv-utils": "latest",
-		"sv": "latest",
+		"@sveltejs/sv-utils": "^0.0.0",
+		"sv": "^0.0.0",
 		"tsdown": "^0.21.7",
 		"vitest": "^4.1.3"
 	},

--- a/packages/sv/src/create/scripts/build-templates.js
+++ b/packages/sv/src/create/scripts/build-templates.js
@@ -98,8 +98,22 @@ async function generate_templates(dist, shared) {
 			// to be able to develop and deploy the app from here, but have a different
 			// package.json in newly created projects (based on package.template.json)
 			if (name === 'package.template.json') {
+				const packagesDir = path.resolve(pkgRoot, '..', '..', '..');
+				const getVersion = (/** @type {string} */ pkgDir) => {
+					const pkgPath = path.join(packagesDir, pkgDir, 'package.json');
+					return JSON.parse(fs.readFileSync(pkgPath, 'utf8')).version;
+				};
+				const replaceWorkspace = (
+					/** @type {string} */ str,
+					/** @type {string} */ key,
+					/** @type {string} */ version
+				) => {
+					return str.replaceAll(`"${key}": "workspace:*"`, `"${key}": "^${version}"`);
+				};
+
 				let contents = fs.readFileSync(path.join(cwd, name), 'utf8');
-				contents = contents.replace(/workspace:\*/g, 'latest');
+				contents = replaceWorkspace(contents, 'sv', getVersion('sv'));
+				contents = replaceWorkspace(contents, '@sveltejs/sv-utils', getVersion('sv-utils'));
 
 				fs.writeFileSync(path.join(dir, 'package.json'), contents);
 				continue;


### PR DESCRIPTION
Closes #1102

The `addon` template was generating `package.json` with `"sv": "latest"` in `peerDependencies`, which pnpm warns about (peer ranges should be real version ranges).

The build script now reads the current `sv` and `@sveltejs/sv-utils` versions from the workspace and substitutes `^<version>` for `workspace:*` in `package.template.json`.

Tests normalize these versions before snapshot comparison so the snapshot doesn't drift on every release.