### PR TITLE
fix: minVersion return with verkit 0.2.0 API

### DIFF
--- a/packages/sv-utils/src/semver.ts
+++ b/packages/sv-utils/src/semver.ts
@@ -20,7 +20,7 @@ export function minVersion(range: string): string {
 	}
 	const min = findMinimumForRange(cleaned);
 	if (!min) throw new Error(`Cannot determine min version from range: ${range}`);
-	return min.version;
+	return min;
 }
 
 /**


### PR DESCRIPTION
In verkit 0.2.0 `findMinimumForRange` returns `string | null`, so `min.version` fails typecheck - CI on `version-1` is currently red because of it. No changeset: type-level fix only.