### PR TITLE
fix(cli): restore create/add when no install flag is passed

### DIFF
--- a/.changeset/fix-create-install-default.md
+++ b/.changeset/fix-create-install-default.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix(cli): restore `sv create` and `sv add` when neither `--install` nor `--no-install` is passed

--- a/packages/sv/src/cli/add.ts
+++ b/packages/sv/src/cli/add.ts
@@ -37,7 +37,7 @@ const addonOptions = getAddonOptionFlags();
 
 const OptionsSchema = v.strictObject({
 	cwd: v.string(),
-	install: v.union([v.boolean(), v.picklist(AGENT_NAMES)]),
+	install: v.optional(v.union([v.boolean(), v.picklist(AGENT_NAMES)]), true),
 	gitCheck: v.boolean(),
 	downloadCheck: v.boolean(),
 	addons: v.record(v.string(), v.optional(v.array(v.string())))

--- a/packages/sv/src/cli/create.ts
+++ b/packages/sv/src/cli/create.ts
@@ -71,7 +71,7 @@ const OptionsSchema = v.strictObject({
 	),
 	addOns: v.boolean(),
 	add: v.array(v.string()),
-	install: v.union([v.boolean(), v.picklist(AGENT_NAMES)]),
+	install: v.optional(v.union([v.boolean(), v.picklist(AGENT_NAMES)]), true),
 	template: v.optional(v.picklist(templateChoices)),
 	fromPlayground: v.optional(v.string()),
 	dirCheck: v.boolean(),


### PR DESCRIPTION
Closes #1126

### Description

The `commander` v15 bump stopped defaulting `install` to `true` when no install flag is passed, so the valibot schema rejected `install: undefined`. Defaults it back to `true` in both `create` and `add`.

### Checklist

- Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)
- [x] Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable)
- [x] Allow maintainers to edit this PR
- [x] I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)
