### PR TITLE
docs: remove non-existent link

### DIFF
--- a/documentation/docs/30-add-ons/14-experimental.md
+++ b/documentation/docs/30-add-ons/14-experimental.md
@@ -2,7 +2,7 @@
 title: experimental
 ---
 
-Enables [Svelte](https://svelte.dev/docs/svelte/compiler-options) and [SvelteKit](https://svelte.dev/docs/kit/configuration#experimental) experimental features, and can opt your project into their `next` pre-release versions.
+Enables Svelte and [SvelteKit](https://svelte.dev/docs/kit/configuration#experimental) experimental features, and can opt your project into their `next` pre-release versions.
 
 ## Usage
 


### PR DESCRIPTION
The link https://svelte.dev/docs/svelte/compiler-options doesn't exist and is causing docs build to fail.