### PR TITLE
feat(migrate): defer formatting to project format script

### DIFF
--- a/.changeset/format-strategy-script.md
+++ b/.changeset/format-strategy-script.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+feat(migrate): defer formatting to the project's own `format`/`fmt` script when present, falling back to `prettier` on modified files

--- a/packages/sv-utils/api-surface.md
+++ b/packages/sv-utils/api-surface.md
@@ -784,6 +784,7 @@ declare const downloadJson: (url: string) => Promise<any>;
 type Package = {
 	name: string;
 	version: string;
+	scripts?: Record<string, string>;
 	dependencies?: Record<string, string>;
 	devDependencies?: Record<string, string>;
 	bugs?: string;

--- a/packages/sv-utils/src/files.ts
+++ b/packages/sv-utils/src/files.ts
@@ -5,6 +5,7 @@ import { parseJson } from './tooling/parsers.ts';
 export type Package = {
 	name: string;
 	version: string;
+	scripts?: Record<string, string>;
 	dependencies?: Record<string, string>;
 	devDependencies?: Record<string, string>;
 	bugs?: string;

--- a/packages/sv/src/cli/add.ts
+++ b/packages/sv/src/cli/add.ts
@@ -755,7 +755,12 @@ export async function runAddonsApply({
 	if (packageManager) {
 		workspace.packageManager = packageManager;
 		await installDependencies(packageManager, options.cwd);
-		await formatFiles({ packageManager, cwd: options.cwd, filesToFormat });
+		await formatFiles({
+			packageManager,
+			cwd: options.cwd,
+			filesToFormat,
+			strategy: 'files-only'
+		});
 	}
 
 	const nextSteps = getNextSteps(successfulAddons, workspace, answers, setupResults);

--- a/packages/sv/src/cli/create.ts
+++ b/packages/sv/src/cli/create.ts
@@ -401,7 +401,12 @@ async function createProject(cwd: ProjectPath, options: Options) {
 	addPnpmAllowBuilds(projectPath, packageManager, 'esbuild');
 	if (packageManager) {
 		await installDependencies(packageManager, projectPath);
-		await formatFiles({ packageManager, cwd: projectPath, filesToFormat: addOnFilesToFormat });
+		await formatFiles({
+			packageManager,
+			cwd: projectPath,
+			filesToFormat: addOnFilesToFormat,
+			strategy: 'files-only'
+		});
 	}
 
 	return { directory: projectPath, addOnNextSteps, packageManager };

--- a/packages/sv/src/cli/migrate.ts
+++ b/packages/sv/src/cli/migrate.ts
@@ -120,14 +120,12 @@ export const migrate = new Command('migrate')
 			if (legacyMigration) return;
 
 			const workspace = await createWorkspace({ cwd: verifiedOptions.cwd });
-			const hasFormatter = !!workspace.dependencyVersion('prettier');
-			if (hasFormatter) {
-				await formatFiles({
-					cwd: workspace.cwd,
-					packageManager: workspace.packageManager,
-					filesToFormat: modifiedFiles.values().toArray()
-				});
-			}
+			await formatFiles({
+				cwd: workspace.cwd,
+				packageManager: workspace.packageManager,
+				filesToFormat: modifiedFiles.values().toArray(),
+				strategy: 'project-script-then-files-only'
+			});
 
 			const packageManager =
 				verifiedOptions.install === false

--- a/packages/sv/src/core/formatFiles.ts
+++ b/packages/sv/src/core/formatFiles.ts
@@ -1,8 +1,8 @@
 import * as p from '@clack/prompts';
 import { type AgentName, loadPackageJson, resolveCommand } from '@sveltejs/sv-utils';
-import { exec } from 'tinyexec';
 import fs from 'node:fs';
 import path from 'node:path';
+import { exec } from 'tinyexec';
 import { detectPackageManager } from './package-manager.ts';
 import { findWorkspaceRoot } from './workspace.ts';
 

--- a/packages/sv/src/core/formatFiles.ts
+++ b/packages/sv/src/core/formatFiles.ts
@@ -1,22 +1,68 @@
 import * as p from '@clack/prompts';
-import { type AgentName, resolveCommand } from '@sveltejs/sv-utils';
+import { type AgentName, loadPackageJson, resolveCommand } from '@sveltejs/sv-utils';
 import { exec } from 'tinyexec';
+import fs from 'node:fs';
+import path from 'node:path';
+import { detectPackageManager } from './package-manager.ts';
+import { findWorkspaceRoot } from './workspace.ts';
+
+export type FormatStrategy =
+	/** Run the nearest `format`/`fmt` script up to the workspace root, else format the files. */
+	| 'project-script-then-files-only'
+	/** Run `prettier --write` on the given files (if `prettier` is available). */
+	| 'files-only';
 
 export async function formatFiles(options: {
 	packageManager: AgentName;
 	cwd: string;
 	filesToFormat: string[];
+	strategy: FormatStrategy;
 }): Promise<void> {
 	if (options.filesToFormat.length === 0) return;
+
+	if (options.strategy === 'project-script-then-files-only') {
+		const script = findFormatScript(options.cwd);
+		if (script) {
+			// the script owns its scope (whole repo/monorepo) and deps - we don't care what runs under it
+			const packageManager = await detectPackageManager(script.dir);
+			const cmd = resolveCommand(packageManager, 'run', [script.name])!;
+			await run(cmd.command, cmd.args, script.dir, `Running ${packageManager} run ${script.name}`);
+			return;
+		}
+	}
+
+	const cmd = resolveCommand(options.packageManager, 'execute-local', [
+		'prettier',
+		'--write',
+		'--ignore-unknown',
+		...options.filesToFormat
+	])!;
+	await run(cmd.command, cmd.args, options.cwd, 'Formatting modified files');
+}
+
+/** Nearest dir from `cwd` up to the workspace root with a `format` or `fmt` package.json script. */
+function findFormatScript(cwd: string): { dir: string; name: 'format' | 'fmt' } | undefined {
+	const workspaceRoot = findWorkspaceRoot(cwd);
+	let directory = path.resolve(cwd);
+	const { root } = path.parse(directory);
+	while (directory && directory.length >= workspaceRoot.length) {
+		if (fs.existsSync(path.join(directory, 'package.json'))) {
+			const { data } = loadPackageJson(directory);
+			if (data.scripts?.format) return { dir: directory, name: 'format' };
+			if (data.scripts?.fmt) return { dir: directory, name: 'fmt' };
+		}
+		if (directory === root) break;
+		directory = path.dirname(directory);
+	}
+	return undefined;
+}
+
+async function run(command: string, args: string[], cwd: string, startMsg: string): Promise<void> {
 	const { start, stop } = p.spinner();
-	start('Formatting modified files');
-
-	const args = ['prettier', '--write', '--ignore-unknown', ...options.filesToFormat];
-	const cmd = resolveCommand(options.packageManager, 'execute-local', args)!;
-
+	start(startMsg);
 	try {
-		const result = await exec(cmd.command, cmd.args, {
-			nodeOptions: { cwd: options.cwd, stdio: 'pipe' },
+		const result = await exec(command, args, {
+			nodeOptions: { cwd, stdio: 'pipe' },
 			throwOnError: true
 		});
 		if (result.exitCode !== 0) {
@@ -30,5 +76,5 @@ export async function formatFiles(options: {
 		p.log.error(e?.output?.stderr || 'unknown error');
 		return;
 	}
-	stop('Successfully formatted modified files');
+	stop('Successfully formatted files');
 }

--- a/packages/sv/src/core/workspace.ts
+++ b/packages/sv/src/core/workspace.ts
@@ -220,7 +220,7 @@ export async function createWorkspace({
 	};
 }
 
-function findWorkspaceRoot(cwd: string): string {
+export function findWorkspaceRoot(cwd: string): string {
 	const { root } = path.parse(cwd);
 	let directory = cwd;
 	while (directory && directory !== root) {


### PR DESCRIPTION
`sv migrate` now formats using the project's own setup instead of always shelling out to `prettier` on the modified files:

- Runs the nearest `format`/`fmt` `package.json` script, walking up from `cwd` to the workspace root (monorepo-aware via existing `findWorkspaceRoot`, which uses `pnpm-workspace.yaml`/`workspaces` - submodule-safe, not `.git`). The script owns its scope and tooling, so biome/dprint/etc. are respected.
- Falls back to today's `prettier --write --ignore-unknown <files>` when no such script exists.

`formatFiles` gains a `strategy` param; `create`/`add` keep the existing files-only behavior.