### PR TITLE
fix(test): stabilize addon e2e npm install on Windows

### DIFF
--- a/packages/sv/src/cli/tests/cli.ts
+++ b/packages/sv/src/cli/tests/cli.ts
@@ -208,7 +208,10 @@ describe('cli', () => {
 							env: {
 								...process.env,
 								// allow npm under a repo whose packageManager is pnpm
-								COREPACK_ENABLE_STRICT: '0'
+								COREPACK_ENABLE_STRICT: '0',
+								// tsdown's optional `*` peers crash npm's arborist peer resolver
+								// (`edgesOut` null); skip strict peer resolution for this install
+								npm_config_legacy_peer_deps: 'true'
 							}
 						}
 					});


### PR DESCRIPTION
Closes #

### Description

The addon e2e runs `npm install` in the scaffolded project. It crashes with `Cannot read properties of null (reading 'edgesOut')` because tsdown (0.20+) declares a peer cycle with `@tsdown/css`/`@tsdown/exe`, which npm 10's arborist can't resolve. This is an npm 10 bug (fixed in npm 11), and CI runs Node 22 (npm 10).

Fixed by setting `npm_config_legacy_peer_deps` for that install, which skips the crashing peer resolution. Can be reverted once CI moves to npm 11 (Node 24).

### Checklist

- Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)
- Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable)
- Allow maintainers to edit this PR
- I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)