### PR TITLE
fix: recognize the nub package manager

### DIFF
--- a/.changeset/recognize-nub-package-manager.md
+++ b/.changeset/recognize-nub-package-manager.md
@@ -1,0 +1,6 @@
+---
+'@sveltejs/sv-utils': patch
+'svelte-migrate': patch
+---
+
+fix: recognize the `nub` package manager

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -31,7 +31,7 @@
 		"@clack/prompts": "1.5.0",
 		"import-meta-resolve": "^4.2.0",
 		"magic-string": "^0.30.21",
-		"package-manager-detector": "^1.6.0",
+		"package-manager-detector": "^1.8.0",
 		"picocolors": "^1.1.1",
 		"semver": "^7.8.1",
 		"tiny-glob": "^0.2.9",

--- a/packages/sv-utils/package.json
+++ b/packages/sv-utils/package.json
@@ -30,7 +30,7 @@
 		"decircular": "^1.0.0",
 		"dedent": "^1.7.2",
 		"esrap": "^2.2.11",
-		"package-manager-detector": "^1.6.0",
+		"package-manager-detector": "^1.8.0",
 		"semver": "^7.8.1",
 		"silver-fleece": "^1.2.1",
 		"smol-toml": "^1.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,8 +81,8 @@ importers:
         specifier: ^0.30.21
         version: 0.30.21
       package-manager-detector:
-        specifier: ^1.6.0
-        version: 1.6.0
+        specifier: ^1.8.0
+        version: 1.8.0
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -185,8 +185,8 @@ importers:
         specifier: ^2.2.11
         version: 2.2.11(@typescript-eslint/types@8.60.1)
       package-manager-detector:
-        specifier: ^1.6.0
-        version: 1.6.0
+        specifier: ^1.8.0
+        version: 1.8.0
       semver:
         specifier: ^7.8.1
         version: 7.8.1
@@ -1837,8 +1837,8 @@ packages:
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
 
-  package-manager-detector@1.6.0:
-    resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+  package-manager-detector@1.8.0:
+    resolution: {integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==}
 
   parse-imports-exports@0.2.4:
     resolution: {integrity: sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==}
@@ -3944,7 +3944,7 @@ snapshots:
     dependencies:
       quansync: 0.2.11
 
-  package-manager-detector@1.6.0: {}
+  package-manager-detector@1.8.0: {}
 
   parse-imports-exports@0.2.4:
     dependencies:


### PR DESCRIPTION
### Description

`sv` delegates package-manager detection and command construction to [`package-manager-detector`](https://github.com/antfu/package-manager-detector). That library added the [`nub`](https://nubjs.com) package manager in v1.8.0 — its agent table, the `nub.lock` lockfile mapping, and the command set (`nub install`, `nub run`, `nubx` for `execute`, `nub exec` for `execute-local`).

`@sveltejs/sv-utils` bundles `package-manager-detector` at build time (`tsdown` `onlyBundle`), so the published bundle only knows about nub once rebuilt against ≥1.8.0. The lockfile currently pins 1.6.0, so `sv create` in a nub project misdetects it as npm.

This bumps the range to `^1.8.0` in `@sveltejs/sv-utils` and `svelte-migrate` and regenerates the lockfile. No source changes — detection is fully delegated, and `AGENTS`/`AGENT_NAMES` derive from the library.

Verified against a fresh build of `packages/sv-utils/dist/index.mjs`:

- `AGENTS` includes `nub`
- `resolveCommand('nub', 'run', ['test'])` → `nub run test`
- `resolveCommand('nub', 'install', [])` → `nub install`
- `resolveCommand('nub', 'execute', ['sv'])` → `nubx sv`
- `resolveCommand('nub', 'execute-local', ['sv'])` → `nub exec sv`

### Checklist

- Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable) — n/a
- Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable) — done
- Allow maintainers to edit this PR
- I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)
