### PR TITLE
docs: fix typo for string in `sv.md`

### DIFF
--- a/documentation/docs/50-api/10-sv.md
+++ b/documentation/docs/50-api/10-sv.md
@@ -88,7 +88,7 @@ Programmatically create a new Svelte project.
 import { create } from 'sv';
 
 create({
-	cwd: './my-app´,
+	cwd: './my-app',
 	name: 'my-app',
 	template: 'minimal',
 	types: 'typescript'


### PR DESCRIPTION
One of the closing string notations was a backtick instead of a single quote. This PR fixes that so that we can merge the CLI docs https://github.com/sveltejs/svelte.dev/pull/2035