### PR TITLE
fix(sv-utils): release defineEnv().importEnv as patch

### DIFF
--- a/.changeset/sv-utils-import-env.md
+++ b/.changeset/sv-utils-import-env.md
@@ -1,5 +1,5 @@
 ---
-'@sveltejs/sv-utils': minor
+'@sveltejs/sv-utils': patch
 ---
 
 feat(env): add `defineEnv().importEnv` to import from the environment module (`$app/env` declared, `$app/environment` legacy) without branching on mode


### PR DESCRIPTION
The `defineEnv().importEnv` changeset from #1136 was marked `minor`, but it's an additive helper with no breaking changes - it should be a `patch`.

Flips the `@sveltejs/sv-utils` bump from `minor` to `patch`.