### PR TITLE
fix: ignore `types` flag when using the `addon` template

### DIFF
--- a/.changeset/famous-wasps-bow.md
+++ b/.changeset/famous-wasps-bow.md
@@ -1,0 +1,5 @@
+---
+"sv": patch
+---
+
+fix: ignore `types` flag when using the `addon` template

--- a/packages/sv/src/cli/create.ts
+++ b/packages/sv/src/cli/create.ts
@@ -177,6 +177,12 @@ async function createProject(cwd: ProjectPath, options: Options) {
 		);
 	}
 
+	if (options.template === 'addon' && options.types === 'typescript') {
+		p.log.warn(
+			`The addon template does not support TypeScript. The ${color.command('--types')} flag will be ignored.`
+		);
+	}
+
 	const promptGroupResult = await p.group(
 		{
 			directory: () => {
@@ -231,8 +237,8 @@ async function createProject(cwd: ProjectPath, options: Options) {
 				});
 			},
 			language: (o) => {
-				if (options.types) return Promise.resolve(options.types);
 				if (o.results.template === 'addon') return Promise.resolve<LanguageType>('none');
+				if (options.types) return Promise.resolve(options.types);
 				return p.select<LanguageType>({
 					message: 'Add type checking with TypeScript?',
 					initialValue: 'typescript',


### PR DESCRIPTION
Closes #

### Description

- also removed `shared/+addon-typescript`, don't believe it is used

### Checklist

- Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)
- Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable)
- Allow maintainers to edit this PR
- I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)
