### PR TITLE
feat(migrate): move Kit 3 setup out of the experimental add-on

### DIFF
--- a/.changeset/calm-utils-trim.md
+++ b/.changeset/calm-utils-trim.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/sv-utils': major
+---
+
+breaking: remove the migration-specific `libSubpathImports` helper

--- a/.changeset/experimental-flags-only.md
+++ b/.changeset/experimental-flags-only.md
@@ -1,0 +1,5 @@
+---
+'sv': major
+---
+
+breaking(addons): limit the `experimental` add-on to enabling experimental features

--- a/.changeset/fresh-libs-migrate.md
+++ b/.changeset/fresh-libs-migrate.md
@@ -1,0 +1,5 @@
+---
+'sv': minor
+---
+
+feat(migrate): migrate SvelteKit 3 dependencies and replace `$lib` with `#lib`

--- a/documentation/docs/30-add-ons/14-experimental.md
+++ b/documentation/docs/30-add-ons/14-experimental.md
@@ -2,7 +2,7 @@
 title: experimental
 ---
 
-Enables Svelte and [SvelteKit](https://svelte.dev/docs/kit/configuration#experimental) experimental features, and can opt your project into their `next` pre-release versions.
+Enables experimental Svelte and [SvelteKit](https://svelte.dev/docs/kit/configuration#experimental) features.
 
 ## Usage
 
@@ -13,19 +13,8 @@ npx sv add experimental
 ## What you get
 
 - the selected experimental flags set in your config
-- optionally `@sveltejs/kit` (and your adapter) moved to their `next` line
 
 ## Options
-
-### versions
-
-Which packages to move to their `next` pre-release version:
-
-- `kit` — `@sveltejs/kit@next` (also bumps your adapter and required peers)
-
-```sh
-npx sv add experimental="versions:kit"
-```
 
 ### features
 
@@ -33,8 +22,6 @@ Which experimental flags to enable:
 
 - `async` — `await` in components
 - `remoteFunctions` — remote functions
-- `explicitEnvironmentVariables` — explicit environment variables (SvelteKit `^2` only)
-- `handleRenderingErrors` — rendering error boundaries
 - `forkPreloads` — forked preloading
 
 ```sh

--- a/packages/sv-utils/api-surface.md
+++ b/packages/sv-utils/api-surface.md
@@ -964,8 +964,6 @@ declare function isKit3(kitRange: string | undefined): boolean;
 
 declare function resolveLibPrefix(kitRange: string | undefined): '#lib' | '$lib';
 
-declare function libSubpathImports(libDir: string): Record<string, string>;
-
 declare const KIT3_TSCONFIG = '$app/tsconfig';
 
 declare const KIT3_TSCONFIG_DEFAULT: Record<string, unknown>;
@@ -1026,7 +1024,6 @@ export {
 	isVersionUnsupportedBelow,
 	index_d_exports$3 as js,
 	json_d_exports as json,
-	libSubpathImports,
 	loadFile,
 	loadPackageJson,
 	minVersion,

--- a/packages/sv-utils/src/index.ts
+++ b/packages/sv-utils/src/index.ts
@@ -88,13 +88,7 @@ export {
 export { defineEnv } from './env.ts';
 
 // Kit 3 specifics (version detection, `$lib` -> `#lib`, the generated tsconfig)
-export {
-	KIT3_TSCONFIG,
-	KIT3_TSCONFIG_DEFAULT,
-	isKit3,
-	libSubpathImports,
-	resolveLibPrefix
-} from './kit3.ts';
+export { KIT3_TSCONFIG, KIT3_TSCONFIG_DEFAULT, isKit3, resolveLibPrefix } from './kit3.ts';
 
 // Terminal styling
 export { color } from './color.ts';

--- a/packages/sv-utils/src/kit3.ts
+++ b/packages/sv-utils/src/kit3.ts
@@ -13,11 +13,6 @@ export function resolveLibPrefix(kitRange: string | undefined): '#lib' | '$lib' 
 	return isKit3(kitRange) ? '#lib' : '$lib';
 }
 
-/** The `package.json#imports` entries backing `#lib`. `libDir` is workspace-relative, e.g. `src/lib`. */
-export function libSubpathImports(libDir: string): Record<string, string> {
-	return { '#lib': `./${libDir}/index.js`, '#lib/*': `./${libDir}/*` };
-}
-
 /** The config kit 3 generates into `node_modules`, replacing `.svelte-kit/tsconfig.json`. */
 export const KIT3_TSCONFIG = '$app/tsconfig';
 

--- a/packages/sv/src/addons/experimental.ts
+++ b/packages/sv/src/addons/experimental.ts
@@ -1,54 +1,16 @@
-import {
-	KIT3_TSCONFIG,
-	KIT3_TSCONFIG_DEFAULT,
-	fileExists,
-	isVersionUnsupportedBelow,
-	libSubpathImports,
-	loadPackageJson,
-	svelteConfig,
-	transforms
-} from '@sveltejs/sv-utils';
-import fs from 'node:fs';
-import path from 'node:path';
+import { svelteConfig } from '@sveltejs/sv-utils';
 import { defineAddon, defineAddonOptions } from '../core/config.ts';
 
-// Single source of truth, keyed by flag name. `path` defaults to `experimental.<name>`; `off` opts out
-// of the default selection; `inNext: false` marks flags removed in kit 3 (skipped when `kit@next` is chosen).
-type Feature = { label: string; path?: string; hint?: string; off?: boolean; inNext?: boolean };
+// Single source of truth, keyed by flag name. `path` defaults to `experimental.<name>` and `off`
+// opts out of the default selection.
+type Feature = { label: string; path?: string; hint?: string; off?: boolean };
 const FEATURES: Record<string, Feature> = {
 	async: { label: 'async', hint: 'await in components', path: 'compilerOptions.experimental.async' }, // prettier-ignore
 	remoteFunctions: { label: 'remote functions' },
-	explicitEnvironmentVariables: { label: 'explicit environment variables', hint: 'kit ^2 only', inNext: false }, // prettier-ignore
-	handleRenderingErrors: { label: 'rendering error boundaries', hint: 'kit ^2 only', inNext: false }, // prettier-ignore
 	forkPreloads: { label: 'forked preloading', off: true }
 };
 
-// files whose `$lib` imports are rewritten to `#lib`
-const SOURCE_EXTENSIONS = ['.svelte', '.svelte.ts', '.svelte.js', '.ts', '.js', '.svx', '.md'];
-
-// only the alias itself: a bare `$lib` specifier or a `$lib/...` subpath. Without the lookahead this
-// also eats identifiers such as the store auto-subscription `$library`.
-const LIB_ALIAS_REGEX = /\$lib(?=\/|['"`])/g;
-
-// the entry this replaces when a project already extends the generated config
-const GENERATED_TSCONFIG_REGEX = /(^|\/)\.svelte-kit\/tsconfig\.json$/;
-
-// kit 3 raises these peer floors; bump only when the project is below them (never downgrade).
-const KIT3_PEERS = {
-	vite: '^8.0.0',
-	'@sveltejs/vite-plugin-svelte': '^7.0.0',
-	svelte: '^5.48.0',
-	typescript: '^6.0.0' // TS projects only
-};
-
 const options = defineAddonOptions()
-	.add('versions', {
-		question: 'Which packages should use their `next` (pre-release) version?',
-		type: 'multiselect',
-		default: ['kit-3'],
-		options: [{ value: 'kit-3', label: '@sveltejs/kit@next' }],
-		required: false
-	})
 	.add('features', {
 		question: 'Which experimental features do you want to enable?',
 		type: 'multiselect',
@@ -65,64 +27,10 @@ export default defineAddon({
 	shortDescription: 'svelte & kit experimental features',
 	homepage: 'https://svelte.dev/docs/kit/configuration#experimental',
 	options,
-
-	setup: ({ runsAfter }) => runsAfter('sveltekitAdapter'),
-
-	run: ({ sv, cwd, options, language, directory, dependencyVersion }) => {
-		const kitNext = options.versions.includes('kit-3');
-
-		if (kitNext) {
-			sv.devDependency('@sveltejs/kit', 'next');
-			for (const [pkg, range] of Object.entries(KIT3_PEERS)) {
-				if (pkg === 'typescript' && language !== 'ts') continue;
-				const current = dependencyVersion(pkg);
-				if (current && isVersionUnsupportedBelow(current, range)) sv.devDependency(pkg, range);
-			}
-			// adapters track kit's major, so move any installed `@sveltejs/adapter-*` to its `next` line too
-			const { data: pkg } = loadPackageJson(cwd);
-			const deps = { ...pkg.devDependencies, ...pkg.dependencies };
-			for (const name of Object.keys(deps)) {
-				if (name.startsWith('@sveltejs/adapter-')) sv.devDependency(name, 'next');
-			}
-		}
-
-		if (kitNext) {
-			// kit 3 serves the generated config from `$app/tsconfig` and no longer supplies `include`
-			for (const name of ['tsconfig.json', 'jsconfig.json']) {
-				if (!fileExists(cwd, name)) continue;
-				sv.file(
-					name,
-					transforms.json(({ data }) => {
-						data.extends = retargetExtends(data.extends);
-						data.include ??= [directory.src];
-						for (const [key, value] of Object.entries(data.compilerOptions ?? {})) {
-							// a differing value is a deliberate override and stays
-							if (KIT3_TSCONFIG_DEFAULT[key] === value) delete data.compilerOptions[key];
-						}
-					})
-				);
-			}
-
-			// `$lib` is gone in favour of `#lib` subpath imports, which Vite resolves from `package.json`
-			sv.file(
-				'package.json',
-				transforms.json(({ data }) => {
-					data.imports = { ...libSubpathImports(directory.lib), ...data.imports };
-				})
-			);
-			// safe here: templates are already written and every add-on emitting `$lib` runs later
-			for (const relative of sourceFiles(cwd, directory.src)) {
-				sv.file(relative, (content) => {
-					const rewritten = content.replace(LIB_ALIAS_REGEX, '#lib');
-					return rewritten === content ? false : rewritten;
-				});
-			}
-		}
-
+	run: ({ sv, cwd, options }) => {
 		const config: Record<string, any> = {};
 		for (const [name, f] of Object.entries(FEATURES)) {
 			if (!options.features.includes(name)) continue;
-			if (kitNext && f.inNext === false) continue;
 			const keys = (f.path ?? `experimental.${name}`).split('.');
 			let target = config;
 			for (const key of keys.slice(0, -1)) target = target[key] ??= {};
@@ -133,32 +41,3 @@ export default defineAddon({
 			svelteConfig.edit({ sv, cwd }, ({ override }) => override(config));
 	}
 });
-
-/**
- * Points `extends` at `$app/tsconfig`. An array form is kept, with only the generated-config entry
- * swapped, so a project's own base config isn't dropped.
- */
-function retargetExtends(current: unknown): string | string[] {
-	if (!Array.isArray(current)) return KIT3_TSCONFIG;
-
-	const index = current.findIndex(
-		(entry) => typeof entry === 'string' && GENERATED_TSCONFIG_REGEX.test(entry)
-	);
-	if (index === -1) return [...current, KIT3_TSCONFIG];
-
-	return current.with(index, KIT3_TSCONFIG);
-}
-
-/** Workspace-relative source files under `src`, for the `$lib` -> `#lib` rewrite. */
-function sourceFiles(cwd: string, src: string): string[] {
-	const root = path.resolve(cwd, src);
-	if (!fs.existsSync(root)) return [];
-	return fs
-		.readdirSync(root, { recursive: true })
-		.map((entry) => path.join(src, entry as string))
-		.filter(
-			(relative) =>
-				SOURCE_EXTENSIONS.some((ext) => relative.endsWith(ext)) &&
-				fs.statSync(path.resolve(cwd, relative)).isFile()
-		);
-}

--- a/packages/sv/src/addons/tests/experimental/test.ts
+++ b/packages/sv/src/addons/tests/experimental/test.ts
@@ -1,4 +1,3 @@
-import { parse } from '@sveltejs/sv-utils';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { expect } from 'vitest';
@@ -11,28 +10,18 @@ const { test, testCases } = setupTest(
 	{
 		kinds: [
 			{
-				// kit@next selected + every feature: the flags removed in kit 3 must be dropped
-				type: 'kit3',
+				type: 'all-features',
 				options: {
 					[addonId]: {
-						versions: ['kit-3'],
-						features: [
-							'async',
-							'remoteFunctions',
-							'explicitEnvironmentVariables',
-							'handleRenderingErrors',
-							'forkPreloads'
-						]
+						features: ['async', 'remoteFunctions', 'forkPreloads']
 					}
 				}
 			},
 			{
-				// kit@next not selected: no kit 3 rewrites, and the kit ^2 only flags survive
-				type: 'kit3-not-selected',
+				type: 'selected-features',
 				options: {
 					[addonId]: {
-						versions: [],
-						features: ['async', 'remoteFunctions', 'explicitEnvironmentVariables']
+						features: ['remoteFunctions']
 					}
 				}
 			}
@@ -49,43 +38,14 @@ test.concurrent.for(testCases)('experimental $kind.type $variant', (testCase, { 
 		.map((name) => join(cwd, name))
 		.find((file) => existsSync(file))!;
 	const source = readFileSync(config, 'utf8');
-	const pkg = readFileSync(join(cwd, 'package.json'), 'utf8');
 
-	const tsconfigPath = ['tsconfig.json', 'jsconfig.json']
-		.map((name) => join(cwd, name))
-		.find((file) => existsSync(file));
-	const tsconfig = tsconfigPath ? parse.json(readFileSync(tsconfigPath, 'utf8')).data : undefined;
-
-	if (testCase.kind.type === 'kit3') {
-		expect(JSON.parse(pkg).devDependencies['@sveltejs/kit']).toBe('next');
-		if (tsconfig) {
-			expect(tsconfig.extends).toBe('$app/tsconfig');
-			expect(tsconfig.include).toStrictEqual(['src']);
-			expect(tsconfig.compilerOptions).not.toHaveProperty('checkJs');
-		}
-		// the adapter must follow kit onto its `next` line (it peers on kit's major)
-		expect(JSON.parse(pkg).devDependencies['@sveltejs/adapter-auto']).toBe('next');
+	if (testCase.kind.type === 'all-features') {
 		expect(source).toMatch('async: true');
 		expect(source).toMatch('remoteFunctions: true');
 		expect(source).toMatch('forkPreloads: true');
-		// kit 3 no longer provides `$lib` on its own - sources move to `#lib` subpath imports
-		expect(JSON.parse(pkg).imports).toMatchObject({ '#lib': expect.any(String) });
-		const libIndex = ['src/lib/index.ts', 'src/lib/index.js']
-			.map((name) => join(cwd, name))
-			.find((file) => existsSync(file))!;
-		expect(readFileSync(libIndex, 'utf8')).not.toMatch('$lib');
-		expect(source).not.toMatch('alias');
-		// removed from experimental in kit 3, so they must be skipped when kit@next is chosen
-		expect(source).not.toMatch('explicitEnvironmentVariables');
-		expect(source).not.toMatch('handleRenderingErrors');
-	} else if (testCase.kind.type === 'kit3-not-selected') {
-		expect(JSON.parse(pkg).devDependencies['@sveltejs/kit']).not.toBe('next');
-		// the template's own `extends` keeps its `.json` suffix; the add-on would rewrite it to `$app/tsconfig`
-		if (tsconfig) expect(tsconfig.extends).toBe('$app/tsconfig.json');
-		expect(source).toMatch('async: true');
+	} else if (testCase.kind.type === 'selected-features') {
 		expect(source).toMatch('remoteFunctions: true');
-		expect(source).toMatch('explicitEnvironmentVariables: true');
-		// not selected -> absent
+		expect(source).not.toMatch('async');
 		expect(source).not.toMatch('forkPreloads');
 	}
 });

--- a/packages/sv/src/cli/tests/cli.ts
+++ b/packages/sv/src/cli/tests/cli.ts
@@ -46,18 +46,7 @@ describe('cli', () => {
 				'sveltekit-adapter=adapter:cloudflare+cfTarget:workers',
 				'drizzle=database:sqlite+sqlite:libsql',
 				'better-auth=demo:password,github',
-				'experimental=versions:+features:explicitEnvironmentVariables'
-			]
-		},
-		{
-			// guards the `kit@next` shape against upstream churn: no snapshot (the point is that it
-			// installs, builds and type-checks, not what it looks like)
-			projectName: 'create-experimental-next',
-			snapshot: false,
-			args: [
-				'--add',
-				'drizzle=database:sqlite+sqlite:libsql',
-				'experimental=versions:kit-3+features:async,remoteFunctions'
+				'experimental=features:remoteFunctions'
 			]
 		},
 		{

--- a/packages/sv/src/cli/tests/snapshots/create-experimental/README.md
+++ b/packages/sv/src/cli/tests/snapshots/create-experimental/README.md
@@ -15,7 +15,7 @@ To recreate this project with the same configuration:
 
 ```sh
 # recreate this project
-npx sv@0.0.0 create --template minimal --types ts --add sveltekit-adapter="adapter:cloudflare+cfTarget:workers" drizzle="database:sqlite+sqlite:libsql" better-auth="demo:password,github" experimental="versions:none+features:explicitEnvironmentVariables" --no-install packages/sv/.test-output/cli/create-experimental
+npx sv@0.0.0 create --template minimal --types ts --add sveltekit-adapter="adapter:cloudflare+cfTarget:workers" drizzle="database:sqlite+sqlite:libsql" better-auth="demo:password,github" experimental="features:remoteFunctions" --no-install packages/sv/.test-output/cli/create-experimental
 ```
 
 ## Developing

--- a/packages/sv/src/cli/tests/snapshots/create-experimental/vite.config.ts
+++ b/packages/sv/src/cli/tests/snapshots/create-experimental/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
 					filename.split(/[/\\]/).includes('node_modules') ? undefined : true
 			},
 			adapter: adapter(),
-			experimental: { explicitEnvironmentVariables: true }
+			experimental: { remoteFunctions: true }
 		})
 	]
 });

--- a/packages/sv/src/migrate/migrations/sveltekit-3/index.ts
+++ b/packages/sv/src/migrate/migrations/sveltekit-3/index.ts
@@ -3,6 +3,7 @@ import { defineMigration } from '../../index.ts';
 import appState from '../app-state/tasks/app-state.ts';
 import environment from './tasks/environment.ts';
 import externalRedirects from './tasks/external-redirects.ts';
+import libAlias from './tasks/lib-alias.ts';
 import packageJson from './tasks/package-json.ts';
 import params from './tasks/params.ts';
 import paths from './tasks/paths.ts';
@@ -12,7 +13,7 @@ import tsconfig from './tasks/tsconfig.ts';
 
 export default defineMigration({
 	id: 'sveltekit-3',
-	changelog: 'https://svelte.dev/blog/whatever',
+	changelog: 'https://github.com/sveltejs/kit/blob/version-3/packages/kit/CHANGELOG.md',
 	description: 'A set of migrations for SvelteKit 3.0',
 	setup: ({ pkg, requires }) => {
 		const kitPackageName = '@sveltejs/kit';
@@ -29,14 +30,18 @@ export default defineMigration({
 		}
 	},
 	collect: ({ tasks }) => {
+		// required
 		tasks.add(packageJson, { prerequisite: true });
+		tasks.add(tsconfig, { prerequisite: true });
+
+		// optional
 		tasks.add(svelteConfig, { prerequisite: false });
 		tasks.add(environment, { prerequisite: false });
 		tasks.add(paths, { prerequisite: false });
 		tasks.add(externalRedirects, { prerequisite: false });
 		tasks.add(shallowRouting, { prerequisite: false });
 		tasks.add(params, { prerequisite: false });
-		tasks.add(tsconfig, { prerequisite: true });
+		tasks.add(libAlias, { prerequisite: false });
 		tasks.add(appState, { prerequisite: false });
 	}
 });

--- a/packages/sv/src/migrate/migrations/sveltekit-3/index.ts
+++ b/packages/sv/src/migrate/migrations/sveltekit-3/index.ts
@@ -13,7 +13,7 @@ import tsconfig from './tasks/tsconfig.ts';
 
 export default defineMigration({
 	id: 'sveltekit-3',
-	changelog: 'https://github.com/sveltejs/kit/blob/version-3/packages/kit/CHANGELOG.md',
+	changelog: 'https://svelte.dev/blog/whatever',
 	description: 'A set of migrations for SvelteKit 3.0',
 	setup: ({ pkg, requires }) => {
 		const kitPackageName = '@sveltejs/kit';

--- a/packages/sv/src/migrate/migrations/sveltekit-3/tasks/lib-alias.ts
+++ b/packages/sv/src/migrate/migrations/sveltekit-3/tasks/lib-alias.ts
@@ -1,7 +1,7 @@
 import { transforms } from '@sveltejs/sv-utils';
 import { defineMigrationTask } from '../../../index.ts';
 
-const LIB_ALIAS = /\$lib(?=\/|['"`])/g;
+const LIB_ALIAS = /(?<=['"`])\$lib(?=\/|['"`])/g;
 
 function libSubpathImports(libDir: string): Record<string, string> {
 	return { '#lib': `./${libDir}/index.js`, '#lib/*': `./${libDir}/*` };

--- a/packages/sv/src/migrate/migrations/sveltekit-3/tasks/lib-alias.ts
+++ b/packages/sv/src/migrate/migrations/sveltekit-3/tasks/lib-alias.ts
@@ -1,0 +1,32 @@
+import { transforms } from '@sveltejs/sv-utils';
+import { defineMigrationTask } from '../../../index.ts';
+
+const LIB_ALIAS = /\$lib(?=\/|['"`])/g;
+
+function libSubpathImports(libDir: string): Record<string, string> {
+	return { '#lib': `./${libDir}/index.js`, '#lib/*': `./${libDir}/*` };
+}
+
+export default defineMigrationTask({
+	id: 'lib-alias',
+	description: 'Replace the $lib alias with #lib subpath imports',
+	run: ({ sv, directory }) => {
+		sv.file(
+			'package.json',
+			transforms.json(({ data }) => {
+				data.imports = { ...libSubpathImports(directory.lib), ...data.imports };
+			})
+		);
+
+		sv.files(
+			{
+				include: `${directory.src}/**/*.{svelte,svelte.ts,svelte.js,ts,js,svx,md}`,
+				where: (content) => content.includes('$lib')
+			},
+			(content) => {
+				const rewritten = content.replace(LIB_ALIAS, '#lib');
+				return rewritten === content ? false : rewritten;
+			}
+		);
+	}
+});

--- a/packages/sv/src/migrate/migrations/sveltekit-3/tasks/package-json.ts
+++ b/packages/sv/src/migrate/migrations/sveltekit-3/tasks/package-json.ts
@@ -1,16 +1,30 @@
-import experimentalAddon from '../../../../addons/experimental.ts';
+import { isVersionUnsupportedBelow, loadPackageJson } from '@sveltejs/sv-utils';
 import { defineMigrationTask } from '../../../index.ts';
+
+const KIT3_PEERS = {
+	vite: '^8.0.0',
+	'@sveltejs/vite-plugin-svelte': '^7.0.0',
+	svelte: '^5.48.0',
+	typescript: '^6.0.0'
+};
 
 export default defineMigrationTask({
 	id: 'package-json',
 	description: 'Update package.json to be compatible with SvelteKit 3.0',
-	run: (args) => {
-		// instead of duplicating the logic of the experimental addon, lets just call it.
-		// migrates kit to it's 'next' version.
-		experimentalAddon.run({
-			...args,
-			options: { versions: ['kit-3'], features: [] },
-			cancel: () => {}
-		});
+	run: ({ sv, cwd, language, dependencyVersion }) => {
+		sv.devDependency('@sveltejs/kit', 'next');
+
+		for (const [pkg, range] of Object.entries(KIT3_PEERS)) {
+			if (pkg === 'typescript' && language !== 'ts') continue;
+			const current = dependencyVersion(pkg);
+			if (current && isVersionUnsupportedBelow(current, range)) sv.devDependency(pkg, range);
+		}
+
+		// Adapters track Kit's major, so installed adapters must move to their prerelease line too.
+		const { data: pkg } = loadPackageJson(cwd);
+		const dependencies = { ...pkg.devDependencies, ...pkg.dependencies };
+		for (const name of Object.keys(dependencies)) {
+			if (name.startsWith('@sveltejs/adapter-')) sv.devDependency(name, 'next');
+		}
 	}
 });

--- a/packages/sv/src/migrate/migrations/sveltekit-3/tests/lib-alias/package.json
+++ b/packages/sv/src/migrate/migrations/sveltekit-3/tests/lib-alias/package.json
@@ -1,0 +1,5 @@
+{
+	"imports": {
+		"#existing": "./src/existing.js"
+	}
+}

--- a/packages/sv/src/migrate/migrations/sveltekit-3/tests/lib-alias/package.snapshot.json
+++ b/packages/sv/src/migrate/migrations/sveltekit-3/tests/lib-alias/package.snapshot.json
@@ -1,0 +1,7 @@
+{
+	"imports": {
+		"#lib": "./src/lib/index.js",
+		"#lib/*": "./src/lib/*",
+		"#existing": "./src/existing.js"
+	}
+}

--- a/packages/sv/src/migrate/migrations/sveltekit-3/tests/lib-alias/src/routes/+page.snapshot.svelte
+++ b/packages/sv/src/migrate/migrations/sveltekit-3/tests/lib-alias/src/routes/+page.snapshot.svelte
@@ -1,0 +1,6 @@
+<script>
+	import component from '#lib/component.svelte';
+	import { library } from '$library';
+</script>
+
+<svelte:component this={component} />

--- a/packages/sv/src/migrate/migrations/sveltekit-3/tests/lib-alias/src/routes/+page.svelte
+++ b/packages/sv/src/migrate/migrations/sveltekit-3/tests/lib-alias/src/routes/+page.svelte
@@ -1,0 +1,6 @@
+<script>
+	import component from '$lib/component.svelte';
+	import { library } from '$library';
+</script>
+
+<svelte:component this={component} />

--- a/packages/sv/src/migrate/migrations/sveltekit-3/tests/package-json/package.json
+++ b/packages/sv/src/migrate/migrations/sveltekit-3/tests/package-json/package.json
@@ -1,9 +1,10 @@
 {
     "devDependencies": {
+        "@sveltejs/adapter-auto": "^4.0.0",
         "@sveltejs/kit": "^2.65.0",
-        "vite": "^8.0.0",
-        "@sveltejs/vite-plugin-svelte": "^7.0.0",
-        "svelte": "^5.48.0",
-        "typescript": "^6.0.0"
+        "vite": "^7.0.0",
+        "@sveltejs/vite-plugin-svelte": "^6.0.0",
+        "svelte": "^5.40.0",
+        "typescript": "^5.0.0"
     }
 }

--- a/packages/sv/src/migrate/migrations/sveltekit-3/tests/package-json/package.snapshot.json
+++ b/packages/sv/src/migrate/migrations/sveltekit-3/tests/package-json/package.snapshot.json
@@ -1,5 +1,6 @@
 {
     "devDependencies": {
+        "@sveltejs/adapter-auto": "next",
         "@sveltejs/kit": "next",
         "@sveltejs/vite-plugin-svelte": "^7.0.0",
         "svelte": "^5.48.0",


### PR DESCRIPTION
Relates #1124 

### Description

Given that `sv@1` now targets `kit@3`, the `experimental` addon needs to change. Well not directly, but given that we will publish `sv migrate sveltekit-3` in the same step, we can safely assume that the user is either on `kit@3` or will use the migration to get there. Therefore the migration no longer needs to bump the peer deps or change any `$lib`/`#lib` stuff. Both things are therefore moved into its own migration task.

The only remaining task of the `experimental` addon is to enable `experimental` options. Thats it. As it should have been.

### Checklist

- Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)
- Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable)
- Allow maintainers to edit this PR
- I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)
