### PR TITLE
chore: add `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = tab
+charset = utf-8
+trim_trailing_whitespace = true


### PR DESCRIPTION
Closes #

### Description

Copied from https://github.com/sveltejs/kit/blob/version-3/.editorconfig.

Why? Makes my life easier.

More specficially? `vscode` + `detent` uses spaces and `prettier` won't format them cause they're string literals.

### Checklist

- Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)
- Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable)
- Allow maintainers to edit this PR
- I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)
