### PR TITLE
fix: improve syntax for drizzle config

### DIFF
--- a/.changeset/sunny-frogs-care.md
+++ b/.changeset/sunny-frogs-care.md
@@ -1,0 +1,5 @@
+---
+"sv": patch
+---
+
+fix: improve syntax for drizzle config

--- a/.changeset/sv-utils-parse-expression-comments.md
+++ b/.changeset/sv-utils-parse-expression-comments.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/sv-utils": patch
+---
+
+fix: prevent `parseExpression` from duplicating nearby comments

--- a/packages/sv-utils/src/tooling/js/common.ts
+++ b/packages/sv-utils/src/tooling/js/common.ts
@@ -153,7 +153,8 @@ function maxLine(node: AstTypes.Node, comments: AstTypes.Comment[]): number {
 
 export function parseExpression(code: string): AstTypes.Expression {
 	const { ast } = parseScript(dedent(code));
-	stripAst(ast, ['raw']);
+	// Drop positions: this node is spliced elsewhere, so its `loc` only makes esrap mis-bind comments.
+	stripAst(ast, ['raw', 'loc', 'start', 'end', 'range']);
 	const statement = ast.body[0]!;
 	if (statement.type !== 'ExpressionStatement') {
 		throw new Error('Code provided was not an expression');

--- a/packages/sv/src/addons/drizzle.ts
+++ b/packages/sv/src/addons/drizzle.ts
@@ -304,7 +304,7 @@ export default defineAddon({
 			override({
 				typescript: {
 					config: js.common.parseExpression(
-						`(config) => ({ ...config, include: [...config.include, '../drizzle.config.${language}'] })`
+						`(config) => { config.include.push('../drizzle.config.${language}')}`
 					)
 				}
 			});

--- a/packages/sv/src/cli/tests/snapshots/create-experimental/vite.config.ts
+++ b/packages/sv/src/cli/tests/snapshots/create-experimental/vite.config.ts
@@ -12,11 +12,10 @@ export default defineConfig({
 			adapter: adapter(),
 			experimental: { explicitEnvironmentVariables: true },
 			typescript: {
-				config: (config) => ({
-					...config,
-					include: [...config.include, '../drizzle.config.ts']
-				})
-			}
+				config: (config) => {
+					config.include.push('../drizzle.config.ts');
+				}
+			}// Force runes mode for the project, except for libraries. Can be removed in svelte 6.
 		})
 	]
 });

--- a/packages/sv/src/cli/tests/snapshots/create-experimental/vite.config.ts
+++ b/packages/sv/src/cli/tests/snapshots/create-experimental/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
 				config: (config) => {
 					config.include.push('../drizzle.config.ts');
 				}
-			}// Force runes mode for the project, except for libraries. Can be removed in svelte 6.
+			}
 		})
 	]
 });

--- a/packages/sv/src/cli/tests/snapshots/create-with-all-addons/vite.config.ts
+++ b/packages/sv/src/cli/tests/snapshots/create-with-all-addons/vite.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
 				config: (config) => {
 					config.include.push('../drizzle.config.ts');
 				}
-			}// Force runes mode for the project, except for libraries. Can be removed in svelte 6.
+			}
 		}),
 		paraglideVitePlugin({ project: './project.inlang', outdir: './src/lib/paraglide' })
 	],

--- a/packages/sv/src/cli/tests/snapshots/create-with-all-addons/vite.config.ts
+++ b/packages/sv/src/cli/tests/snapshots/create-with-all-addons/vite.config.ts
@@ -18,11 +18,10 @@ export default defineConfig({
 			preprocess: [mdsvex({ extensions: ['.svx', '.md'] })],
 			extensions: ['.svelte', '.svx', '.md'],
 			typescript: {
-				config: (config) => ({
-					...config,
-					include: [...config.include, '../drizzle.config.ts']
-				})
-			}
+				config: (config) => {
+					config.include.push('../drizzle.config.ts');
+				}
+			}// Force runes mode for the project, except for libraries. Can be removed in svelte 6.
 		}),
 		paraglideVitePlugin({ project: './project.inlang', outdir: './src/lib/paraglide' })
 	],


### PR DESCRIPTION
### Description

> A function that allows you to edit the generated tsconfig.json. You can mutate the config (recommended)
https://svelte.dev/docs/kit/configuration#typescript

### Checklist

- Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)
- Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable)
- Allow maintainers to edit this PR
- I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)
