### PR TITLE
test(cli): raise create e2e timeout to 240s

### DIFF
--- a/packages/sv/src/cli/tests/cli.ts
+++ b/packages/sv/src/cli/tests/cli.ts
@@ -55,7 +55,7 @@ describe('cli', () => {
 
 	it.for(testCases)(
 		'should create a new project with name $projectName',
-		{ timeout: 123_000 },
+		{ timeout: 240_000 },
 		async (testCase) => {
 			const { projectName, args, template = 'minimal' } = testCase;
 


### PR DESCRIPTION
### Description

The `create-with-all-addons` case (create + cold-install ~11 add-ons + build + `auth:schema` + check) regularly exceeds the 123s budget on ubuntu CI runners, causing flaky timeouts unrelated to the change under test. Raise the per-test timeout to 240s.

### Checklist

- [ ] Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)
- [ ] Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable) - N/A, test only
- [x] Allow maintainers to edit this PR
- [x] I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)