### PR TITLE
chore: run addon tests on request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,6 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm exec playwright install chromium
       - run: pnpm build
       - run: pnpm test:ci
   addon-integration-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ on:
       - 'LICENSE'
       - 'README.md'
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     paths-ignore: *paths_ignore
 
 # cancel in-progress runs on new commits to same PR (gitub.event.number)
@@ -65,4 +66,23 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm exec playwright install chromium
       - run: pnpm build
-      - run: pnpm test
+      - run: pnpm test -- --project='!addons'
+  addon-integration-tests:
+    if: >-
+      github.event_name == 'pull_request' &&
+      contains(github.event.pull_request.labels.*.name, 'needs-addon-integration-tests')
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm exec playwright install chromium
+      - run: pnpm build
+      - run: pnpm test -- --project=addons

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm exec playwright install chromium
       - run: pnpm build
-      - run: pnpm test -- --project='!addons'
+      - run: pnpm test:ci
   addon-integration-tests:
     if: >-
       github.event_name == 'pull_request' &&
@@ -85,4 +85,4 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm exec playwright install chromium
       - run: pnpm build
-      - run: pnpm test -- --project=addons
+      - run: pnpm test:addons

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 
+      - name: Require addon integration tests on Changesets PR
+        if: steps.changesets.outputs.pullRequestNumber != ''
+        run: >-
+          gh pr edit "${{ steps.changesets.outputs.pullRequestNumber }}"
+          --add-label needs-addon-integration-tests
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Update Template Repo
         if: steps.changesets.outputs.published == 'true'
         run: pnpm -F @sveltejs/create update-template-repo

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,8 @@ pnpm dev
 
 For each add-on we have integration tests setup. These install the deps, build the app, run the dev server and then run a few small snippets against the add-on to see if the changes introduced by the add-on are working as expected.
 
+Because the add-on integration tests take a long time, CI only runs them when a pull request has the `needs-addon-integration-tests` label. Add this label to pull requests that change add-on behavior or could otherwise affect add-on integrations. Changesets release pull requests receive the label automatically.
+
 Tests are split into projects: `cli`, `core`, `sv-utils`, `addons`, `create`, `migrate`. **Always run tests by project** for faster feedback:
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
 		"format": "pnpm --parallel format",
 		"lint": "pnpm --parallel lint && eslint --cache --cache-location node_modules/.eslintcache",
 		"test": "vitest run --silent",
+		"test:addons": "vitest run --silent --project=addons",
+		"test:ci": "vitest run --silent --project=!addons",
 		"test:ecosystem-ci": "vitest run --exclude='**/storybook/test.ts'",
 		"test:ui": "vitest --ui",
 		"update-deps": "node ./scripts/update-dependencies.js && pnpm format"


### PR DESCRIPTION
The addon tests are the only ones that take quite a lot of time to run. So we run them in a separate runner to get faster general feedback. Additionally most of the changes we do, do not affect the addons itself. In such cases it is wasteful to run the addon tests. Therefore we add a new label [`needs-addon-integration-tests`](https://github.com/sveltejs/cli/labels) similar to the `needs-platform-tests` in kit, that we can add to the prs on a per need basis. Changeset PR's automatically receive that label.

### Description

<!-- Please describe what your PR does -->

### Checklist

- Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)
- Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable)
- Allow maintainers to edit this PR
- I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)
