### PR TITLE
feat(sv): add prisma as first class add-on

### DIFF
--- a/documentation/docs/30-add-ons/07-prisma.md
+++ b/documentation/docs/30-add-ons/07-prisma.md
@@ -1,0 +1,55 @@
+---
+title: prisma
+---
+
+[Prisma](https://www.prisma.io/) is a another TypeScript ORM for Node.js applications, with a schema-driven workflow and generated client.
+
+## Usage
+
+```sh
+npx sv add prisma
+```
+
+## What you get
+
+- a Prisma setup for SvelteKit projects
+- a generated Prisma client wired into the app
+- a `prisma/schema.prisma` schema file
+- a `prisma.config.ts` or `prisma.config.js` config file
+- an `.env` file with a database connection string
+
+## Options
+
+### database
+
+Which database to use:
+
+- `postgresql` — a common default for hosted and production setups
+- `sqlite` — a file-based option for local and lightweight setups
+
+```sh
+# PostgreSQL (default)
+npx sv add prisma="database:postgresql"
+
+# SQLite
+npx sv add prisma="database:sqlite"
+```
+
+This initial implementation focuses on PostgreSQL and SQLite, which are the most common starting points for Prisma projects.
+
+### adapter
+
+The Prisma adapter depends on the selected [`database`](#database):
+
+- For `postgresql`: `@prisma/adapter-pg`
+- For `sqlite`: `@prisma/adapter-better-sqlite3`
+
+```sh
+# PostgreSQL uses @prisma/adapter-pg
+npx sv add prisma="database:postgresql"
+
+# SQLite uses @prisma/adapter-better-sqlite3
+npx sv add prisma="database:sqlite"
+```
+
+The adapter is chosen automatically based on the selected database.

--- a/packages/sv/src/addons/index.ts
+++ b/packages/sv/src/addons/index.ts
@@ -7,6 +7,7 @@ import mdsvex from './mdsvex.ts';
 import paraglide from './paraglide.ts';
 import playwright from './playwright.ts';
 import prettier from './prettier.ts';
+import prisma from './prisma.ts';
 import storybook from './storybook.ts';
 import sveltekitAdapter from './sveltekit-adapter.ts';
 import tailwindcss from './tailwindcss.ts';
@@ -20,6 +21,7 @@ type OfficialAddons = {
 	tailwindcss: Addon<any>;
 	sveltekitAdapter: Addon<any>;
 	drizzle: Addon<any>;
+	prisma: Addon<any>;
 	betterAuth: Addon<any>;
 	mdsvex: Addon<any>;
 	paraglide: Addon<any>;
@@ -37,6 +39,7 @@ export const officialAddons: OfficialAddons = {
 	tailwindcss,
 	sveltekitAdapter,
 	drizzle,
+	prisma,
 	betterAuth,
 	mdsvex,
 	paraglide,

--- a/packages/sv/src/addons/prisma.ts
+++ b/packages/sv/src/addons/prisma.ts
@@ -62,7 +62,7 @@ export default defineAddon({
 			}
 		}
 
-		sv.devDependency('prisma', PRISMA_VERSION);
+		sv.dependency('prisma', PRISMA_VERSION);
 		sv.dependency('@prisma/client', PRISMA_CLIENT_VERSION);
 
 		if (database === 'sqlite') {

--- a/packages/sv/src/addons/prisma.ts
+++ b/packages/sv/src/addons/prisma.ts
@@ -81,8 +81,7 @@ export default defineAddon({
 
 		sv.dependency('dotenv', DOTENV_VERSION);
 
-		sv.file('.env', generateEnv(database, false));
-		sv.file('.env.example', generateEnv(database, true));
+		sv.file('.env', generateEnv(database));
 
 		sv.file(
 			file.package,
@@ -265,16 +264,13 @@ const generateSchema = (database: Database) => {
 	throw new Error(`Unsupported Prisma database: ${database}`);
 };
 
-type GenerateEnv = (database: Database, isExample: boolean) => TransformFn;
-const generateEnv: GenerateEnv = (database, isExample) =>
+type GenerateEnv = (database: Database) => TransformFn;
+const generateEnv: GenerateEnv = (database) =>
 	transforms.text(({ content, text }) => {
 		let value: string;
 		let comment: string;
 
-		if (isExample) {
-			value = '""';
-			comment = 'Prisma';
-		} else if (database === 'sqlite') {
+		if (database === 'sqlite') {
 			value = '"file:dev.db"';
 			comment = 'Replace with your SQLite file URL!';
 		} else if (database === 'postgresql') {

--- a/packages/sv/src/addons/prisma.ts
+++ b/packages/sv/src/addons/prisma.ts
@@ -19,6 +19,8 @@ const TYPES_PG_VERSION = '^8.20.0';
 const DOTENV_VERSION = '^17.4.2';
 const BETTER_SQLITE3_VERSION = '^12.10.0';
 
+type Database = 'postgresql' | 'sqlite';
+
 const options = defineAddonOptions()
 	.add('database', {
 		question: 'Which database would you like to use?',
@@ -43,7 +45,7 @@ export default defineAddon({
 		if (!isKit) return unsupported('Requires SvelteKit');
 	},
 	run: ({ sv, language, cwd, cancel, file, dependencyVersion, packageManager, options }) => {
-		const isSqlite = options.database === 'sqlite';
+		const database = options.database as Database;
 		const schemaPath = path.resolve(cwd, 'prisma', 'schema.prisma');
 		const configPath = path.resolve(cwd, `prisma.config.${language}`);
 		const clientPath = path.resolve(cwd, 'src', 'lib', `prisma.${language}`);
@@ -63,22 +65,24 @@ export default defineAddon({
 		sv.devDependency('prisma', PRISMA_VERSION);
 		sv.dependency('@prisma/client', PRISMA_CLIENT_VERSION);
 
-		if (isSqlite) {
+		if (database === 'sqlite') {
 			sv.dependency('@prisma/adapter-better-sqlite3', PRISMA_BETTER_SQLITE3_ADAPTER_VERSION);
 			sv.dependency('better-sqlite3', BETTER_SQLITE3_VERSION);
 			if (packageManager === 'pnpm') {
 				sv.file(file.findUp('pnpm-workspace.yaml'), pnpm.allowBuilds('better-sqlite3'));
 			}
-		} else {
+		} else if (database === 'postgresql') {
 			sv.dependency('@prisma/adapter-pg', PRISMA_PG_ADAPTER_VERSION);
 			sv.dependency('pg', PG_VERSION);
 			sv.devDependency('@types/pg', TYPES_PG_VERSION);
+		} else {
+			throw new Error(`Unsupported Prisma database: ${database}`);
 		}
 
 		sv.dependency('dotenv', DOTENV_VERSION);
 
-		sv.file('.env', generateEnv(isSqlite, false));
-		sv.file('.env.example', generateEnv(isSqlite, true));
+		sv.file('.env', generateEnv(database, false));
+		sv.file('.env.example', generateEnv(database, true));
 
 		sv.file(
 			file.package,
@@ -115,7 +119,7 @@ export default defineAddon({
 			transforms.text(({ content }) => {
 				if (content) return false;
 
-				return generateSchema(isSqlite);
+				return generateSchema(database);
 			})
 		);
 
@@ -146,7 +150,7 @@ export default defineAddon({
 			transforms.text(({ content }) => {
 				if (content) return false;
 
-				if (isSqlite) {
+				if (database === 'sqlite') {
 					return dedent`
 						import { PrismaBetterSqlite3 } from "@prisma/adapter-better-sqlite3";
 						import { PrismaClient } from "../generated/prisma/client";
@@ -162,12 +166,11 @@ export default defineAddon({
 
 						export default prisma;
 					`;
-				}
-
-				return dedent`
-					import { PrismaPg } from "@prisma/adapter-pg";
-					import { PrismaClient } from "../generated/prisma/client";
-					import { DATABASE_URL } from "$env/static/private";
+				} else if (database === 'postgresql') {
+					return dedent`
+						import { PrismaPg } from "@prisma/adapter-pg";
+						import { PrismaClient } from "../generated/prisma/client";
+						import { DATABASE_URL } from "$env/static/private";
 
 					const adapter = new PrismaPg({
 						connectionString: DATABASE_URL
@@ -177,65 +180,113 @@ export default defineAddon({
 						adapter
 					});
 
-					export default prisma;
-				`;
+						export default prisma;
+					`;
+				}
+
+				throw new Error(`Unsupported Prisma database: ${database}`);
 			})
 		);
 	},
 	nextSteps: ({ packageManager, options }) => [
-		options.database === 'sqlite'
-			? `Use ${color.env('DATABASE_URL')} in ${color.path('.env')} to point at your SQLite file`
-			: `Create a Prisma Postgres database, then replace ${color.env('DATABASE_URL')} in ${color.path('.env')}`,
+		(() => {
+			const database = options.database as Database;
+			if (database === 'sqlite') {
+				return `Use ${color.env('DATABASE_URL')} in ${color.path('.env')} to point at your SQLite file`;
+			} else if (database === 'postgresql') {
+				return `Create a Postgres database, then replace ${color.env('DATABASE_URL')} in ${color.path('.env')}`;
+			}
+
+			throw new Error(`Unsupported Prisma database: ${database}`);
+		})(),
 		`Run ${color.command(resolveCommandArray(packageManager, 'run', ['db:migrate']))} to create tables`,
 		`Run ${color.command(resolveCommandArray(packageManager, 'run', ['db:generate']))} after schema changes`,
 		`Run ${color.command(resolveCommandArray(packageManager, 'run', ['db:studio']))} to inspect your data`
 	]
 });
 
-const generateSchema = (isSqlite: boolean) => dedent`
-	generator client {
-	  provider = "prisma-client"
-	  output   = "../src/generated/prisma"
+const generateSchema = (database: Database) => {
+	if (database === 'sqlite') {
+		return dedent`
+			generator client {
+			  provider = "prisma-client"
+			  output   = "../src/generated/prisma"
+			}
+
+			datasource db {
+			  provider = "sqlite"
+			}
+
+			model User {
+			  id    Int     @id @default(autoincrement())
+			  email String  @unique
+			  name  String?
+			  posts Post[]
+			}
+
+			model Post {
+			  id        Int     @id @default(autoincrement())
+			  title     String
+			  content   String?
+			  published Boolean @default(false)
+			  authorId  Int
+			  author    User    @relation(fields: [authorId], references: [id])
+			}
+		`;
+	} else if (database === 'postgresql') {
+		return dedent`
+			generator client {
+			  provider = "prisma-client"
+			  output   = "../src/generated/prisma"
+			}
+
+			datasource db {
+			  provider = "postgresql"
+			}
+
+			model User {
+			  id    Int     @id @default(autoincrement())
+			  email String  @unique
+			  name  String?
+			  posts Post[]
+			}
+
+			model Post {
+			  id        Int     @id @default(autoincrement())
+			  title     String
+			  content   String?
+			  published Boolean @default(false)
+			  authorId  Int
+			  author    User    @relation(fields: [authorId], references: [id])
+			}
+		`;
 	}
 
-	datasource db {
-	  provider = "${isSqlite ? 'sqlite' : 'postgresql'}"
-	}
+	throw new Error(`Unsupported Prisma database: ${database}`);
+};
 
-	model User {
-	  id    Int     @id @default(autoincrement())
-	  email String  @unique
-	  name  String?
-	  posts Post[]
-	}
-
-	model Post {
-	  id        Int     @id @default(autoincrement())
-	  title     String
-	  content   String?
-	  published Boolean @default(false)
-	  authorId  Int
-	  author    User    @relation(fields: [authorId], references: [id])
-	}
-`;
-
-type GenerateEnv = (isSqlite: boolean, isExample: boolean) => TransformFn;
-const generateEnv: GenerateEnv = (isSqlite, isExample) =>
+type GenerateEnv = (database: Database, isExample: boolean) => TransformFn;
+const generateEnv: GenerateEnv = (database, isExample) =>
 	transforms.text(({ content, text }) => {
-		const value = isExample
-			? '""'
-			: isSqlite
-				? '"file:dev.db"'
-				: '"postgres://user:password@host:port/db-name"';
+		let value: string;
+		let comment: string;
+
+		if (isExample) {
+			value = '""';
+			comment = 'Prisma';
+		} else if (database === 'sqlite') {
+			value = '"file:dev.db"';
+			comment = 'Replace with your SQLite file URL!';
+		} else if (database === 'postgresql') {
+			value = '"postgres://user:password@host:port/db-name"';
+			comment = 'Replace with your Prisma Postgres connection string!';
+		} else {
+			throw new Error(`Unsupported Prisma database: ${database}`);
+		}
 
 		content = text.upsert(content, 'DATABASE_URL', {
 			value,
-			comment: [
-				'Prisma',
-				isSqlite
-					? 'Replace with your SQLite file URL!'
-					: 'Replace with your Prisma Postgres connection string!'
-			],
+			comment: ['Prisma', comment],
 			separator: true
 		});
 

--- a/packages/sv/src/addons/prisma.ts
+++ b/packages/sv/src/addons/prisma.ts
@@ -3,18 +3,33 @@ import {
 	dedent,
 	type TransformFn,
 	transforms,
+	pnpm,
 	resolveCommandArray
 } from '@sveltejs/sv-utils';
 import fs from 'node:fs';
 import path from 'node:path';
 import { defineAddon, defineAddonOptions } from '../core/config.ts';
 
-const PRISMA_VERSION = '^7.6.0';
-const PG_VERSION = '^8.13.1';
-const DOTENV_VERSION = '^16.4.7';
-const TYPES_PG_VERSION = '^8.11.11';
+const PRISMA_VERSION = '^7.8.0';
+const PRISMA_CLIENT_VERSION = '^7.8.0';
+const PRISMA_PG_ADAPTER_VERSION = '^7.8.0';
+const PRISMA_BETTER_SQLITE3_ADAPTER_VERSION = '^7.8.0';
+const PG_VERSION = '^8.21.0';
+const TYPES_PG_VERSION = '^8.20.0';
+const DOTENV_VERSION = '^17.4.2';
+const BETTER_SQLITE3_VERSION = '^12.10.0';
 
-const options = defineAddonOptions().build();
+const options = defineAddonOptions()
+	.add('database', {
+		question: 'Which database would you like to use?',
+		type: 'select',
+		default: 'postgresql',
+		options: [
+			{ value: 'postgresql', label: 'PostgreSQL' },
+			{ value: 'sqlite', label: 'SQLite' }
+		]
+	})
+	.build();
 
 export default defineAddon({
 	id: 'prisma',
@@ -27,7 +42,8 @@ export default defineAddon({
 
 		if (!isKit) return unsupported('Requires SvelteKit');
 	},
-	run: ({ sv, language, cwd, cancel, file, dependencyVersion }) => {
+	run: ({ sv, language, cwd, cancel, file, dependencyVersion, packageManager, options }) => {
+		const isSqlite = options.database === 'sqlite';
 		const schemaPath = path.resolve(cwd, 'prisma', 'schema.prisma');
 		const configPath = path.resolve(cwd, `prisma.config.${language}`);
 		const clientPath = path.resolve(cwd, 'src', 'lib', `prisma.${language}`);
@@ -45,14 +61,24 @@ export default defineAddon({
 		}
 
 		sv.devDependency('prisma', PRISMA_VERSION);
-		sv.dependency('@prisma/client', PRISMA_VERSION);
-		sv.dependency('@prisma/adapter-pg', PRISMA_VERSION);
-		sv.dependency('pg', PG_VERSION);
-		sv.devDependency('@types/pg', TYPES_PG_VERSION);
+		sv.dependency('@prisma/client', PRISMA_CLIENT_VERSION);
+
+		if (isSqlite) {
+			sv.dependency('@prisma/adapter-better-sqlite3', PRISMA_BETTER_SQLITE3_ADAPTER_VERSION);
+			sv.dependency('better-sqlite3', BETTER_SQLITE3_VERSION);
+			if (packageManager === 'pnpm') {
+				sv.file(file.findUp('pnpm-workspace.yaml'), pnpm.allowBuilds('better-sqlite3'));
+			}
+		} else {
+			sv.dependency('@prisma/adapter-pg', PRISMA_PG_ADAPTER_VERSION);
+			sv.dependency('pg', PG_VERSION);
+			sv.devDependency('@types/pg', TYPES_PG_VERSION);
+		}
+
 		sv.dependency('dotenv', DOTENV_VERSION);
 
-		sv.file('.env', generateEnv(false));
-		sv.file('.env.example', generateEnv(true));
+		sv.file('.env', generateEnv(isSqlite, false));
+		sv.file('.env.example', generateEnv(isSqlite, true));
 
 		sv.file(
 			file.package,
@@ -89,32 +115,7 @@ export default defineAddon({
 			transforms.text(({ content }) => {
 				if (content) return false;
 
-				return dedent`
-					generator client {
-					  provider = "prisma-client"
-					  output   = "../src/generated/prisma"
-					}
-
-					datasource db {
-					  provider = "postgresql"
-					}
-
-					model User {
-					  id    Int     @id @default(autoincrement())
-					  email String  @unique
-					  name  String?
-					  posts Post[]
-					}
-
-					model Post {
-					  id        Int     @id @default(autoincrement())
-					  title     String
-					  content   String?
-					  published Boolean @default(false)
-					  authorId  Int
-					  author    User    @relation(fields: [authorId], references: [id])
-					}
-				`;
+				return generateSchema(isSqlite);
 			})
 		);
 
@@ -145,6 +146,24 @@ export default defineAddon({
 			transforms.text(({ content }) => {
 				if (content) return false;
 
+				if (isSqlite) {
+					return dedent`
+						import { PrismaBetterSqlite3 } from "@prisma/adapter-better-sqlite3";
+						import { PrismaClient } from "../generated/prisma/client";
+						import { DATABASE_URL } from "$env/static/private";
+
+						const adapter = new PrismaBetterSqlite3({
+							url: DATABASE_URL
+						});
+
+						const prisma = new PrismaClient({
+							adapter
+						});
+
+						export default prisma;
+					`;
+				}
+
 				return dedent`
 					import { PrismaPg } from "@prisma/adapter-pg";
 					import { PrismaClient } from "../generated/prisma/client";
@@ -163,20 +182,60 @@ export default defineAddon({
 			})
 		);
 	},
-	nextSteps: ({ packageManager }) => [
-		`Create a Prisma Postgres database, then replace ${color.env('DATABASE_URL')} in ${color.path('.env')}`,
+	nextSteps: ({ packageManager, options }) => [
+		options.database === 'sqlite'
+			? `Use ${color.env('DATABASE_URL')} in ${color.path('.env')} to point at your SQLite file`
+			: `Create a Prisma Postgres database, then replace ${color.env('DATABASE_URL')} in ${color.path('.env')}`,
 		`Run ${color.command(resolveCommandArray(packageManager, 'run', ['db:migrate']))} to create tables`,
 		`Run ${color.command(resolveCommandArray(packageManager, 'run', ['db:generate']))} after schema changes`,
 		`Run ${color.command(resolveCommandArray(packageManager, 'run', ['db:studio']))} to inspect your data`
 	]
 });
 
-type GenerateEnv = (isExample: boolean) => TransformFn;
-const generateEnv: GenerateEnv = (isExample) =>
+const generateSchema = (isSqlite: boolean) => dedent`
+	generator client {
+	  provider = "prisma-client"
+	  output   = "../src/generated/prisma"
+	}
+
+	datasource db {
+	  provider = "${isSqlite ? 'sqlite' : 'postgresql'}"
+	}
+
+	model User {
+	  id    Int     @id @default(autoincrement())
+	  email String  @unique
+	  name  String?
+	  posts Post[]
+	}
+
+	model Post {
+	  id        Int     @id @default(autoincrement())
+	  title     String
+	  content   String?
+	  published Boolean @default(false)
+	  authorId  Int
+	  author    User    @relation(fields: [authorId], references: [id])
+	}
+`;
+
+type GenerateEnv = (isSqlite: boolean, isExample: boolean) => TransformFn;
+const generateEnv: GenerateEnv = (isSqlite, isExample) =>
 	transforms.text(({ content, text }) => {
+		const value = isExample
+			? '""'
+			: isSqlite
+				? '"file:dev.db"'
+				: '"postgres://user:password@host:port/db-name"';
+
 		content = text.upsert(content, 'DATABASE_URL', {
-			value: isExample ? '""' : '"postgres://user:password@host:port/db-name"',
-			comment: ['Prisma', 'Replace with your Prisma Postgres connection string!'],
+			value,
+			comment: [
+				'Prisma',
+				isSqlite
+					? 'Replace with your SQLite file URL!'
+					: 'Replace with your Prisma Postgres connection string!'
+			],
 			separator: true
 		});
 

--- a/packages/sv/src/addons/prisma.ts
+++ b/packages/sv/src/addons/prisma.ts
@@ -62,7 +62,7 @@ export default defineAddon({
 			}
 		}
 
-		sv.dependency('prisma', PRISMA_VERSION);
+		sv.devDependency('prisma', PRISMA_VERSION);
 		sv.dependency('@prisma/client', PRISMA_CLIENT_VERSION);
 
 		if (database === 'sqlite') {

--- a/packages/sv/src/addons/prisma.ts
+++ b/packages/sv/src/addons/prisma.ts
@@ -1,0 +1,184 @@
+import {
+	color,
+	dedent,
+	type TransformFn,
+	transforms,
+	resolveCommandArray
+} from '@sveltejs/sv-utils';
+import fs from 'node:fs';
+import path from 'node:path';
+import { defineAddon, defineAddonOptions } from '../core/config.ts';
+
+const PRISMA_VERSION = '^7.6.0';
+const PG_VERSION = '^8.13.1';
+const DOTENV_VERSION = '^16.4.7';
+const TYPES_PG_VERSION = '^8.11.11';
+
+const options = defineAddonOptions().build();
+
+export default defineAddon({
+	id: 'prisma',
+	shortDescription: 'database orm',
+	homepage: 'https://www.prisma.io',
+	options,
+	setup: ({ isKit, unsupported, runsAfter }) => {
+		runsAfter('prettier');
+		runsAfter('sveltekitAdapter');
+
+		if (!isKit) return unsupported('Requires SvelteKit');
+	},
+	run: ({ sv, language, cwd, cancel, file, dependencyVersion }) => {
+		const schemaPath = path.resolve(cwd, 'prisma', 'schema.prisma');
+		const configPath = path.resolve(cwd, `prisma.config.${language}`);
+		const clientPath = path.resolve(cwd, 'src', 'lib', `prisma.${language}`);
+		const generatedClientPath = path.resolve(cwd, 'src', 'generated', 'prisma');
+
+		for (const [label, filePath] of Object.entries({
+			'Prisma schema': schemaPath,
+			'Prisma config': configPath,
+			'Prisma client': clientPath,
+			'Prisma generated client': generatedClientPath
+		})) {
+			if (fs.existsSync(filePath)) {
+				return cancel(`Preexisting ${label} at '${filePath}'`);
+			}
+		}
+
+		sv.devDependency('prisma', PRISMA_VERSION);
+		sv.dependency('@prisma/client', PRISMA_VERSION);
+		sv.dependency('@prisma/adapter-pg', PRISMA_VERSION);
+		sv.dependency('pg', PG_VERSION);
+		sv.devDependency('@types/pg', TYPES_PG_VERSION);
+		sv.dependency('dotenv', DOTENV_VERSION);
+
+		sv.file('.env', generateEnv(false));
+		sv.file('.env.example', generateEnv(true));
+
+		sv.file(
+			file.package,
+			transforms.json(({ data, json }) => {
+				json.packageScriptsUpsert(data, 'db:migrate', 'prisma migrate dev');
+				json.packageScriptsUpsert(data, 'db:generate', 'prisma generate');
+				json.packageScriptsUpsert(data, 'db:studio', 'prisma studio');
+			})
+		);
+
+		const hasPrettier = Boolean(dependencyVersion('prettier'));
+		if (hasPrettier) {
+			sv.file(
+				'.prettierignore',
+				transforms.text(({ content, text }) => text.upsert(content, '/src/generated/prisma/'))
+			);
+		}
+
+		sv.file(
+			file.gitignore,
+			transforms.text(({ content, text }) => {
+				if (content.length === 0) return false;
+				return text.upsert(content, '/src/generated/prisma/', {
+					comment: 'Prisma generated client',
+					separator: true
+				});
+			})
+		);
+
+		fs.mkdirSync(path.resolve(cwd, 'prisma'), { recursive: true });
+
+		sv.file(
+			'prisma/schema.prisma',
+			transforms.text(({ content }) => {
+				if (content) return false;
+
+				return dedent`
+					generator client {
+					  provider = "prisma-client"
+					  output   = "../src/generated/prisma"
+					}
+
+					datasource db {
+					  provider = "postgresql"
+					}
+
+					model User {
+					  id    Int     @id @default(autoincrement())
+					  email String  @unique
+					  name  String?
+					  posts Post[]
+					}
+
+					model Post {
+					  id        Int     @id @default(autoincrement())
+					  title     String
+					  content   String?
+					  published Boolean @default(false)
+					  authorId  Int
+					  author    User    @relation(fields: [authorId], references: [id])
+					}
+				`;
+			})
+		);
+
+		sv.file(
+			`prisma.config.${language}`,
+			transforms.text(({ content }) => {
+				if (content) return false;
+
+				return dedent`
+					import "dotenv/config";
+					import { defineConfig, env } from "prisma/config";
+
+					export default defineConfig({
+						schema: "prisma/schema.prisma",
+						migrations: {
+							path: "prisma/migrations"
+						},
+						datasource: {
+							url: env("DATABASE_URL")
+						}
+					});
+				`;
+			})
+		);
+
+		sv.file(
+			`src/lib/prisma.${language}`,
+			transforms.text(({ content }) => {
+				if (content) return false;
+
+				return dedent`
+					import { PrismaPg } from "@prisma/adapter-pg";
+					import { PrismaClient } from "../generated/prisma/client";
+					import { DATABASE_URL } from "$env/static/private";
+
+					const adapter = new PrismaPg({
+						connectionString: DATABASE_URL
+					});
+
+					const prisma = new PrismaClient({
+						adapter
+					});
+
+					export default prisma;
+				`;
+			})
+		);
+	},
+	nextSteps: ({ packageManager }) => [
+		`Create a Prisma Postgres database, then replace ${color.env('DATABASE_URL')} in ${color.path('.env')}`,
+		`Run ${color.command(resolveCommandArray(packageManager, 'run', ['db:migrate']))} to create tables`,
+		`Run ${color.command(resolveCommandArray(packageManager, 'run', ['db:generate']))} after schema changes`,
+		`Run ${color.command(resolveCommandArray(packageManager, 'run', ['db:studio']))} to inspect your data`
+	]
+});
+
+type GenerateEnv = (isExample: boolean) => TransformFn;
+const generateEnv: GenerateEnv = (isExample) =>
+	transforms.text(({ content, text }) => {
+		content = text.upsert(content, 'DATABASE_URL', {
+			value: isExample ? '""' : '"postgres://user:password@host:port/db-name"',
+			comment: ['Prisma', 'Replace with your Prisma Postgres connection string!'],
+			separator: true
+		});
+
+		return content;
+	});

--- a/packages/sv/src/addons/tests/prisma/test.ts
+++ b/packages/sv/src/addons/tests/prisma/test.ts
@@ -1,0 +1,61 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { expect } from 'vitest';
+import prisma from '../../prisma.ts';
+import { setupTest } from '../_setup/suite.ts';
+
+const { test, testCases } = setupTest(
+	{ prisma },
+	{
+		kinds: [
+			{ type: 'sqlite', options: { prisma: { database: 'sqlite' } } },
+			{ type: 'postgresql', options: { prisma: { database: 'postgresql' } } }
+		],
+		browser: false,
+		filter: (addonTestCase) => addonTestCase.variant.includes('kit')
+	}
+);
+
+test.concurrent.for(testCases)('prisma $kind.type $variant', (testCase, { ...ctx }) => {
+	const cwd = ctx.cwd(testCase);
+	const language = testCase.variant.endsWith('ts') ? 'ts' : 'js';
+	const packageJson = JSON.parse(fs.readFileSync(path.resolve(cwd, 'package.json'), 'utf8'));
+	const schema = fs.readFileSync(path.resolve(cwd, 'prisma/schema.prisma'), 'utf8');
+	const config = fs.readFileSync(path.resolve(cwd, `prisma.config.${language}`), 'utf8');
+	const client = fs.readFileSync(path.resolve(cwd, `src/lib/prisma.${language}`), 'utf8');
+	const env = fs.readFileSync(path.resolve(cwd, '.env'), 'utf8');
+	const envExample = fs.readFileSync(path.resolve(cwd, '.env.example'), 'utf8');
+
+	expect(packageJson.dependencies?.['@prisma/client']).toBe('^7.8.0');
+	expect(packageJson.dependencies?.dotenv).toBe('^17.4.2');
+	expect(config).toContain('schema: "prisma/schema.prisma"');
+	expect(config).toContain('url: env("DATABASE_URL")');
+
+	if (testCase.kind.type === 'sqlite') {
+		expect(schema).toContain('provider = "sqlite"');
+		expect(client).toContain('@prisma/adapter-better-sqlite3');
+		expect(client).toContain('PrismaBetterSqlite3');
+		expect(client).toContain('url: DATABASE_URL');
+		expect(env).toContain('DATABASE_URL="file:dev.db"');
+		expect(envExample).toContain('DATABASE_URL=""');
+		expect(packageJson.dependencies?.['@prisma/adapter-better-sqlite3']).toBe('^7.8.0');
+		expect(packageJson.dependencies?.['better-sqlite3']).toBe('^12.10.0');
+		expect(packageJson.dependencies?.['@prisma/adapter-pg']).toBeUndefined();
+		expect(packageJson.dependencies?.pg).toBeUndefined();
+		expect(packageJson.devDependencies?.['@types/pg']).toBeUndefined();
+	} else if (testCase.kind.type === 'postgresql') {
+		expect(schema).toContain('provider = "postgresql"');
+		expect(client).toContain('@prisma/adapter-pg');
+		expect(client).toContain('PrismaPg');
+		expect(client).toContain('connectionString: DATABASE_URL');
+		expect(env).toContain('DATABASE_URL="postgres://user:password@host:port/db-name"');
+		expect(envExample).toContain('DATABASE_URL=""');
+		expect(packageJson.dependencies?.['@prisma/adapter-pg']).toBe('^7.8.0');
+		expect(packageJson.dependencies?.pg).toBe('^8.21.0');
+		expect(packageJson.devDependencies?.['@types/pg']).toBe('^8.20.0');
+		expect(packageJson.dependencies?.['@prisma/adapter-better-sqlite3']).toBeUndefined();
+		expect(packageJson.dependencies?.['better-sqlite3']).toBeUndefined();
+	} else {
+		throw new Error(`Unsupported prisma test kind: ${testCase.kind.type}`);
+	}
+});

--- a/packages/sv/src/addons/tests/prisma/test.ts
+++ b/packages/sv/src/addons/tests/prisma/test.ts
@@ -26,9 +26,9 @@ test.concurrent.for(testCases)('prisma $kind.type $variant', (testCase, { ...ctx
 	const env = fs.readFileSync(path.resolve(cwd, '.env'), 'utf8');
 
 	// checks all the neccesary files and packages in package.json
-	expect(packageJson.dependencies?.prisma).toBe('^7.8.0');
+	expect(packageJson.devDependencies.prisma).toBe('^7.8.0');
 	expect(packageJson.dependencies?.['@prisma/client']).toBe('^7.8.0');
-	expect(packageJson.dependencies?.dotenv).toBe('^17.4.2');
+	expect(packageJson.dependencies.dotenv).toBe('^17.4.2');
 	expect(config).toContain('schema: "prisma/schema.prisma"');
 	expect(config).toContain('url: env("DATABASE_URL")');
 
@@ -38,22 +38,22 @@ test.concurrent.for(testCases)('prisma $kind.type $variant', (testCase, { ...ctx
 		expect(client).toContain('PrismaBetterSqlite3');
 		expect(client).toContain('url: DATABASE_URL');
 		expect(env).toContain('DATABASE_URL="file:dev.db"');
-		expect(packageJson.dependencies?.['@prisma/adapter-better-sqlite3']).toBe('^7.8.0');
-		expect(packageJson.dependencies?.['better-sqlite3']).toBe('^12.10.0');
-		expect(packageJson.dependencies?.['@prisma/adapter-pg']).toBeUndefined();
-		expect(packageJson.dependencies?.pg).toBeUndefined();
-		expect(packageJson.devDependencies?.['@types/pg']).toBeUndefined();
+		expect(packageJson.dependencies['@prisma/adapter-better-sqlite3']).toBe('^7.8.0');
+		expect(packageJson.dependencies['better-sqlite3']).toBe('^12.10.0');
+		expect(packageJson.dependencies['@prisma/adapter-pg']).toBeUndefined();
+		expect(packageJson.dependencies.pg).toBeUndefined();
+		expect(packageJson.devDependencies['@types/pg']).toBeUndefined();
 	} else if (testCase.kind.type === 'postgresql') {
 		expect(schema).toContain('provider = "postgresql"');
 		expect(client).toContain('@prisma/adapter-pg');
 		expect(client).toContain('PrismaPg');
 		expect(client).toContain('connectionString: DATABASE_URL');
 		expect(env).toContain('DATABASE_URL="postgres://user:password@host:port/db-name"');
-		expect(packageJson.dependencies?.['@prisma/adapter-pg']).toBe('^7.8.0');
-		expect(packageJson.dependencies?.pg).toBe('^8.21.0');
-		expect(packageJson.devDependencies?.['@types/pg']).toBe('^8.20.0');
-		expect(packageJson.dependencies?.['@prisma/adapter-better-sqlite3']).toBeUndefined();
-		expect(packageJson.dependencies?.['better-sqlite3']).toBeUndefined();
+		expect(packageJson.dependencies['@prisma/adapter-pg']).toBe('^7.8.0');
+		expect(packageJson.dependencies.pg).toBe('^8.21.0');
+		expect(packageJson.devDependencies['@types/pg']).toBe('^8.20.0');
+		expect(packageJson.dependencies['@prisma/adapter-better-sqlite3']).toBeUndefined();
+		expect(packageJson.dependencies['better-sqlite3']).toBeUndefined();
 	} else {
 		throw new Error(`Unsupported prisma test kind: ${testCase.kind.type}`);
 	}

--- a/packages/sv/src/addons/tests/prisma/test.ts
+++ b/packages/sv/src/addons/tests/prisma/test.ts
@@ -25,6 +25,8 @@ test.concurrent.for(testCases)('prisma $kind.type $variant', (testCase, { ...ctx
 	const client = fs.readFileSync(path.resolve(cwd, `src/lib/prisma.${language}`), 'utf8');
 	const env = fs.readFileSync(path.resolve(cwd, '.env'), 'utf8');
 
+	// checks all the neccesary files and packages in package.json
+	expect(packageJson.dependencies?.prisma).toBe('^7.8.0');
 	expect(packageJson.dependencies?.['@prisma/client']).toBe('^7.8.0');
 	expect(packageJson.dependencies?.dotenv).toBe('^17.4.2');
 	expect(config).toContain('schema: "prisma/schema.prisma"');

--- a/packages/sv/src/addons/tests/prisma/test.ts
+++ b/packages/sv/src/addons/tests/prisma/test.ts
@@ -24,7 +24,6 @@ test.concurrent.for(testCases)('prisma $kind.type $variant', (testCase, { ...ctx
 	const config = fs.readFileSync(path.resolve(cwd, `prisma.config.${language}`), 'utf8');
 	const client = fs.readFileSync(path.resolve(cwd, `src/lib/prisma.${language}`), 'utf8');
 	const env = fs.readFileSync(path.resolve(cwd, '.env'), 'utf8');
-	const envExample = fs.readFileSync(path.resolve(cwd, '.env.example'), 'utf8');
 
 	expect(packageJson.dependencies?.['@prisma/client']).toBe('^7.8.0');
 	expect(packageJson.dependencies?.dotenv).toBe('^17.4.2');
@@ -37,7 +36,6 @@ test.concurrent.for(testCases)('prisma $kind.type $variant', (testCase, { ...ctx
 		expect(client).toContain('PrismaBetterSqlite3');
 		expect(client).toContain('url: DATABASE_URL');
 		expect(env).toContain('DATABASE_URL="file:dev.db"');
-		expect(envExample).toContain('DATABASE_URL=""');
 		expect(packageJson.dependencies?.['@prisma/adapter-better-sqlite3']).toBe('^7.8.0');
 		expect(packageJson.dependencies?.['better-sqlite3']).toBe('^12.10.0');
 		expect(packageJson.dependencies?.['@prisma/adapter-pg']).toBeUndefined();
@@ -49,7 +47,6 @@ test.concurrent.for(testCases)('prisma $kind.type $variant', (testCase, { ...ctx
 		expect(client).toContain('PrismaPg');
 		expect(client).toContain('connectionString: DATABASE_URL');
 		expect(env).toContain('DATABASE_URL="postgres://user:password@host:port/db-name"');
-		expect(envExample).toContain('DATABASE_URL=""');
 		expect(packageJson.dependencies?.['@prisma/adapter-pg']).toBe('^7.8.0');
 		expect(packageJson.dependencies?.pg).toBe('^8.21.0');
 		expect(packageJson.devDependencies?.['@types/pg']).toBe('^8.20.0');


### PR DESCRIPTION
This adds Prisma as a first-class database ORM add-on in `sv`.

`sv` already provides Drizzle ORM as an official addon. In the TypeScript and Node.js ecosystem, Prisma is the other widely used choice, which is why I added this add-on.

This implementation supports:

- PostgreSQL
- SQLite

These are the most commonly used Prisma database options and provide a strong starting point for most projects.

## Why this matters

The goal is to make Prisma available through the same built-in add-on workflow that already exists for other core tooling in `sv`, so contributors can choose their preferred ORM without manual setup.

It is also inspired from `tanstack` cli. It provides both `drizzle` and `prisma` as first class addons

## Notes

- I tested the generated sveltekit projects in every format and everything is working as expected so far.
- MySQL is intentionally left out for now to keep the initial contribution focused.
- If there is community demand, I can add MySQL support in a follow-up.