### PR TITLE
fix: drop obsolete pnpm allowBuilds entries and surface real format errors

### DIFF
--- a/.changeset/great-pans-shave.md
+++ b/.changeset/great-pans-shave.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix: run prettier directly instead of through the package manager, and stop allowing builds for packages that no longer have install scripts (`@tailwindcss/oxide`, `sharp`)

--- a/packages/sv/src/addons/sveltekit-adapter.ts
+++ b/packages/sv/src/addons/sveltekit-adapter.ts
@@ -113,7 +113,7 @@ export default defineAddon({
 			sv.devDependency('wrangler', '^4.97.0');
 
 			if (packageManager === 'pnpm') {
-				sv.file(file.findUp('pnpm-workspace.yaml'), pnpm.allowBuilds('workerd', 'sharp'));
+				sv.file(file.findUp('pnpm-workspace.yaml'), pnpm.allowBuilds('workerd'));
 			}
 
 			// default to jsonc

--- a/packages/sv/src/addons/tailwindcss.ts
+++ b/packages/sv/src/addons/tailwindcss.ts
@@ -1,4 +1,4 @@
-import { pnpm, transforms } from '@sveltejs/sv-utils';
+import { transforms } from '@sveltejs/sv-utils';
 import { defineAddon, defineAddonOptions } from '../core/config.ts';
 import { addPrettierTailwind, prettierConfigPath } from './common.ts';
 
@@ -31,14 +31,11 @@ export default defineAddon({
 	shortDescription: 'css framework',
 	homepage: 'https://tailwindcss.com',
 	options,
-	run: ({ sv, options, file, isKit, directory, dependencyVersion, language, packageManager }) => {
+	run: ({ sv, options, file, isKit, directory, dependencyVersion, language }) => {
 		const prettierInstalled = Boolean(dependencyVersion('prettier'));
 
 		sv.devDependency('tailwindcss', '^4.3.0');
 		sv.devDependency('@tailwindcss/vite', '^4.3.0');
-		if (packageManager === 'pnpm') {
-			sv.file(file.findUp('pnpm-workspace.yaml'), pnpm.allowBuilds('@tailwindcss/oxide'));
-		}
 
 		if (prettierInstalled) sv.devDependency('prettier-plugin-tailwindcss', '^0.8.0');
 

--- a/packages/sv/src/cli/tests/cli.ts
+++ b/packages/sv/src/cli/tests/cli.ts
@@ -147,9 +147,12 @@ describe('cli', () => {
 			}
 
 			if (projectName === 'create-with-all-addons' && process.platform !== 'win32') {
-				const installResult = await exec('pnpm', ['install', '--no-frozen-lockfile'], {
-					nodeOptions: { stdio: 'pipe', cwd: testOutputPath }
-				});
+				// the generated project lives inside this repo, so it must not join its workspace
+				const installResult = await exec(
+					'pnpm',
+					['install', '--no-frozen-lockfile', '--ignore-workspace'],
+					{ nodeOptions: { stdio: 'pipe', cwd: testOutputPath } }
+				);
 				expect(
 					installResult.exitCode,
 					`pnpm install failed:\n  stdout: ${installResult.stdout}\n  stderr: ${installResult.stderr}`

--- a/packages/sv/src/cli/tests/snapshots/create-experimental/pnpm-workspace.yaml
+++ b/packages/sv/src/cli/tests/snapshots/create-experimental/pnpm-workspace.yaml
@@ -1,3 +1,2 @@
 onlyBuiltDependencies:
   - workerd
-  - sharp

--- a/packages/sv/src/cli/tests/snapshots/create-with-all-addons/pnpm-workspace.yaml
+++ b/packages/sv/src/cli/tests/snapshots/create-with-all-addons/pnpm-workspace.yaml
@@ -1,2 +1,0 @@
-onlyBuiltDependencies:
-  - '@tailwindcss/oxide'

--- a/packages/sv/src/core/formatFiles.ts
+++ b/packages/sv/src/core/formatFiles.ts
@@ -11,24 +11,40 @@ export async function formatFiles(options: {
 	const { start, stop } = p.spinner();
 	start('Formatting modified files');
 
-	const args = ['prettier', '--write', '--ignore-unknown', ...options.filesToFormat];
-	const cmd = resolveCommand(options.packageManager, 'execute-local', args)!;
+	const args = ['--write', '--ignore-unknown', ...options.filesToFormat];
 
-	try {
-		const result = await exec(cmd.command, cmd.args, {
-			nodeOptions: { cwd: options.cwd, stdio: 'pipe' },
-			throwOnError: true
-		});
-		if (result.exitCode !== 0) {
-			stop('Failed to format files');
-			p.log.error(result.stderr);
-			return;
-		}
-	} catch (e) {
+	// tinyexec resolves `prettier` from `node_modules/.bin`; going through the package
+	// manager can fail on unrelated state (e.g. pnpm refusing to run while build scripts
+	// are unapproved), but it's the only way to reach binaries under Yarn PnP
+	let result = await run('prettier', args, options.cwd);
+	if (result.notFound) {
+		const cmd = resolveCommand(options.packageManager, 'execute-local', ['prettier', ...args])!;
+		result = await run(cmd.command, cmd.args, options.cwd);
+	}
+
+	if (result.error !== undefined) {
 		stop('Failed to format files');
-		// @ts-expect-error
-		p.log.error(e?.output?.stderr || 'unknown error');
+		p.log.error(result.error);
 		return;
 	}
 	stop('Successfully formatted modified files');
+}
+
+async function run(
+	command: string,
+	args: string[],
+	cwd: string
+): Promise<{ error?: string; notFound?: boolean }> {
+	try {
+		await exec(command, args, { nodeOptions: { cwd, stdio: 'pipe' }, throwOnError: true });
+		return {};
+	} catch (e) {
+		// @ts-expect-error tinyexec rethrows the spawn error as-is
+		if (e?.code === 'ENOENT') return { notFound: true, error: `${command} not found` };
+		// @ts-expect-error `output` is only present on tinyexec's `NonZeroExitError`
+		const output = e?.output as { stderr?: string; stdout?: string } | undefined;
+		// failures can land on either stream, so report both
+		const message = [output?.stderr, output?.stdout].filter(Boolean).join('\n').trim();
+		return { error: message || (e instanceof Error ? e.message : 'unknown error') };
+	}
 }


### PR DESCRIPTION
Closes #1141
Closes #1166

### Description

- Drop `allowBuilds` for `@tailwindcss/oxide` and `sharp` - neither ships an install script anymore (`workerd` and `better-sqlite3` still do, so they stay).
- Formatting now runs `prettier` from `node_modules/.bin` (falling back to the package manager for Yarn PnP), and errors report stdout too. pnpm refuses to run `pnpm exec` after it writes `set this to true or false` placeholders on skipped builds, and it prints that on stdout, which surfaced as `Failed to format files / unknown error`.

### Checklist

- Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)
- Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable)
- Allow maintainers to edit this PR
- I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)
