### PR TITLE
feat(migrate): remove `handleRenderingErrors` from sveltekit config

### DIFF
--- a/packages/sv/src/migrate/migrations/sveltekit-3/tasks/svelte-config.ts
+++ b/packages/sv/src/migrate/migrations/sveltekit-3/tasks/svelte-config.ts
@@ -71,6 +71,12 @@ export default defineMigrationTask({
 				if (prop.key.type !== 'Identifier') continue;
 				if (prop.key.name === 'kit') continue;
 
+				// Rendering error boundaries are always enabled in SvelteKit 3, and the old opt-in
+				// is rejected by its config validation. Drop it instead of moving it to vite.config.
+				if (prop.key.name === 'experimental' && prop.value.type === 'ObjectExpression') {
+					removeProperty(prop.value, 'handleRenderingErrors');
+				}
+
 				const propAttachment = attachments.get(prop);
 
 				// `csrf: { checkOrigin: false }` is deprecated; the equivalent is now
@@ -188,6 +194,14 @@ function forEachNode(root: unknown, visit: (node: AstTypes.Node) => void): void 
 		if (key === 'loc' || key === 'range' || key === 'parent') continue;
 		forEachNode(node[key], visit);
 	}
+}
+
+/** Removes a statically named property from an object literal. */
+function removeProperty(value: AstTypes.ObjectExpression, name: string): void {
+	const index = value.properties.findIndex(
+		(prop) => prop.type === 'Property' && prop.key.type === 'Identifier' && prop.key.name === name
+	);
+	if (index !== -1) value.properties.splice(index, 1);
 }
 
 /**

--- a/packages/sv/src/migrate/migrations/sveltekit-3/tasks/svelte-config.ts
+++ b/packages/sv/src/migrate/migrations/sveltekit-3/tasks/svelte-config.ts
@@ -90,6 +90,45 @@ export default defineMigrationTask({
 					}
 				}
 
+				// prerender.origin is removed in favor of paths.origin
+				if (prop.key.name === 'prerender' && prop.value.type === 'ObjectExpression') {
+					const originProp = prop.value.properties.find(
+						(prop): prop is AstTypes.Property & { key: AstTypes.Identifier } =>
+							prop.type === 'Property' &&
+							prop.key.type === 'Identifier' &&
+							prop.key.name === 'origin'
+					);
+					if (originProp) {
+						// prerender may come before paths and may be merged so we need to ensure the current object first
+						keyedConfig.paths ??= newConfigProperties.find(
+							(
+								prop
+							): prop is AstTypes.Property & {
+								key: AstTypes.Identifier;
+								value: AstTypes.ObjectExpression;
+							} =>
+								prop.type === 'Property' &&
+								prop.key.type === 'Identifier' &&
+								prop.key.name === 'paths' &&
+								prop.value.type === 'ObjectExpression'
+						)?.value ?? {
+							type: 'ObjectExpression',
+							properties: []
+						};
+						(keyedConfig.paths as AstTypes.ObjectExpression).properties.push({
+							type: 'Property',
+							key: { type: 'Identifier', name: 'origin' },
+							value: originProp.value,
+							kind: 'init',
+							method: false,
+							shorthand: false,
+							computed: false
+						});
+						removeProperty(prop.value, 'origin');
+						if (prop.value.properties.length === 0) continue; // drop the empty prerender object entirely
+					}
+				}
+
 				const propAttachment = attachments.get(prop);
 
 				// `csrf: { checkOrigin: false }` is deprecated; the equivalent is now
@@ -110,6 +149,9 @@ export default defineMigrationTask({
 				keyedConfig[prop.key.name] = prop.value;
 				if (propAttachment) propComments.set(prop.key.name, propAttachment);
 			}
+
+			// preloadStrategy is removed
+			delete keyedConfig.preloadStrategy;
 
 			override(keyedConfig);
 

--- a/packages/sv/src/migrate/migrations/sveltekit-3/tasks/svelte-config.ts
+++ b/packages/sv/src/migrate/migrations/sveltekit-3/tasks/svelte-config.ts
@@ -73,8 +73,21 @@ export default defineMigrationTask({
 
 				// Rendering error boundaries are always enabled in SvelteKit 3, and the old opt-in
 				// is rejected by its config validation. Drop it instead of moving it to vite.config.
+				// Tracing is also no longer experimental.
 				if (prop.key.name === 'experimental' && prop.value.type === 'ObjectExpression') {
 					removeProperty(prop.value, 'handleRenderingErrors');
+					removeProperty(prop.value, 'instrumentation');
+
+					const index = prop.value.properties.findIndex(
+						(prop) =>
+							prop.type === 'Property' &&
+							prop.key.type === 'Identifier' &&
+							prop.key.name === 'tracing'
+					);
+					if (index !== -1) {
+						keyedConfig.tracing = (prop.value.properties[index] as AstTypes.Property).value;
+						prop.value.properties.splice(index, 1);
+					}
 				}
 
 				const propAttachment = attachments.get(prop);

--- a/packages/sv/src/migrate/migrations/sveltekit-3/tasks/svelte-config.ts
+++ b/packages/sv/src/migrate/migrations/sveltekit-3/tasks/svelte-config.ts
@@ -63,7 +63,7 @@ export default defineMigrationTask({
 				...originalConfigObject.config.properties,
 				...originalConfigObject.kit.properties
 			];
-			const keyedConfig: Record<string, any> = [];
+			const keyedConfig: Record<string, AstTypes.Node> = {};
 			let trustsAllOrigins = false;
 
 			for (const prop of newConfigProperties) {
@@ -71,28 +71,34 @@ export default defineMigrationTask({
 				if (prop.key.type !== 'Identifier') continue;
 				if (prop.key.name === 'kit') continue;
 
+				const propAttachment = attachments.get(prop);
+				keyedConfig[prop.key.name] = prop.value;
+				if (propAttachment) propComments.set(prop.key.name, propAttachment);
+			}
+
+			for (const [key, value] of Object.entries(keyedConfig)) {
 				// Rendering error boundaries are always enabled in SvelteKit 3, and the old opt-in
 				// is rejected by its config validation. Drop it instead of moving it to vite.config.
 				// Tracing is also no longer experimental.
-				if (prop.key.name === 'experimental' && prop.value.type === 'ObjectExpression') {
-					removeProperty(prop.value, 'handleRenderingErrors');
-					removeProperty(prop.value, 'instrumentation');
+				if (key === 'experimental' && value.type === 'ObjectExpression') {
+					removeProperty(value, 'handleRenderingErrors');
+					removeProperty(value, 'instrumentation');
 
-					const index = prop.value.properties.findIndex(
+					const index = value.properties.findIndex(
 						(prop) =>
 							prop.type === 'Property' &&
 							prop.key.type === 'Identifier' &&
 							prop.key.name === 'tracing'
 					);
 					if (index !== -1) {
-						keyedConfig.tracing = (prop.value.properties[index] as AstTypes.Property).value;
-						prop.value.properties.splice(index, 1);
+						keyedConfig.tracing = (value.properties[index] as AstTypes.Property).value;
+						value.properties.splice(index, 1);
 					}
 				}
 
 				// prerender.origin is removed in favor of paths.origin
-				if (prop.key.name === 'prerender' && prop.value.type === 'ObjectExpression') {
-					const originProp = prop.value.properties.find(
+				if (key === 'prerender' && value.type === 'ObjectExpression') {
+					const originProp = value.properties.find(
 						(prop): prop is AstTypes.Property & { key: AstTypes.Identifier } =>
 							prop.type === 'Property' &&
 							prop.key.type === 'Identifier' &&
@@ -100,18 +106,7 @@ export default defineMigrationTask({
 					);
 					if (originProp) {
 						// prerender may come before paths and may be merged so we need to ensure the current object first
-						keyedConfig.paths ??= newConfigProperties.find(
-							(
-								prop
-							): prop is AstTypes.Property & {
-								key: AstTypes.Identifier;
-								value: AstTypes.ObjectExpression;
-							} =>
-								prop.type === 'Property' &&
-								prop.key.type === 'Identifier' &&
-								prop.key.name === 'paths' &&
-								prop.value.type === 'ObjectExpression'
-						)?.value ?? {
+						keyedConfig.paths ??= {
 							type: 'ObjectExpression',
 							properties: []
 						};
@@ -124,18 +119,19 @@ export default defineMigrationTask({
 							shorthand: false,
 							computed: false
 						});
-						removeProperty(prop.value, 'origin');
-						if (prop.value.properties.length === 0) continue; // drop the empty prerender object entirely
+						removeProperty(value, 'origin');
+						if (value.properties.length === 0) {
+							// drop the empty prerender object entirely
+							delete keyedConfig.prerender;
+						}
 					}
 				}
-
-				const propAttachment = attachments.get(prop);
 
 				// `csrf: { checkOrigin: false }` is deprecated; the equivalent is now
 				// `csrf: { trustedOrigins: ['*'] }`. Rewrite the property in place so any sibling
 				// `csrf` options are preserved and `trustedOrigins` stays nested under `csrf`.
-				if (prop.key.name === 'csrf' && prop.value.type === 'ObjectExpression') {
-					const checkOrigin = findDisabledCheckOrigin(prop.value);
+				if (key === 'csrf' && value.type === 'ObjectExpression') {
+					const checkOrigin = findDisabledCheckOrigin(value);
 					if (checkOrigin) {
 						checkOrigin.key.name = 'trustedOrigins';
 						checkOrigin.value = {
@@ -145,9 +141,6 @@ export default defineMigrationTask({
 						trustsAllOrigins = true;
 					}
 				}
-
-				keyedConfig[prop.key.name] = prop.value;
-				if (propAttachment) propComments.set(prop.key.name, propAttachment);
 			}
 
 			// preloadStrategy is removed

--- a/packages/sv/src/migrate/migrations/sveltekit-3/tests/svelte-config/svelte.config.template.js
+++ b/packages/sv/src/migrate/migrations/sveltekit-3/tests/svelte-config/svelte.config.template.js
@@ -15,7 +15,8 @@ const config = {
 	onwarn,
 	kit: {
 		experimental: {
-			remoteFunctions: true // still experimental
+			remoteFunctions: true, // still experimental
+			handleRenderingErrors: true
 		},
 		csrf: {
 			checkOrigin: false

--- a/packages/sv/src/migrate/migrations/sveltekit-3/tests/svelte-config/svelte.config.template.js
+++ b/packages/sv/src/migrate/migrations/sveltekit-3/tests/svelte-config/svelte.config.template.js
@@ -16,7 +16,13 @@ const config = {
 	kit: {
 		experimental: {
 			remoteFunctions: true, // still experimental
-			handleRenderingErrors: true
+			handleRenderingErrors: true,
+			tracing: {
+				server: true,
+			},
+			instrumentation: {
+				server: true
+			}
 		},
 		csrf: {
 			checkOrigin: false

--- a/packages/sv/src/migrate/migrations/sveltekit-3/tests/svelte-config/svelte.config.template.js
+++ b/packages/sv/src/migrate/migrations/sveltekit-3/tests/svelte-config/svelte.config.template.js
@@ -27,7 +27,9 @@ const config = {
 		csrf: {
 			checkOrigin: false
 		},
+		prerender: { origin: 'https://example.com' },
 		paths: { ...paths, base },
+		preloadStrategy: 'modulepreload',
 		// adapter is selected via the helper above
 		adapter: adapter(adapterConfig)
 	},

--- a/packages/sv/src/migrate/migrations/sveltekit-3/tests/svelte-config/vite.config.snapshot.ts
+++ b/packages/sv/src/migrate/migrations/sveltekit-3/tests/svelte-config/vite.config.snapshot.ts
@@ -21,7 +21,6 @@ export default defineConfig({
 			preprocess: vitePreprocess(),
 			compilerOptions: { experimental: { async: true } },
 			vitePlugin: { inspector: {}, onwarn },
-			tracing: { server: true },
 			experimental: { remoteFunctions: true /* still experimental */ },
 			csrf: {
 				// @migration-task trusting all origins with '*' is generally not recommended, see https://svelte.dev/docs/kit/configuration#csrf
@@ -29,7 +28,8 @@ export default defineConfig({
 			},
 			paths: { ...paths, base, origin: 'https://example.com' },
 			// adapter is selected via the helper above
-			adapter: adapter(adapterConfig)
+			adapter: adapter(adapterConfig),
+			tracing: { server: true }
 		}),
 		devtoolsJson()
 	]

--- a/packages/sv/src/migrate/migrations/sveltekit-3/tests/svelte-config/vite.config.snapshot.ts
+++ b/packages/sv/src/migrate/migrations/sveltekit-3/tests/svelte-config/vite.config.snapshot.ts
@@ -27,7 +27,7 @@ export default defineConfig({
 				// @migration-task trusting all origins with '*' is generally not recommended, see https://svelte.dev/docs/kit/configuration#csrf
 				trustedOrigins: ['*']
 			},
-			paths: { ...paths, base },
+			paths: { ...paths, base, origin: 'https://example.com' },
 			// adapter is selected via the helper above
 			adapter: adapter(adapterConfig)
 		}),

--- a/packages/sv/src/migrate/migrations/sveltekit-3/tests/svelte-config/vite.config.snapshot.ts
+++ b/packages/sv/src/migrate/migrations/sveltekit-3/tests/svelte-config/vite.config.snapshot.ts
@@ -21,6 +21,7 @@ export default defineConfig({
 			preprocess: vitePreprocess(),
 			compilerOptions: { experimental: { async: true } },
 			vitePlugin: { inspector: {}, onwarn },
+			tracing: { server: true },
 			experimental: { remoteFunctions: true /* still experimental */ },
 			csrf: {
 				// @migration-task trusting all origins with '*' is generally not recommended, see https://svelte.dev/docs/kit/configuration#csrf


### PR DESCRIPTION
Relates #1124 

### Description

See https://github.com/sveltejs/kit/pull/16265. Property needs to be removed during migration

### Checklist

- Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)
- Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable)
- Allow maintainers to edit this PR
- I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)
