### PR TITLE
chore: deprecate `svelte-migrate`

### DIFF
--- a/.changeset/wise-beers-switch.md
+++ b/.changeset/wise-beers-switch.md
@@ -1,0 +1,5 @@
+---
+'svelte-migrate': major
+---
+
+breaking: the `svelte-migrate` package has been replaced by the `sv` package


### PR DESCRIPTION
This is the contrary #1182 
Only merge this, once we actually want to deprecate `svelte-migrate`