### PR TITLE
chore: skip CI when updating non-relevant files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,17 @@ on:
   push:
     branches:
       - main
+    paths-ignore: &paths_ignore
+      - '.changeset/**'
+      - '.github/FUNDING.yml'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
+      - 'documentation/**'
+      - 'packages/*/CHANGELOG*.md'
+      - 'CONTRIBUTING.md'
+      - 'LICENSE'
+      - 'README.md'
   pull_request:
+    paths-ignore: *paths_ignore
 
 # cancel in-progress runs on new commits to same PR (gitub.event.number)
 concurrency:


### PR DESCRIPTION
We added this to the Kit repo a while back and it's useful for saving CI time https://github.com/sveltejs/kit/blob/main/.github/workflows/ci.yml