### PR TITLE
fix(addon): relax community addon requirements

### DIFF
--- a/.changeset/warm-snails-hope.md
+++ b/.changeset/warm-snails-hope.md
@@ -1,0 +1,5 @@
+---
+"sv": patch
+---
+
+fix(addon): Dependencies are allowed in multi-export repos.

--- a/documentation/docs/30-add-ons/99-community.md
+++ b/documentation/docs/30-add-ons/99-community.md
@@ -150,7 +150,7 @@ Community add-ons are bundled with [tsdown](https://tsdown.dev/) into a single f
 
 ### `package.json`
 
-Your add-on must have `sv` as a peer dependency and **no** `dependencies` in `package.json`:
+Your add-on must have `sv` as a peer dependency. Any `dependencies` declared will **not** be available at runtime, everything must be bundled:
 
 ```jsonc
 {
@@ -164,7 +164,7 @@ Your add-on must have `sv` as a peer dependency and **no** `dependencies` in `pa
 	"publishConfig": {
 		"access": "public"
 	},
-	// cannot have dependencies
+	// packages declared here will not be available during runtime, it must be bundled
 	"dependencies": {},
 	"peerDependencies": {
 		// minimum version required to run by this add-on

--- a/packages/sv/src/cli/tests/snapshots/@my-org/sv/CONTRIBUTING.md
+++ b/packages/sv/src/cli/tests/snapshots/@my-org/sv/CONTRIBUTING.md
@@ -45,4 +45,4 @@ npm publish
 
 ## Things to be aware of
 
-Community add-ons must have `sv` as a `peerDependency` and should **not** have any `dependencies`. Everything else (including `@sveltejs/sv-utils`) is bundled at build time by tsdown.
+Community add-ons must have `sv` as a `peerDependency`. Any `dependencies` declared in `package.json` will not be available at runtime. Everything else (including `@sveltejs/sv-utils`) is bundled at build time by tsdown.

--- a/packages/sv/src/core/fetch-packages.ts
+++ b/packages/sv/src/core/fetch-packages.ts
@@ -1,4 +1,4 @@
-import { color, coerceVersion, downloadJson } from '@sveltejs/sv-utils';
+import { color, coerceVersion, dedent, downloadJson } from '@sveltejs/sv-utils';
 import { unpackTar } from 'modern-tar/fs';
 import fs from 'node:fs';
 import { platform } from 'node:os';
@@ -13,9 +13,18 @@ import type { AddonDefinition, AddonReference } from './config.ts';
 // path to the `node_modules` directory of `sv`
 const NODE_MODULES = fileURLToPath(new URL('../../node_modules', import.meta.url));
 
+function isStandalone(addonPkg: Record<string, any>): boolean {
+	const exports = addonPkg.exports;
+	if (!exports) return true;
+	if (typeof exports === 'string') return true;
+	if (typeof exports === 'object') return Object.keys(exports).length === 1;
+	return true;
+}
+
 function verifyPackage(addonPkg: Record<string, any>, specifier: string): string | undefined {
 	const peerDeps = { ...addonPkg.peerDependencies };
 	const deps = { ...addonPkg.dependencies };
+	const standalone = isStandalone(addonPkg);
 
 	// valid addons should always have `sv` as a peerDependency
 	const addonSvVersion = peerDeps['sv'];
@@ -25,10 +34,12 @@ function verifyPackage(addonPkg: Record<string, any>, specifier: string): string
 		);
 	}
 
-	// addons should not have any dependencies (everything should be bundled)
-	if (Object.keys(deps).length > 0) {
+	// standalone addons must not have dependencies (everything should be bundled)
+	if (standalone && Object.keys(deps).length > 0) {
 		throw new Error(
-			`Invalid add-on package detected: '${specifier}'\nCommunity add-ons should not have any 'dependencies'. Use 'peerDependencies' for 'sv' and bundle everything else`
+			dedent`
+				Invalid add-on package detected: '${specifier}'
+				Standalone add-ons must not have 'dependencies' in package.json. Everything should be bundled with your add-on.`
 		);
 	}
 

--- a/packages/sv/src/create/shared/+addon/CONTRIBUTING.md
+++ b/packages/sv/src/create/shared/+addon/CONTRIBUTING.md
@@ -45,4 +45,4 @@ npm publish
 
 ## Things to be aware of
 
-Community add-ons must have `sv` as a `peerDependency` and should **not** have any `dependencies`. Everything else (including `@sveltejs/sv-utils`) is bundled at build time by tsdown.
+Community add-ons must have `sv` as a `peerDependency`. Any `dependencies` declared in `package.json` will not be available at runtime. Everything else (including `@sveltejs/sv-utils`) is bundled at build time by tsdown.


### PR DESCRIPTION
Closes #1210

### Description

My initial take is to just relax the check for multi export repos. This doesn't really flag the problem if the addon dev decides to use those dependencies.

I considered static analysis, but it seems complicated to do.

### Checklist

- Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)
- Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable)
- Allow maintainers to edit this PR
- I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)
