### PR TITLE
feat: smart package manager selection

### DIFF
--- a/.changeset/honest-bugs-jam.md
+++ b/.changeset/honest-bugs-jam.md
@@ -1,0 +1,5 @@
+---
+"sv": patch
+---
+
+feat: smart(er) package manager selection

--- a/packages/sv/src/cli/add.ts
+++ b/packages/sv/src/cli/add.ts
@@ -1,5 +1,5 @@
 import * as p from '@clack/prompts';
-import { color } from '@sveltejs/sv-utils';
+import { color, resolveCommandArray } from '@sveltejs/sv-utils';
 import { Command } from 'commander';
 import * as pkg from 'empathic/package';
 import fs from 'node:fs';
@@ -774,13 +774,21 @@ export async function runAddonsApply({
 		common.buildAndLogArgs(packageManager, 'add', argsFormattedAddons);
 	}
 
+	let depsInstalled = true;
 	if (packageManager) {
 		workspace.packageManager = packageManager;
-		await installDependencies(packageManager, options.cwd);
-		await formatFiles({ packageManager, cwd: options.cwd, filesToFormat });
+		depsInstalled = await installDependencies(packageManager, options.cwd);
+		if (depsInstalled) {
+			await formatFiles({ packageManager, cwd: options.cwd, filesToFormat });
+		}
 	}
 
 	const nextSteps = getNextSteps(successfulAddons, workspace, answers, setupResults);
+	if (packageManager && !depsInstalled) {
+		nextSteps.unshift(
+			`Install ${color.command(packageManager)}, then run ${color.command(resolveCommandArray(packageManager, 'install', []))}`
+		);
+	}
 
 	return { nextSteps, argsFormattedAddons, filesToFormat, successfulAddons, setupResults };
 }

--- a/packages/sv/src/cli/create.ts
+++ b/packages/sv/src/cli/create.ts
@@ -132,7 +132,10 @@ export const create = new Command('create')
 		}
 
 		common.runCommand(async () => {
-			const { directory, addOnNextSteps, packageManager } = await createProject(cwd, options);
+			const { directory, addOnNextSteps, packageManager, depsInstalled } = await createProject(
+				cwd,
+				options
+			);
 
 			let i = 1;
 			const initialSteps: string[] = ['📁 Project steps', ''];
@@ -144,7 +147,10 @@ export const create = new Command('create')
 					`  ${i++}: ${color.command(`cd ${pathHasSpaces ? `"${relative}"` : relative}`)}`
 				);
 			}
-			if (!packageManager) {
+			if (packageManager && !depsInstalled) {
+				initialSteps.push(`  ${i++}: Install ${color.command(pm)}`);
+			}
+			if (!packageManager || !depsInstalled) {
 				initialSteps.push(`  ${i++}: ${color.command(resolveCommandArray(pm, 'install', []))}`);
 			}
 
@@ -405,12 +411,15 @@ async function createProject(cwd: ProjectPath, options: Options) {
 	const addOnNextSteps = getNextSteps(addOnSuccessfulAddons, workspace, answers, addonSetupResults);
 
 	addPnpmAllowBuilds(projectPath, packageManager, 'esbuild');
+	let depsInstalled = false;
 	if (packageManager) {
-		await installDependencies(packageManager, projectPath);
-		await formatFiles({ packageManager, cwd: projectPath, filesToFormat: addOnFilesToFormat });
+		depsInstalled = await installDependencies(packageManager, projectPath);
+		if (depsInstalled) {
+			await formatFiles({ packageManager, cwd: projectPath, filesToFormat: addOnFilesToFormat });
+		}
 	}
 
-	return { directory: projectPath, addOnNextSteps, packageManager };
+	return { directory: projectPath, addOnNextSteps, packageManager, depsInstalled };
 }
 
 async function createProjectFromPlayground(url: string, cwd: string): Promise<void> {

--- a/packages/sv/src/core/package-manager.ts
+++ b/packages/sv/src/core/package-manager.ts
@@ -73,6 +73,15 @@ export async function packageManagerPrompt(cwd: string): Promise<AgentName | und
 }
 
 export async function installDependencies(agent: AgentName, cwd: string): Promise<void> {
+	if (!isInstalled(agent)) {
+		p.log.error(
+			`Package manager ${color.command(agent)} is not installed. Please install it first.`
+		);
+		p.log.message();
+		p.cancel('Operation failed.');
+		process.exit(1);
+	}
+
 	const task = p.taskLog({
 		title: `Installing dependencies with ${color.command(agent)}...`,
 		limit: Math.ceil(process.stdout.rows / 2),

--- a/packages/sv/src/core/package-manager.ts
+++ b/packages/sv/src/core/package-manager.ts
@@ -13,32 +13,56 @@ import * as find from 'empathic/find';
 import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
-import { exec } from 'tinyexec';
+import { exec, execSync } from 'tinyexec';
 
 export const AGENT_NAMES: AgentName[] = AGENTS.filter(
 	(agent): agent is AgentName => !agent.includes('@')
-);
-const agentOptions: PackageManagerOptions = AGENT_NAMES.map((pm) => ({ value: pm, label: pm }));
-agentOptions.unshift({ label: 'None', value: undefined });
+	// put `pnpm` first
+).sort((a, b) => {
+	if (a === 'pnpm') return -1;
+	if (b === 'pnpm') return 1;
+	return a.localeCompare(b);
+});
 
 export const installOption: Option = new Option(
 	'--install <package-manager>',
 	'installs dependencies with a specified package manager'
 ).choices(AGENT_NAMES);
+type PackageManagerOptions = Array<{
+	value: AgentName | undefined;
+	label: AgentName | 'None';
+	disabled?: boolean;
+	hint?: string;
+}>;
 
-type PackageManagerOptions = Array<{ value: AgentName | undefined; label: AgentName | 'None' }>;
 export async function packageManagerPrompt(cwd: string): Promise<AgentName | undefined> {
 	const detected = await detect({ cwd });
-	const agent = detected?.name ?? getUserAgent();
+	const detectedAgent = detected?.name ?? getUserAgent();
+	const installedAgents = AGENT_NAMES.filter(isInstalled);
+	const initialAgent =
+		detectedAgent && installedAgents.includes(detectedAgent) ? detectedAgent : installedAgents[0];
+
+	const options: PackageManagerOptions = AGENT_NAMES.map((agent) => ({
+		value: agent,
+		label: agent,
+		disabled: !installedAgents.includes(agent),
+		hint: installedAgents.includes(agent) ? undefined : 'not installed'
+	})).sort((a, b) => {
+		if (a.disabled && !b.disabled) return 1;
+		if (!a.disabled && b.disabled) return -1;
+		return 0;
+	});
+
+	options.unshift({ label: 'None', value: undefined, disabled: false });
 
 	// If we are in a non interactive environment just go with the detected package manager.
 	// There is no need to prompt in that case.
-	if (!process.stdout.isTTY) return agent;
+	if (!process.stdout.isTTY) return initialAgent;
 
 	const pm = await p.select({
 		message: 'Which package manager do you want to install dependencies with?',
-		options: agentOptions,
-		initialValue: agent
+		options,
+		initialValue: initialAgent
 	});
 	if (p.isCancel(pm)) {
 		p.cancel('Operation cancelled.');
@@ -98,7 +122,7 @@ export async function detectPackageManager(cwd: string): Promise<AgentName> {
 	return detected?.name ?? getUserAgent() ?? 'npm';
 }
 
-export function getUserAgent(): AgentName | undefined {
+function getUserAgent(): AgentName | undefined {
 	const userAgent = process.env.npm_config_user_agent;
 	if (!userAgent) return undefined;
 
@@ -106,6 +130,17 @@ export function getUserAgent(): AgentName | undefined {
 	const separatorPos = pmSpec.lastIndexOf('/');
 	const name = pmSpec.substring(0, separatorPos) as AgentName;
 	return AGENTS.includes(name) ? name : undefined;
+}
+
+function isInstalled(agent: AgentName): boolean {
+	try {
+		const result = execSync('sh', ['-c', `command -v ${agent}`], {
+			nodeOptions: { stdio: 'pipe' }
+		});
+		return result.stdout.trim().length > 0;
+	} catch {
+		return false;
+	}
 }
 
 export function addPnpmAllowBuilds(

--- a/packages/sv/src/core/package-manager.ts
+++ b/packages/sv/src/core/package-manager.ts
@@ -17,12 +17,7 @@ import { exec, execSync } from 'tinyexec';
 
 export const AGENT_NAMES: AgentName[] = AGENTS.filter(
 	(agent): agent is AgentName => !agent.includes('@')
-	// put `pnpm` first
-).sort((a, b) => {
-	if (a === 'pnpm') return -1;
-	if (b === 'pnpm') return 1;
-	return a.localeCompare(b);
-});
+);
 
 export const installOption: Option = new Option(
 	'--install <package-manager>',

--- a/packages/sv/src/core/package-manager.ts
+++ b/packages/sv/src/core/package-manager.ts
@@ -39,8 +39,7 @@ export async function packageManagerPrompt(cwd: string): Promise<AgentName | und
 	const detected = await detect({ cwd });
 	const detectedAgent = detected?.name ?? getUserAgent();
 	const installedAgents = AGENT_NAMES.filter(isInstalled);
-	const initialAgent =
-		detectedAgent && installedAgents.includes(detectedAgent) ? detectedAgent : installedAgents[0];
+	const agent = detectedAgent ?? installedAgents[0];
 
 	const options: PackageManagerOptions = AGENT_NAMES.map((agent) => ({
 		value: agent,
@@ -57,12 +56,20 @@ export async function packageManagerPrompt(cwd: string): Promise<AgentName | und
 
 	// If we are in a non interactive environment just go with the detected package manager.
 	// There is no need to prompt in that case.
-	if (!process.stdout.isTTY) return initialAgent;
+	if (!process.stdout.isTTY) {
+		if (detectedAgent && !installedAgents.includes(detectedAgent)) {
+			p.cancel(
+				`This project uses ${color.command(detectedAgent)}, please install it and try again.`
+			);
+			process.exit(1);
+		}
+		return agent;
+	}
 
 	const pm = await p.select({
 		message: 'Which package manager do you want to install dependencies with?',
 		options,
-		initialValue: initialAgent
+		initialValue: agent
 	});
 	if (p.isCancel(pm)) {
 		p.cancel('Operation cancelled.');
@@ -74,11 +81,7 @@ export async function packageManagerPrompt(cwd: string): Promise<AgentName | und
 
 export async function installDependencies(agent: AgentName, cwd: string): Promise<void> {
 	if (!isInstalled(agent)) {
-		p.log.error(
-			`Package manager ${color.command(agent)} is not installed. Please install it first.`
-		);
-		p.log.message();
-		p.cancel('Operation failed.');
+		p.cancel(`${color.command(agent)} is not installed. Please install it and try again.`);
 		process.exit(1);
 	}
 

--- a/packages/sv/src/core/package-manager.ts
+++ b/packages/sv/src/core/package-manager.ts
@@ -41,7 +41,7 @@ export async function packageManagerPrompt(cwd: string): Promise<AgentName | und
 	const installedAgents = AGENT_NAMES.filter(isInstalled);
 	const agent = detectedAgent ?? installedAgents[0];
 
-	const options: PackageManagerOptions = AGENT_NAMES.map((agent) => ({
+	const agentOptions: PackageManagerOptions = AGENT_NAMES.map((agent) => ({
 		value: agent,
 		label: agent,
 		disabled: !installedAgents.includes(agent),
@@ -51,8 +51,7 @@ export async function packageManagerPrompt(cwd: string): Promise<AgentName | und
 		if (!a.disabled && b.disabled) return -1;
 		return 0;
 	});
-
-	options.unshift({ label: 'None', value: undefined, disabled: false });
+	agentOptions.unshift({ label: 'None', value: undefined, disabled: false });
 
 	// If we are in a non interactive environment just go with the detected package manager.
 	// There is no need to prompt in that case.
@@ -68,7 +67,7 @@ export async function packageManagerPrompt(cwd: string): Promise<AgentName | und
 
 	const pm = await p.select({
 		message: 'Which package manager do you want to install dependencies with?',
-		options,
+		options: agentOptions,
 		initialValue: agent
 	});
 	if (p.isCancel(pm)) {

--- a/packages/sv/src/core/package-manager.ts
+++ b/packages/sv/src/core/package-manager.ts
@@ -140,10 +140,8 @@ function getUserAgent(): AgentName | undefined {
 
 function isInstalled(agent: AgentName): boolean {
 	try {
-		const result = execSync('sh', ['-c', `command -v ${agent}`], {
-			nodeOptions: { stdio: 'pipe' }
-		});
-		return result.stdout.trim().length > 0;
+		execSync(agent, ['--version'], { nodeOptions: { stdio: 'ignore' } });
+		return true;
 	} catch {
 		return false;
 	}

--- a/packages/sv/src/core/package-manager.ts
+++ b/packages/sv/src/core/package-manager.ts
@@ -23,12 +23,6 @@ export const installOption: Option = new Option(
 	'--install <package-manager>',
 	'installs dependencies with a specified package manager'
 ).choices(AGENT_NAMES);
-type PackageManagerOptions = Array<{
-	value: AgentName | undefined;
-	label: AgentName | 'None';
-	disabled?: boolean;
-	hint?: string;
-}>;
 
 export async function packageManagerPrompt(cwd: string): Promise<AgentName | undefined> {
 	const detected = await detect({ cwd });
@@ -36,29 +30,22 @@ export async function packageManagerPrompt(cwd: string): Promise<AgentName | und
 	const installedAgents = AGENT_NAMES.filter(isInstalled);
 	const agent = detectedAgent ?? installedAgents[0];
 
-	const agentOptions: PackageManagerOptions = AGENT_NAMES.map((agent) => ({
-		value: agent,
-		label: agent,
-		disabled: !installedAgents.includes(agent),
-		hint: installedAgents.includes(agent) ? undefined : 'not installed'
-	})).sort((a, b) => {
-		if (a.disabled && !b.disabled) return 1;
-		if (!a.disabled && b.disabled) return -1;
-		return 0;
-	});
-	agentOptions.unshift({ label: 'None', value: undefined, disabled: false });
+	const agentOptions = [
+		{ label: 'None', value: undefined },
+		...AGENT_NAMES.map((agent) => {
+			const installed = installedAgents.includes(agent);
+			return {
+				value: agent,
+				label: installed ? agent : color.dim(`${agent} (not installed)`),
+				installed
+			};
+			// installed ones first
+		}).sort((a, b) => Number(b.installed) - Number(a.installed))
+	];
 
 	// If we are in a non interactive environment just go with the detected package manager.
 	// There is no need to prompt in that case.
-	if (!process.stdout.isTTY) {
-		if (detectedAgent && !installedAgents.includes(detectedAgent)) {
-			p.cancel(
-				`This project uses ${color.command(detectedAgent)}, please install it and try again.`
-			);
-			process.exit(1);
-		}
-		return agent;
-	}
+	if (!process.stdout.isTTY) return agent;
 
 	const pm = await p.select({
 		message: 'Which package manager do you want to install dependencies with?',
@@ -73,10 +60,11 @@ export async function packageManagerPrompt(cwd: string): Promise<AgentName | und
 	return pm;
 }
 
-export async function installDependencies(agent: AgentName, cwd: string): Promise<void> {
+/** Returns `false` when the package manager isn't installed and the install was skipped. */
+export async function installDependencies(agent: AgentName, cwd: string): Promise<boolean> {
 	if (!isInstalled(agent)) {
-		p.cancel(`${color.command(agent)} is not installed. Please install it and try again.`);
-		process.exit(1);
+		p.log.warn(`${color.command(agent)} is not installed, skipping dependency installation.`);
+		return false;
 	}
 
 	const task = p.taskLog({
@@ -107,7 +95,7 @@ export async function installDependencies(agent: AgentName, cwd: string): Promis
 	const exitCode = proc.exitCode ?? 0;
 	if (exitCode === 0) {
 		task.success(`Successfully installed dependencies with ${color.command(agent)}`);
-		return;
+		return true;
 	}
 
 	if (agent === 'pnpm' && output.join('\n').includes('ERR_PNPM_IGNORED_BUILDS')) {
@@ -115,7 +103,7 @@ export async function installDependencies(agent: AgentName, cwd: string): Promis
 		p.log.warn(
 			`Some build scripts were skipped. Run ${color.command(`${agent} approve-builds`)} to approve them.`
 		);
-		return;
+		return true;
 	}
 
 	task.error('Failed to install dependencies');

--- a/packages/sv/src/core/package-manager.ts
+++ b/packages/sv/src/core/package-manager.ts
@@ -26,26 +26,24 @@ export const installOption: Option = new Option(
 
 export async function packageManagerPrompt(cwd: string): Promise<AgentName | undefined> {
 	const detected = await detect({ cwd });
-	const detectedAgent = detected?.name ?? getUserAgent();
-	const installedAgents = AGENT_NAMES.filter(isInstalled);
-	const agent = detectedAgent ?? installedAgents[0];
+	const agent = detected?.name ?? getUserAgent();
 
+	// If we are in a non interactive environment just go with the detected package manager.
+	// There is no need to prompt in that case.
+	if (!process.stdout.isTTY) return agent;
+
+	// installed ones first
 	const agentOptions = [
 		{ label: 'None', value: undefined },
 		...AGENT_NAMES.map((agent) => {
-			const installed = installedAgents.includes(agent);
+			const installed = isInstalled(agent);
 			return {
 				value: agent,
 				label: installed ? agent : color.dim(`${agent} (not installed)`),
 				installed
 			};
-			// installed ones first
 		}).sort((a, b) => Number(b.installed) - Number(a.installed))
 	];
-
-	// If we are in a non interactive environment just go with the detected package manager.
-	// There is no need to prompt in that case.
-	if (!process.stdout.isTTY) return agent;
 
 	const pm = await p.select({
 		message: 'Which package manager do you want to install dependencies with?',
@@ -126,13 +124,19 @@ function getUserAgent(): AgentName | undefined {
 	return AGENTS.includes(name) ? name : undefined;
 }
 
+const installedCache = new Map<AgentName, boolean>();
 function isInstalled(agent: AgentName): boolean {
-	try {
-		execSync(agent, ['--version'], { nodeOptions: { stdio: 'ignore' } });
-		return true;
-	} catch {
-		return false;
+	let installed = installedCache.get(agent);
+	if (installed === undefined) {
+		try {
+			execSync(agent, ['--version'], { nodeOptions: { stdio: 'ignore' } });
+			installed = true;
+		} catch {
+			installed = false;
+		}
+		installedCache.set(agent, installed);
 	}
+	return installed;
 }
 
 export function addPnpmAllowBuilds(


### PR DESCRIPTION

<img width="1075" height="283" alt="image" src="https://github.com/user-attachments/assets/24a0654b-8ba3-4fee-b796-c0f35aeae8d3" />


Closes #1159

### Description

- order is `None`, `pnpm`, abc, not installed
- `command -v <pm>` over `which <pm>` based on [this](https://unix.stackexchange.com/questions/85249/why-not-use-which-what-to-use-then) discussion.

### todo
- [x] handle non interactive mode selecting an invalid pm


### Checklist

- Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)
- Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable)
- Allow maintainers to edit this PR
- I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)
