### PR TITLE
fix(better-auth): manage $app/env

### DIFF
--- a/.changeset/better-auth-app-env.md
+++ b/.changeset/better-auth-app-env.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix(better-auth): import `building` from `$app/env` when explicit environment variables are enabled

--- a/.changeset/sv-utils-import-env.md
+++ b/.changeset/sv-utils-import-env.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/sv-utils': minor
+---
+
+feat(env): add `defineEnv().importEnv` to import from the environment module (`$app/env` declared, `$app/environment` legacy) without branching on mode

--- a/packages/sv-utils/api-surface.md
+++ b/packages/sv-utils/api-surface.md
@@ -849,6 +849,8 @@ type DefineEnv = {
 	mode: EnvMode;
 	define: (spec: EnvVarSpec) => void;
 	reference: (ast: estree.Program, js: typeof index_d_exports$3, opts: ReferenceOpts) => string;
+
+	importEnv: (ast: estree.Program, js: typeof index_d_exports$3, imports: string[]) => void;
 };
 
 declare function defineEnv({ sv, cwd, dependencyVersion }: DefineEnvContext): DefineEnv;

--- a/packages/sv-utils/src/env.ts
+++ b/packages/sv-utils/src/env.ts
@@ -45,6 +45,12 @@ export type DefineEnv = {
 	mode: EnvMode;
 	define: (spec: EnvVarSpec) => void;
 	reference: (ast: AstTypes.Program, js: typeof jsNs, opts: ReferenceOpts) => string;
+	/**
+	 * Adds a named import from the environment module (`building`, `dev`, `browser`, ...),
+	 * resolving the right namespace (`$app/env` declared, `$app/environment` legacy) so add-ons
+	 * never branch on {@link mode} themselves.
+	 */
+	importEnv: (ast: AstTypes.Program, js: typeof jsNs, imports: string[]) => void;
 };
 
 function findProp(obj: AstTypes.ObjectExpression, name: string): AstTypes.Property | undefined {
@@ -161,6 +167,12 @@ export function _bindEnv({
 			}
 			js.imports.addNamed(ast, { from: `$env/dynamic/${scope}`, imports: ['env'] });
 			return `env.${opts.name}`;
+		},
+		importEnv(ast, js, imports) {
+			js.imports.addNamed(ast, {
+				from: mode === 'declared' ? '$app/env' : '$app/environment',
+				imports
+			});
 		}
 	};
 }

--- a/packages/sv-utils/src/tests/env.ts
+++ b/packages/sv-utils/src/tests/env.ts
@@ -66,6 +66,22 @@ describe('defineEnv.reference', () => {
 	});
 });
 
+describe('defineEnv.importEnv', () => {
+	test('declared: named import from $app/env', () => {
+		const { env } = envFor('declared');
+		const { ast, generateCode } = parseScript('');
+		env.importEnv(ast, js, ['building']);
+		expect(generateCode()).toContain("import { building } from '$app/env';");
+	});
+
+	test('legacy: named import from $app/environment', () => {
+		const { env } = envFor('legacy');
+		const { ast, generateCode } = parseScript('');
+		env.importEnv(ast, js, ['building']);
+		expect(generateCode()).toContain("import { building } from '$app/environment';");
+	});
+});
+
 const reader = (files: Record<string, string>) => (path: string) => files[path] ?? null;
 
 describe('readExplicitEnvFlag', () => {

--- a/packages/sv/src/addons/better-auth.ts
+++ b/packages/sv/src/addons/better-auth.ts
@@ -287,10 +287,7 @@ export default defineAddon({
 					imports: [d1 ? 'createAuth' : 'auth'],
 					from: '$lib/server/auth'
 				});
-				js.imports.addNamed(ast, {
-					imports: ['building'],
-					from: env.mode === 'declared' ? '$app/env' : '$app/environment'
-				});
+				env.importEnv(ast, js, ['building']);
 
 				const d1HandleSetup = d1
 					? dedent`

--- a/packages/sv/src/addons/better-auth.ts
+++ b/packages/sv/src/addons/better-auth.ts
@@ -287,7 +287,10 @@ export default defineAddon({
 					imports: [d1 ? 'createAuth' : 'auth'],
 					from: '$lib/server/auth'
 				});
-				js.imports.addNamed(ast, { imports: ['building'], from: '$app/environment' });
+				js.imports.addNamed(ast, {
+					imports: ['building'],
+					from: env.mode === 'declared' ? '$app/env' : '$app/environment'
+				});
 
 				const d1HandleSetup = d1
 					? dedent`

--- a/packages/sv/src/cli/tests/snapshots/create-experimental/src/hooks.server.ts
+++ b/packages/sv/src/cli/tests/snapshots/create-experimental/src/hooks.server.ts
@@ -1,5 +1,5 @@
 import type { Handle } from '@sveltejs/kit';
-import { building } from '$app/environment';
+import { building } from '$app/env';
 import { auth } from '$lib/server/auth';
 import { svelteKitHandler } from 'better-auth/svelte-kit';
 


### PR DESCRIPTION
Closes #

### Description

When `explicitEnvironmentVariables` is enabled (declared env mode), `$app/env` is the alias of `$app/environment`. The `better-auth` add-on now imports `building` from `$app/env` in that mode, and from `$app/environment` otherwise.

### Checklist

- Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)
- Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable)
- Allow maintainers to edit this PR
- I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)