### PR TITLE
fix(better-auth): use the `auth` CLI binary in the auth:schema script

### DIFF
--- a/.changeset/tame-pandas-shout.md
+++ b/.changeset/tame-pandas-shout.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix(better-auth): use the `auth` CLI binary in the `auth:schema` script

--- a/packages/sv/src/addons/better-auth.ts
+++ b/packages/sv/src/addons/better-auth.ts
@@ -181,7 +181,7 @@ export default defineAddon({
 					/**
 					 * DO NOT USE!
 					 *
-					 * This instance is used by the \`better-auth\` CLI for schema generation ONLY.
+					 * This instance is used by the \`auth\` CLI for schema generation ONLY.
 					 * To access \`auth\` at runtime, use \`event.locals.auth\`.
 					 */
 					export const auth = createAuth(null${ts('!')});`;
@@ -212,7 +212,7 @@ export default defineAddon({
 				json.packageScriptsUpsert(
 					data,
 					'auth:schema',
-					`better-auth generate --config ${authConfigPath} --output ${authSchemaPath} --yes`
+					`auth generate --config ${authConfigPath} --output ${authSchemaPath} --yes`
 				);
 			})
 		);

--- a/packages/sv/src/cli/tests/snapshots/create-experimental/package.json
+++ b/packages/sv/src/cli/tests/snapshots/create-experimental/package.json
@@ -15,7 +15,7 @@
 		"db:generate": "drizzle-kit generate",
 		"db:migrate": "drizzle-kit migrate",
 		"db:studio": "drizzle-kit studio",
-		"auth:schema": "better-auth generate --config src/lib/server/auth.ts --output src/lib/server/db/auth.schema.ts --yes"
+		"auth:schema": "auth generate --config src/lib/server/auth.ts --output src/lib/server/db/auth.schema.ts --yes"
 	},
 	"devDependencies": {
 		"@libsql/client": "^0.17.3",

--- a/packages/sv/src/cli/tests/snapshots/create-with-all-addons/package.json
+++ b/packages/sv/src/cli/tests/snapshots/create-with-all-addons/package.json
@@ -19,7 +19,7 @@
 		"db:generate": "drizzle-kit generate",
 		"db:migrate": "drizzle-kit migrate",
 		"db:studio": "drizzle-kit studio",
-		"auth:schema": "better-auth generate --config src/lib/server/auth.ts --output src/lib/server/db/auth.schema.ts --yes"
+		"auth:schema": "auth generate --config src/lib/server/auth.ts --output src/lib/server/db/auth.schema.ts --yes"
 	},
 	"devDependencies": {
 		"@eslint/js": "^10.0.1",


### PR DESCRIPTION
The addon installs the `auth` package, which ships both `auth` and `better-auth` bins. The generated `auth:schema` script now calls `auth generate` instead of the legacy `better-auth` alias.

Snapshots updated accordingly.