### PR TITLE
fix: use the detected package manager in add-on next steps

### DIFF
--- a/.changeset/playwright-next-steps-pm.md
+++ b/.changeset/playwright-next-steps-pm.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix: use the detected package manager in add-on next steps (playwright, drizzle d1)

--- a/packages/sv/src/addons/drizzle.ts
+++ b/packages/sv/src/addons/drizzle.ts
@@ -522,7 +522,7 @@ export default defineAddon({
 				`Add your ${color.env('CLOUDFLARE_ACCOUNT_ID')}, ${color.env('CLOUDFLARE_DATABASE_ID')}, and ${color.env('CLOUDFLARE_D1_TOKEN')} to ${color.path('.env')}`
 			);
 			steps.push(
-				`Run ${color.command(resolveCommandArray(packageManager, 'run', ['wrangler', 'd1', 'create', '<DATABASE_NAME>']))} to generate a D1 database ID for your ${color.path(`wrangler.${ext}`)}`
+				`Run ${color.command(resolveCommandArray(packageManager, 'execute-local', ['wrangler', 'd1', 'create', '<DATABASE_NAME>']))} to generate a D1 database ID for your ${color.path(`wrangler.${ext}`)}`
 			);
 		}
 

--- a/packages/sv/src/addons/playwright.ts
+++ b/packages/sv/src/addons/playwright.ts
@@ -1,5 +1,5 @@
 import { log } from '@clack/prompts';
-import { color, dedent, transforms } from '@sveltejs/sv-utils';
+import { color, dedent, resolveCommandArray, transforms } from '@sveltejs/sv-utils';
 import { defineAddon } from '../core/config.ts';
 import { addToDemoPage } from './common.ts';
 
@@ -91,16 +91,20 @@ export default defineAddon({
 		);
 	},
 
-	nextSteps: ({ isKit }) => {
+	nextSteps: ({ isKit, packageManager }) => {
 		const steps: string[] = [];
 
-		steps.push(`Run ${color.command('npx playwright install')} to download browsers`);
+		steps.push(
+			`Run ${color.command(resolveCommandArray(packageManager, 'execute-local', ['playwright', 'install']))} to download browsers`
+		);
 
 		if (isKit) {
 			steps.push(`Visit ${color.route('/demo/playwright')} to see the demo page`);
 		}
 
-		steps.push(`Run ${color.command('npm run test:e2e')} to execute the example tests`);
+		steps.push(
+			`Run ${color.command(resolveCommandArray(packageManager, 'run', ['test:e2e']))} to execute the example tests`
+		);
 
 		return steps;
 	}


### PR DESCRIPTION
Closes #1132

### Description

fix: use the detected package manager in add-on next steps
note that in a few places we use `npm` in purpose today. It's debattable! In CI for example & in playwright preview script.

### Checklist

- Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)
- Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable)
- Allow maintainers to edit this PR
- I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)
