### PR TITLE
feat: migration-task comment management

### DIFF
--- a/packages/sv/src/cli/migrate.ts
+++ b/packages/sv/src/cli/migrate.ts
@@ -16,14 +16,16 @@ import {
 import { verifyCleanWorkingDirectory } from '../core/verifiers.ts';
 import { createWorkspace } from '../core/workspace.ts';
 import {
-	MIGRATION_TASK_MARKER,
-	getMigrationTaskCount,
-	resetMigrationTaskCount,
 	type Migration,
 	type MigrationCollectOptions,
 	type MigrationSetupOptions,
 	type TaskWithOptions
 } from '../migrate/index.ts';
+import {
+	MIGRATION_TASK_MARKER,
+	getMigrationTaskCount,
+	resetMigrationTaskCount
+} from '../migrate/migration-task.ts';
 import { legacyMigrations } from '../migrate/migrations/legacy-migrations/index.ts';
 import kit3 from '../migrate/migrations/sveltekit-3/index.ts';
 

--- a/packages/sv/src/cli/tests/migrate.ts
+++ b/packages/sv/src/cli/tests/migrate.ts
@@ -1,12 +1,12 @@
-import type { Comments } from '@sveltejs/sv-utils';
+import type { AstTypes, Comments } from '@sveltejs/sv-utils';
 import process from 'node:process';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { type TaskWithOptions } from '../../migrate/index.ts';
 import {
 	addMigrationTask,
 	getMigrationTaskCount,
-	resetMigrationTaskCount,
-	type TaskWithOptions
-} from '../../migrate/index.ts';
+	resetMigrationTaskCount
+} from '../../migrate/migration-task.ts';
 import { hasInstallConflict, selectOptionalTasksFromArgs } from '../migrate.ts';
 
 const optionalTasks: TaskWithOptions[] = [
@@ -68,7 +68,7 @@ describe('selectTasks', () => {
 describe('migration task tally', () => {
 	// a `Comments` stub: addMigrationTask only needs `add`
 	const comments = { add: () => {} } as unknown as Comments;
-	const node = {} as Parameters<typeof addMigrationTask>[1];
+	const node = {} as AstTypes.Node;
 
 	afterEach(() => resetMigrationTaskCount());
 
@@ -76,14 +76,14 @@ describe('migration task tally', () => {
 		resetMigrationTaskCount();
 		expect(getMigrationTaskCount()).toBe(0);
 
-		addMigrationTask(comments, node, 'do this');
-		addMigrationTask(comments, node, 'do that');
+		addMigrationTask('do this', { comments, node });
+		addMigrationTask('do that', { comments, node });
 
 		expect(getMigrationTaskCount()).toBe(2);
 	});
 
 	it('resets the count back to zero', () => {
-		addMigrationTask(comments, node, 'do this');
+		addMigrationTask('do this', { comments, node });
 		resetMigrationTaskCount();
 		expect(getMigrationTaskCount()).toBe(0);
 	});

--- a/packages/sv/src/migrate/index.ts
+++ b/packages/sv/src/migrate/index.ts
@@ -1,35 +1,6 @@
-import type { AstTypes, Comments, Package } from '@sveltejs/sv-utils';
+import type { Package } from '@sveltejs/sv-utils';
 import type { SvApi } from '../core/config.ts';
 import type { Workspace } from '../core/workspace.ts';
-
-/** Marker prefixing every manual follow-up a migration leaves in the user's code. */
-export const MIGRATION_TASK_MARKER = '@migration-task';
-
-let migrationTaskCount = 0;
-
-/** Running total of `@migration-task` comments left in the user's code during this migration run. */
-export function getMigrationTaskCount(): number {
-	return migrationTaskCount;
-}
-
-/** Resets the running total; call before starting a migration run. */
-export function resetMigrationTaskCount(): void {
-	migrationTaskCount = 0;
-}
-
-/**
- * Leaves a standardized `@migration-task` comment on `node` for the user to resolve manually,
- * and bumps the running total so the post-migration summary can report it without re-reading files.
- */
-export function addMigrationTask(
-	comments: Comments,
-	node: AstTypes.Node,
-	message: string,
-	options?: { position?: 'leading' | 'trailing' }
-): void {
-	comments.add(node, { type: 'Line', value: ` ${MIGRATION_TASK_MARKER} ${message}` }, options);
-	migrationTaskCount++;
-}
 
 export type Migration = {
 	id: string;

--- a/packages/sv/src/migrate/migration-task.spec.ts
+++ b/packages/sv/src/migrate/migration-task.spec.ts
@@ -1,0 +1,34 @@
+import { parse } from '@sveltejs/sv-utils';
+import { describe, expect, test } from 'vitest';
+import {
+	MIGRATION_TASK_MARKER,
+	addMigrationTask,
+	getMigrationTaskCount,
+	resetMigrationTaskCount
+} from './migration-task.ts';
+
+describe('addMigrationTask (svelte fragment target)', () => {
+	test('prints a real svelte comment and bumps the count', () => {
+		resetMigrationTaskCount();
+		const before = getMigrationTaskCount();
+
+		const { ast, generateCode } = parse.svelte('<p>hello</p>\n');
+		addMigrationTask('do something manually', { fragment: ast.fragment });
+
+		const code = generateCode();
+		expect(code).toContain(`<!-- ${MIGRATION_TASK_MARKER} do something manually -->`);
+		expect(getMigrationTaskCount()).toBe(before + 1);
+	});
+
+	test('inserts before the anchor node when it is a direct fragment child', () => {
+		const { ast, generateCode } = parse.svelte('<p>a</p>\n<span>b</span>\n');
+		const anchor = ast.fragment.nodes.find(
+			(node) => node.type === 'RegularElement' && node.name === 'span'
+		);
+		addMigrationTask('near span', { fragment: ast.fragment, anchor });
+
+		const code = generateCode();
+		expect(code.indexOf('@migration-task')).toBeLessThan(code.indexOf('<span'));
+		expect(code.indexOf('<p')).toBeLessThan(code.indexOf('@migration-task'));
+	});
+});

--- a/packages/sv/src/migrate/migration-task.ts
+++ b/packages/sv/src/migrate/migration-task.ts
@@ -1,0 +1,91 @@
+import type { AstTypes, Comments, SvelteAst } from '@sveltejs/sv-utils';
+
+/** Marker prefixing every manual follow-up a migration leaves in the user's code. */
+export const MIGRATION_TASK_MARKER = '@migration-task';
+
+let migrationTaskCount = 0;
+
+/** Running total of `@migration-task` comments left in the user's code during this migration run. */
+export function getMigrationTaskCount(): number {
+	return migrationTaskCount;
+}
+
+/** Resets the running total; call before starting a migration run. */
+export function resetMigrationTaskCount(): void {
+	migrationTaskCount = 0;
+}
+
+/** Target a JS/TS AST: attach the comment to `node` via the `comments` registry. */
+export type JsMigrationTaskTarget = {
+	comments: Comments;
+	node: AstTypes.Node;
+	position?: 'leading' | 'trailing';
+};
+
+/**
+ * Target a Svelte component: insert a real `Comment` node into `fragment`. Needed because the
+ * Svelte printer ignores the `Comments` registry but does print `Comment` AST nodes. The comment
+ * is placed before `anchor` when it's a direct child of the fragment, otherwise prepended.
+ */
+export type SvelteMigrationTaskTarget = {
+	fragment: SvelteAst.Fragment;
+	anchor?: SvelteAst.SvelteNode;
+};
+
+/**
+ * Leaves a standardized `@migration-task` comment for the user to resolve manually, and bumps the
+ * running total so the post-migration summary can report it without re-reading files.
+ *
+ * The placement depends on the `target` you pass:
+ * - `{ comments, node }` for a JS/TS AST (`transforms.script`)
+ * - `{ fragment }` for a `.svelte` component (`transforms.svelte` / `svelteScript`)
+ *
+ * @example
+ * ```ts
+ * addMigrationTask('rewrite this manually', { comments, node });
+ * addMigrationTask('rewrite this manually', { fragment: ast.fragment, anchor });
+ * ```
+ */
+export function addMigrationTask(
+	message: string,
+	target: JsMigrationTaskTarget | SvelteMigrationTaskTarget
+): void {
+	if ('fragment' in target) {
+		addSvelteComment(target.fragment, message, target.anchor);
+	} else {
+		target.comments.add(
+			target.node,
+			{ type: 'Line', value: ` ${MIGRATION_TASK_MARKER} ${message}` },
+			target.position ? { position: target.position } : undefined
+		);
+	}
+
+	migrationTaskCount++;
+}
+
+function addSvelteComment(
+	fragment: SvelteAst.Fragment,
+	message: string,
+	anchor?: SvelteAst.SvelteNode
+): void {
+	const comment: SvelteAst.Comment = {
+		type: 'Comment',
+		data: ` ${MIGRATION_TASK_MARKER} ${message} `,
+		start: 0,
+		end: 0
+	};
+	const newline: SvelteAst.Text = {
+		type: 'Text',
+		data: '\n',
+		raw: '\n',
+		start: 0,
+		end: 0
+	};
+
+	const index = anchor ? fragment.nodes.indexOf(anchor as (typeof fragment.nodes)[number]) : -1;
+	if (index === -1) {
+		fragment.nodes.unshift(comment, newline);
+	} else {
+		fragment.nodes.splice(index, 0, comment, newline);
+	}
+}

--- a/packages/sv/src/migrate/migrations/sveltekit-3/tasks/environment/explicit-env-vars.ts
+++ b/packages/sv/src/migrate/migrations/sveltekit-3/tasks/environment/explicit-env-vars.ts
@@ -1,5 +1,5 @@
 import { Walker, js, type AstTypes, type Comments, type SvelteAst } from '@sveltejs/sv-utils';
-import { addMigrationTask } from '../../../../index.ts';
+import { addMigrationTask } from '../../../../migration-task.ts';
 
 type UsageInfo = {
 	node: AstTypes.Expression;
@@ -52,8 +52,8 @@ export function migrateExplicitEnvVars(
 		mutated = true;
 	}
 
-	if (migrateDynamicEnvImports(ast, envVars, comments)) mutated = true;
-	if (template && migrateDynamicEnvImports(template, envVars, comments)) mutated = true;
+	if (migrateDynamicEnvImports(ast, envVars, comments, template)) mutated = true;
+	if (template && migrateDynamicEnvImports(template, envVars, comments, template)) mutated = true;
 
 	return mutated;
 }
@@ -66,7 +66,8 @@ export function migrateExplicitEnvVars(
 function migrateDynamicEnvImports(
 	node: AstTypes.Node | SvelteAst.SvelteNode,
 	envVars: Map<string, EnvVar>,
-	comments?: Comments
+	comments?: Comments,
+	svelteFragment?: SvelteAst.Fragment
 ): boolean {
 	let mutated = false;
 
@@ -85,7 +86,11 @@ function migrateDynamicEnvImports(
 				envVars.set(name, { type, scope, name });
 			}
 		} else {
-			addUnsupportedDynamicImportComment(comments, findCommentTarget(found.path) ?? found.node);
+			addUnsupportedDynamicImportComment(
+				comments,
+				findCommentTarget(found.path) ?? found.node,
+				svelteFragment
+			);
 		}
 	}
 
@@ -112,11 +117,19 @@ function getDestructuredEnvNames(
 
 function addUnsupportedDynamicImportComment(
 	comments: Comments | undefined,
-	node: AstTypes.Node
+	node: AstTypes.Node,
+	svelteFragment?: SvelteAst.Fragment
 ): void {
+	const message = 'Declare the imported env variables in src/env.ts manually.';
+
+	if (svelteFragment) {
+		addMigrationTask(message, { fragment: svelteFragment, anchor: node as SvelteAst.SvelteNode });
+		return;
+	}
+
 	if (!comments) return;
 
-	addMigrationTask(comments, node, 'Declare the imported env variables in src/env.ts manually.');
+	addMigrationTask(message, { comments, node });
 }
 
 function collectEnvImports(
@@ -176,12 +189,12 @@ function collectDynamicEnvImport(
 	);
 	if (!hasEnvImport) return;
 
-	const usages = getDynamicEnvUsages(ast, importNode, comments);
+	const usages = getDynamicEnvUsages(ast, importNode, comments, template);
 	if (!usages) {
 		return 'migration-task';
 	}
 	if (template) {
-		const templateUsages = getDynamicEnvUsages(template, importNode, comments);
+		const templateUsages = getDynamicEnvUsages(template, importNode, comments, template);
 		if (!templateUsages) {
 			return 'migration-task';
 		}
@@ -221,7 +234,8 @@ function collectStaticEnvImport(
 function getDynamicEnvUsages(
 	node: AstTypes.Node | SvelteAst.SvelteNode,
 	importNode: AstTypes.ImportDeclaration,
-	comments?: Comments
+	comments?: Comments,
+	svelteFragment?: SvelteAst.Fragment
 ): UsageInfo[] | undefined {
 	const importNames = new Set<string>();
 
@@ -245,7 +259,11 @@ function getDynamicEnvUsages(
 				const name = getDynamicEnvUsageName(node);
 				if (!name) {
 					hasUnsupportedUsage = true;
-					addUnsupportedDynamicEnvComment(comments, findCommentTarget(walkContext.path) ?? node);
+					addUnsupportedDynamicEnvComment(
+						comments,
+						findCommentTarget(walkContext.path) ?? node,
+						svelteFragment
+					);
 					walkContext.next();
 					return;
 				}
@@ -268,11 +286,19 @@ function getDynamicEnvUsages(
 
 function addUnsupportedDynamicEnvComment(
 	comments: Comments | undefined,
-	node: AstTypes.Node
+	node: AstTypes.Node,
+	svelteFragment?: SvelteAst.Fragment
 ): void {
+	const message = 'Rewrite dynamic env lookup manually.';
+
+	if (svelteFragment) {
+		addMigrationTask(message, { fragment: svelteFragment, anchor: node as SvelteAst.SvelteNode });
+		return;
+	}
+
 	if (!comments) return;
 
-	addMigrationTask(comments, node, 'Rewrite dynamic env lookup manually.');
+	addMigrationTask(message, { comments, node });
 }
 
 function findCommentTarget(

--- a/packages/sv/src/migrate/migrations/sveltekit-3/tasks/svelte-config.ts
+++ b/packages/sv/src/migrate/migrations/sveltekit-3/tasks/svelte-config.ts
@@ -1,8 +1,8 @@
 import { svelteConfig, transforms, Walker, type AstTypes, type Comments } from '@sveltejs/sv-utils';
 import fs from 'node:fs';
 import path from 'node:path';
-import { addMigrationTask } from '../../../migration-task.ts';
 import { defineMigrationTask } from '../../../index.ts';
+import { addMigrationTask } from '../../../migration-task.ts';
 
 // matches `svelte.config`, optionally with a (m/c)js/ts extension, at the end of an import source
 const SVELTE_CONFIG_IMPORT = /(^|\/)svelte\.config(\.[mc]?[jt]s)?$/;

--- a/packages/sv/src/migrate/migrations/sveltekit-3/tasks/svelte-config.ts
+++ b/packages/sv/src/migrate/migrations/sveltekit-3/tasks/svelte-config.ts
@@ -1,7 +1,8 @@
 import { svelteConfig, transforms, Walker, type AstTypes, type Comments } from '@sveltejs/sv-utils';
 import fs from 'node:fs';
 import path from 'node:path';
-import { addMigrationTask, defineMigrationTask } from '../../../index.ts';
+import { addMigrationTask } from '../../../migration-task.ts';
+import { defineMigrationTask } from '../../../index.ts';
 
 // matches `svelte.config`, optionally with a (m/c)js/ts extension, at the end of an import source
 const SVELTE_CONFIG_IMPORT = /(^|\/)svelte\.config(\.[mc]?[jt]s)?$/;
@@ -93,9 +94,8 @@ export default defineMigrationTask({
 					Property(node: AstTypes.Property, { next }: Walker.Context<AstTypes.Node, null>) {
 						if (node.key.type === 'Identifier' && node.key.name === 'trustedOrigins') {
 							addMigrationTask(
-								comments,
-								node,
-								"trusting all origins with '*' is generally not recommended, see https://svelte.dev/docs/kit/configuration#csrf"
+								"trusting all origins with '*' is generally not recommended, see https://svelte.dev/docs/kit/configuration#csrf",
+								{ comments, node }
 							);
 						}
 						next();
@@ -154,7 +154,7 @@ export default defineMigrationTask({
 					const found = js.imports.findAll(ast, { from: SVELTE_CONFIG_IMPORT });
 					if (found.length === 0) return false;
 					for (const imp of found) {
-						addMigrationTask(comments, imp.node, message);
+						addMigrationTask(message, { comments, node: imp.node });
 					}
 				})(content);
 			}

--- a/packages/sv/src/migrate/migrations/sveltekit-3/tests/environment/unsupported-dynamic-env.snapshot.svelte
+++ b/packages/sv/src/migrate/migrations/sveltekit-3/tests/environment/unsupported-dynamic-env.snapshot.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+	import { env } from '$env/dynamic/public';
+
+	let { name }: { name: string } = $props();
+</script>
+
+<!-- @migration-task Rewrite dynamic env lookup manually. -->
+<p>{env[name]}</p>

--- a/packages/sv/src/migrate/migrations/sveltekit-3/tests/environment/unsupported-dynamic-env.svelte
+++ b/packages/sv/src/migrate/migrations/sveltekit-3/tests/environment/unsupported-dynamic-env.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { env } from '$env/dynamic/public';
+
+	let { name }: { name: string } = $props();
+</script>
+
+<p>{env[name]}</p>


### PR DESCRIPTION
Targets `feat/sv-migrate`.

- `@migration-task` comments now also work in `.svelte` files. The Svelte printer ignores the JS `Comments` registry, so we insert real `Comment` nodes into the fragment. Fixes the environment task silently dropping these comments.
- One `addMigrationTask(message, target)` API, where the target picks the placement: `{ comments, node }` for JS/TS, `{ fragment, anchor? }` for `.svelte`.
- Split `migrate/index.ts` into `index.ts` (the `defineMigration*` framework) + `migration-task.ts` (the comment API, paired with its spec).