### PR TITLE
fix(cli): update pm layout

### DIFF
--- a/.changeset/rich-papayas-hide.md
+++ b/.changeset/rich-papayas-hide.md
@@ -2,4 +2,4 @@
 "sv": patch
 ---
 
-fix(cli): pm can appear invisible
+fix(cli): omit undetected package managers from install prompt

--- a/.changeset/rich-papayas-hide.md
+++ b/.changeset/rich-papayas-hide.md
@@ -1,0 +1,5 @@
+---
+"sv": patch
+---
+
+fix(cli): pm can appear invisible

--- a/packages/sv/src/core/package-manager.ts
+++ b/packages/sv/src/core/package-manager.ts
@@ -32,25 +32,17 @@ export async function packageManagerPrompt(cwd: string): Promise<AgentName | und
 	// There is no need to prompt in that case.
 	if (!process.stdout.isTTY) return agent;
 
-	const maxAgentLength = AGENT_NAMES.reduce((a, c) => (c.length > a ? c.length : a), 0);
-	// installed ones first
 	const agentOptions = [
 		{ label: 'None', value: undefined },
-		...AGENT_NAMES.map((agent) => {
-			const installed = isInstalled(agent);
-			return {
-				value: agent,
-				label: installed ? agent : `${agent.padEnd(maxAgentLength)} (not installed)`,
-				installed
-			};
-		}).sort((a, b) => Number(b.installed) - Number(a.installed))
+		...AGENT_NAMES.flatMap((agent) => (isInstalled(agent) ? { value: agent } : []))
 	];
 
 	const pm = await p.select({
-		message: 'Which package manager do you want to install dependencies with?',
+		message: 'Detected package managers. Which one should we use to install dependencies?',
 		options: agentOptions,
 		initialValue: agent
 	});
+
 	if (p.isCancel(pm)) {
 		p.cancel('Operation cancelled.');
 		process.exit(1);

--- a/packages/sv/src/core/package-manager.ts
+++ b/packages/sv/src/core/package-manager.ts
@@ -34,7 +34,7 @@ export async function packageManagerPrompt(cwd: string): Promise<AgentName | und
 
 	const agentOptions = [
 		{ label: 'None', value: undefined },
-		...AGENT_NAMES.flatMap((agent) => (isInstalled(agent) ? { value: agent } : []))
+		...AGENT_NAMES.filter(isInstalled).map((agent) => ({ value: agent }))
 	];
 
 	const pm = await p.select({

--- a/packages/sv/src/core/package-manager.ts
+++ b/packages/sv/src/core/package-manager.ts
@@ -32,6 +32,7 @@ export async function packageManagerPrompt(cwd: string): Promise<AgentName | und
 	// There is no need to prompt in that case.
 	if (!process.stdout.isTTY) return agent;
 
+	const maxAgentLength = AGENT_NAMES.reduce((a, c) => (c.length > a ? c.length : a), 0);
 	// installed ones first
 	const agentOptions = [
 		{ label: 'None', value: undefined },
@@ -39,7 +40,7 @@ export async function packageManagerPrompt(cwd: string): Promise<AgentName | und
 			const installed = isInstalled(agent);
 			return {
 				value: agent,
-				label: installed ? agent : color.dim(`${agent} (not installed)`),
+				label: installed ? agent : `${agent.padEnd(maxAgentLength)} (not installed)`,
 				installed
 			};
 		}).sort((a, b) => Number(b.installed) - Number(a.installed))


### PR DESCRIPTION
| Before | After |
|--------|--------|
| ![](https://github.com/user-attachments/assets/09ac53dc-79af-43a2-853e-f3f232b8c439) | ![](https://github.com/user-attachments/assets/0b5b24f0-36ca-4ce8-b681-8a383c3713c2) |

Closes #

### Description

Don't know if it affects anyone else, but `pm` are invisible to me, I also added some padding.

### Checklist

- Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)
- Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable)
- Allow maintainers to edit this PR
- I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)
