### PR TITLE
chore: document default values for `prepareServer`

### DIFF
--- a/.changeset/tiny-zoos-add.md
+++ b/.changeset/tiny-zoos-add.md
@@ -1,0 +1,5 @@
+---
+"sv": patch
+---
+
+chore: document default values for `prepareServer`

--- a/packages/sv/src/testing.ts
+++ b/packages/sv/src/testing.ts
@@ -204,7 +204,9 @@ export type SetupTestOptions<Addons extends AddonMap> = {
 export type PrepareServerOptions = {
 	cwd: string;
 	page: Page;
+	/** @default 'pnpm build' */
 	buildCommand?: string;
+	/** @default 'pnpm preview' */
 	previewCommand?: string;
 	/**
 	 * Vitest's `expect`, injected by `createSetupTest`. Used to make a Vitest-counted


### PR DESCRIPTION
### Description

Small QOL update, I was wondering why my test was failing with `Error: spawn pnpm ENOENT`

### Checklist

- Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)
- Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable)
- Allow maintainers to edit this PR
- I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)
