### PR TITLE
fix(migrate): correctness fixes in the migrate CLI and sveltekit-3 tasks

### DIFF
--- a/.changeset/olive-jars-repeat.md
+++ b/.changeset/olive-jars-repeat.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix(migrate): correctness fixes in the migrate CLI and sveltekit-3 tasks

--- a/packages/sv/src/addons/ai-tools.ts
+++ b/packages/sv/src/addons/ai-tools.ts
@@ -259,7 +259,8 @@ export default defineAddon({
 			if (!filesAdded.includes(agentPath)) {
 				sv.file(agentPath, (content) => {
 					if (content) {
-						filesExistingAlready.push(agentPath);
+						// several clients share AGENTS.md, so the same path can land here more than once
+						if (!filesExistingAlready.includes(agentPath)) filesExistingAlready.push(agentPath);
 						return false;
 					}
 					filesAdded.push(agentPath);

--- a/packages/sv/src/cli/migrate.ts
+++ b/packages/sv/src/cli/migrate.ts
@@ -172,7 +172,7 @@ async function determineTasks(
 	};
 
 	try {
-		migration.setup(setupOptions);
+		await migration.setup(setupOptions);
 	} catch (err) {
 		common.errorAndExit(err instanceof Error ? err.message : String(err));
 		return;
@@ -196,7 +196,7 @@ async function determineTasks(
 			}
 		}
 	};
-	migration.collect(collectOptions);
+	await migration.collect(collectOptions);
 
 	if (allTasks.length === 0) {
 		common.errorAndExit(`Migration "${migration.id}" did not return any tasks to run.`);
@@ -250,6 +250,12 @@ async function determineTasks(
 			message: 'Do you want to proceed?',
 			initialValue: false
 		});
+
+		// a cancel is a truthy symbol, so it has to be checked before the falsy "no"
+		if (typeof proceed === 'symbol') {
+			p.cancel('Operation cancelled.');
+			process.exit(1);
+		}
 
 		if (!proceed) {
 			common.errorAndExit('Migration cancelled by the user.');

--- a/packages/sv/src/cli/migrate.ts
+++ b/packages/sv/src/cli/migrate.ts
@@ -93,7 +93,7 @@ export const migrate = new Command('migrate')
 				});
 			}
 
-			if (!verifiedMigrationName || typeof verifiedMigrationName === 'symbol') {
+			if (p.isCancel(verifiedMigrationName)) {
 				p.cancel('Operation cancelled.');
 				process.exit(1);
 			}
@@ -223,7 +223,7 @@ async function determineTasks(
 			required: false
 		});
 
-		if (typeof optionalTaskIdsToRun === 'symbol') {
+		if (p.isCancel(optionalTaskIdsToRun)) {
 			p.cancel('Operation cancelled.');
 			process.exit(1);
 		}

--- a/packages/sv/src/cli/migrate.ts
+++ b/packages/sv/src/cli/migrate.ts
@@ -252,7 +252,7 @@ async function determineTasks(
 		});
 
 		// a cancel is a truthy symbol, so it has to be checked before the falsy "no"
-		if (isCancel(proceed)) {
+		if (p.isCancel(proceed)) {
 			p.cancel('Operation cancelled.');
 			process.exit(1);
 		}

--- a/packages/sv/src/cli/migrate.ts
+++ b/packages/sv/src/cli/migrate.ts
@@ -252,7 +252,7 @@ async function determineTasks(
 		});
 
 		// a cancel is a truthy symbol, so it has to be checked before the falsy "no"
-		if (typeof proceed === 'symbol') {
+		if (isCancel(proceed)) {
 			p.cancel('Operation cancelled.');
 			process.exit(1);
 		}

--- a/packages/sv/src/migrate/migrations/app-state/tasks/app-state/migrate.ts
+++ b/packages/sv/src/migrate/migrations/app-state/tasks/app-state/migrate.ts
@@ -227,6 +227,13 @@ function derefStores(
 			if (local === undefined) return;
 
 			const parent = ctx.path[ctx.path.length - 1];
+			if (!isReference(node, parent)) return;
+
+			// `{ $page }` shorthand carries the name twice; keep the key and rewrite only the value
+			if (parent.type === 'Property' && parent.shorthand && parent.key === node) {
+				parent.key = { ...node };
+				parent.shorthand = false;
+			}
 
 			if (local.store === 'updated') {
 				// `$updated` -> `updated.current`
@@ -252,6 +259,19 @@ function derefStores(
 			node.name = local.name;
 		}
 	});
+}
+
+/**
+ * Whether `node` is a value reference rather than a property name. `obj.$page` and `{ $page: x }`
+ * only borrow the name, so renaming them would rewrite unrelated members and object keys.
+ */
+function isReference(
+	node: AstTypes.Node,
+	parent: AstTypes.Node | SvelteAst.SvelteNode
+): boolean {
+	if (parent.type === 'MemberExpression') return parent.computed || parent.object === node;
+	if (parent.type === 'Property') return parent.computed || parent.shorthand || parent.key !== node;
+	return true;
 }
 
 /** Whether `node` is the object being accessed in `parent` (e.g. `$navigating` in `$navigating.to`). */

--- a/packages/sv/src/migrate/migrations/app-state/tasks/app-state/migrate.ts
+++ b/packages/sv/src/migrate/migrations/app-state/tasks/app-state/migrate.ts
@@ -265,10 +265,7 @@ function derefStores(
  * Whether `node` is a value reference rather than a property name. `obj.$page` and `{ $page: x }`
  * only borrow the name, so renaming them would rewrite unrelated members and object keys.
  */
-function isReference(
-	node: AstTypes.Node,
-	parent: AstTypes.Node | SvelteAst.SvelteNode
-): boolean {
+function isReference(node: AstTypes.Node, parent: AstTypes.Node | SvelteAst.SvelteNode): boolean {
 	if (parent.type === 'MemberExpression') return parent.computed || parent.object === node;
 	if (parent.type === 'Property') return parent.computed || parent.shorthand || parent.key !== node;
 	return true;

--- a/packages/sv/src/migrate/migrations/sveltekit-3/tasks/environment.ts
+++ b/packages/sv/src/migrate/migrations/sveltekit-3/tasks/environment.ts
@@ -37,7 +37,7 @@ export default defineMigrationTask({
 
 		if (envVars.size > 0) {
 			sv.file(
-				'src/env.ts',
+				`src/env.${language}`,
 				transforms.script(({ ast }) => addEnvDeclarationFile(ast, envVars))
 			);
 		}

--- a/packages/sv/src/migrate/migrations/sveltekit-3/tasks/environment/explicit-env-vars.ts
+++ b/packages/sv/src/migrate/migrations/sveltekit-3/tasks/environment/explicit-env-vars.ts
@@ -469,7 +469,7 @@ export function addEnvDeclarationFile(
 ): false | void {
 	if (envVars.size === 0) return false;
 
-	js.imports.addNamed(ast, { from: '@sveltejs/kit/hooks', imports: ['defineEnvVars'] });
+	js.imports.addNamed(ast, { from: '@sveltejs/kit/env', imports: ['defineEnvVars'] });
 
 	const defineCall = js.functions.createCall({
 		name: 'defineEnvVars',

--- a/packages/sv/src/migrate/migrations/sveltekit-3/tasks/tsconfig.ts
+++ b/packages/sv/src/migrate/migrations/sveltekit-3/tasks/tsconfig.ts
@@ -51,10 +51,15 @@ export default defineMigrationTask({
 			transforms.json<TypeConfig>(({ data }) => {
 				const extended = Array.isArray(data.extends) ? [...data.extends] : [data.extends];
 				const index = extended.findIndex((entry) => entry && GENERATED_CONFIG.test(entry));
-				if (index === -1) return false;
 
-				extended[index] = PARENT_CONFIG;
-				data.extends = Array.isArray(data.extends) ? (extended as string[]) : PARENT_CONFIG;
+				// a prerequisite task may have retargeted `extends` already; the `include` paths below
+				// still have to move, so only bail when neither config is referenced
+				if (index === -1 && !extended.includes(PARENT_CONFIG)) return false;
+
+				if (index !== -1) {
+					extended[index] = PARENT_CONFIG;
+					data.extends = Array.isArray(data.extends) ? (extended as string[]) : PARENT_CONFIG;
+				}
 
 				// the generated config no longer carries `include`, so the project owns it now
 				const include = (data.include ??= ['src']);

--- a/packages/sv/src/migrate/migrations/sveltekit-3/tests/environment/src/env.snapshot.ts
+++ b/packages/sv/src/migrate/migrations/sveltekit-3/tests/environment/src/env.snapshot.ts
@@ -1,4 +1,4 @@
-import { defineEnvVars } from '@sveltejs/kit/hooks';
+import { defineEnvVars } from '@sveltejs/kit/env';
 
 export const variables = defineEnvVars({
 	ENV_PRIVATE_DYNAMIC_1: {},

--- a/packages/sv/src/migrate/migrations/tests.spec.ts
+++ b/packages/sv/src/migrate/migrations/tests.spec.ts
@@ -81,7 +81,9 @@ for (const migrationDirectory of migrationDirectories) {
 					const expectedPath = path.join(cwd, expectedFileName);
 					await expect(actual).toMatchFileSnapshot(expectedPath, expectedFileName);
 
-					remainingSnapshotFiles.splice(remainingSnapshotFiles.indexOf(expectedFileName), 1);
+					// a snapshot vitest just created isn't in the list; `-1` would drop an unrelated entry
+					const snapshotIndex = remainingSnapshotFiles.indexOf(expectedFileName);
+					if (snapshotIndex !== -1) remainingSnapshotFiles.splice(snapshotIndex, 1);
 				}
 
 				// if we have any snapshots remaining that were not tested against, fail the test to make sure all snapshots are up to date and tested against.


### PR DESCRIPTION
Six independent bugs found while reviewing `feat/update-templates-to-kit-3`. None are caused by that branch - they all live on `version-1` already.

- **Ctrl+C at the migrate confirm prompt ran the migration anyway.** clack returns a truthy symbol on cancel, so `!proceed` was never true.
- The sveltekit-3 env task emitted `@sveltejs/kit/hooks` (the pre-kit-3 specifier) instead of `@sveltejs/kit/env`, and hardcoded `src/env.ts` in JS projects.
- The tsconfig task bailed - silently dropping migrated `include` paths - when a prerequisite task had already retargeted `extends`.
- `derefStores` renamed identifiers by name only, so `obj.$page` and `{ $page: x }` were rewritten too.
- A `-1` `splice` in the snapshot test dropped an unrelated entry, masking the assertion it exists for.
- The ai-tools warning listed `AGENTS.md` once per selected IDE.

`--project migrate --project sv-utils`: 289 passed.

One further issue is **not** fixed here: `sveltekit-3/tasks/svelte-config.ts` unlinks `svelte.config` outside the `sv` API, so a `--files` filter that suppresses the `vite.config` write leaves the project with no config at all. A correct fix needs an `sv.remove` that honours `filesFilter`.