### PR TITLE
chore: remove `svelte-migrate` changeset

### DIFF
--- a/.changeset/wise-beers-switch.md
+++ b/.changeset/wise-beers-switch.md
@@ -1,5 +1,0 @@
----
-'svelte-migrate': major
----
-
-breaking: the `svelte-migrate` package has been replaced by the `sv` package


### PR DESCRIPTION
See #1181 
Since we will deprecate `svelte-migrate` there is no need to do a pre-release for that. So remove it temporarily.
