### PR TITLE
docs: update the deprecated create overload

### DIFF
--- a/documentation/docs/50-api/10-sv.md
+++ b/documentation/docs/50-api/10-sv.md
@@ -87,7 +87,8 @@ Programmatically create a new Svelte project.
 ```js
 import { create } from 'sv';
 
-create('./my-app', {
+create({
+	cwd: './my-app´,
 	name: 'my-app',
 	template: 'minimal',
 	types: 'typescript'


### PR DESCRIPTION
Closes #1127

### Description

Updates the documentation for `create`.

### Checklist

- Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)
- Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable)
- Allow maintainers to edit this PR
- I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)
