### PR TITLE
fix: format all created project files so fresh projects pass lint

### DIFF
--- a/.changeset/format-created-project-files.md
+++ b/.changeset/format-created-project-files.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix: format all created project files when using the prettier add-on

--- a/packages/sv/src/cli/create.ts
+++ b/packages/sv/src/cli/create.ts
@@ -176,7 +176,7 @@ export const create = new Command('create')
 	})
 	.showHelpAfterError(true);
 
-async function createProject(cwd: ProjectPath, options: Options) {
+export async function createProject(cwd: ProjectPath, options: Options) {
 	if (options.fromPlayground) {
 		p.log.warn(
 			'Svelte maintainers have not reviewed playgrounds for malicious code! Use at your discretion.'
@@ -415,7 +415,10 @@ async function createProject(cwd: ProjectPath, options: Options) {
 	if (packageManager) {
 		depsInstalled = await installDependencies(packageManager, projectPath);
 		if (depsInstalled) {
-			await formatFiles({ packageManager, cwd: projectPath, filesToFormat: addOnFilesToFormat });
+			const filesToFormat = addOnSuccessfulAddons.some((addon) => addon.addon.id === 'prettier')
+				? ['.']
+				: addOnFilesToFormat;
+			await formatFiles({ packageManager, cwd: projectPath, filesToFormat });
 		}
 	}
 

--- a/packages/sv/src/create/tests/check.ts
+++ b/packages/sv/src/create/tests/check.ts
@@ -6,6 +6,7 @@ import { promisify } from 'node:util';
 import { exec } from 'tinyexec';
 import { beforeAll, describe, expect, test } from 'vitest';
 import { add, officialAddons } from '../../../../sv/src/index.ts';
+import { createProject } from '../../cli/create.ts';
 import { type LanguageType, type TemplateType, create } from '../index.ts';
 
 // Resolve the given path relative to the current file
@@ -48,8 +49,31 @@ for (const template of templates.filter((t) => t !== 'addon')) {
 		const cwd = path.join(test_workspace_dir, `${template}-${types}`);
 		fs.rmSync(cwd, { recursive: true, force: true });
 
-		create({ cwd, name: `create-svelte-test-${template}-${types}`, template, types });
-		await add({ cwd, addons: { eslint: officialAddons.eslint }, options: { eslint: {} } });
+		if (template === 'demo' && types === 'typescript') {
+			const ignoredArtifact = path.join(cwd, 'static', 'ignored.json');
+			fs.mkdirSync(path.dirname(ignoredArtifact), { recursive: true });
+			fs.writeFileSync(ignoredArtifact, '{"ignored":true}');
+
+			await createProject(cwd, {
+				types,
+				addOns: true,
+				add: ['prettier', 'eslint'],
+				install: 'pnpm',
+				template,
+				fromPlayground: undefined,
+				dirCheck: false,
+				downloadCheck: false
+			});
+
+			describe('prettier ignore', () => {
+				test(`${template}-${types}`, () => {
+					expect(fs.readFileSync(ignoredArtifact, 'utf-8')).toBe('{"ignored":true}');
+				});
+			});
+		} else {
+			create({ cwd, name: `create-svelte-test-${template}-${types}`, template, types });
+			await add({ cwd, addons: { eslint: officialAddons.eslint }, options: { eslint: {} } });
+		}
 
 		const pkg = JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf-8'));
 


### PR DESCRIPTION
Port of #1134 / #1170 to `main`, as @jycouet asked.

When a project is scaffolded with prettier among the add-ons, `sv create` now formats the whole project (`['.']`) rather than only the add-on-touched file list, so a freshly created project passes its own `pnpm lint`. Prettier's own ignore rules apply, so generated and ignored files are left alone.

The version-1 branch and `main` had diverged in `packages/sv/src/cli/create.ts`, and `main` additionally has `packages/sv/src/core/formatFiles.ts`, so this is a port rather than a cherry-pick.

Test: `packages/sv/src/create/tests/check.ts` scaffolds a demo project with prettier + eslint, plants a `static/ignored.json` artifact, and asserts formatting leaves it untouched. `vitest run packages/sv/src/create/tests/check.ts` -> 29 passed locally.

One thing worth a look: the test needs `createProject` exported from `cli/create.ts`. Happy to restructure if you'd rather not widen that surface.
