### PR TITLE
fix(create): `demo` project with typescript no longer causes lint error

### DIFF
--- a/.changeset/floppy-stamps-decide.md
+++ b/.changeset/floppy-stamps-decide.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix(create): `demo` project with typescript no longer causes lint error

--- a/packages/sv/src/create/templates/demo/src/routes/sverdle/+page.svelte
+++ b/packages/sv/src/create/templates/demo/src/routes/sverdle/+page.svelte
@@ -64,9 +64,8 @@
 	 */
 	function update(event: MouseEvent) {
 		event.preventDefault();
-		const key = /** @type {HTMLButtonElement} */ (event.target as HTMLButtonElement).getAttribute(
-			'data-key'
-		);
+		const target = /** @type {HTMLButtonElement} */ event.target as HTMLButtonElement;
+		const key = target.getAttribute('data-key');
 
 		if (key === 'backspace') {
 			currentGuess = currentGuess.slice(0, -1);


### PR DESCRIPTION
Closes #1134 

### Description

Since we generate the ts/js-doc/js templates from one template, this can cause issues. The ts and js-docs templates are now lint-error free after this change. The js template still causes a lint errors, which is because we removed the a jsdoc type beforehand. I think this should be fine though

### Checklist

- Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)
- Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable)
- Allow maintainers to edit this PR
- I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)
