### PR TITLE
fix: adjust paraglide add-on

### DIFF
--- a/.changeset/flat-pianos-create.md
+++ b/.changeset/flat-pianos-create.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix: adjust paraglide add-on

--- a/.changeset/flat-pianos-create.md
+++ b/.changeset/flat-pianos-create.md
@@ -2,4 +2,4 @@
 'sv': patch
 ---
 
-fix: adjust paraglide add-on
+fix(paraglide): adjust paraglide add-on

--- a/packages/sv/src/addons/paraglide.ts
+++ b/packages/sv/src/addons/paraglide.ts
@@ -143,8 +143,7 @@ export default defineAddon({
 				});
 
 				const hookHandleContent = `({ event, resolve }) => paraglideMiddleware(event.request, ({ request, locale }) => {
-		event.request = request;
-		return resolve(event, {
+		return resolve({ ...event, request }, {
 			transformPageChunk: ({ html }) => html.replace('%paraglide.lang%', locale).replace('%paraglide.dir%', getTextDirection(locale))
 		});
 	});`;

--- a/packages/sv/src/cli/tests/snapshots/create-with-all-addons/src/hooks.server.ts
+++ b/packages/sv/src/cli/tests/snapshots/create-with-all-addons/src/hooks.server.ts
@@ -7,9 +7,7 @@ import { getTextDirection } from '#lib/paraglide/runtime';
 import { paraglideMiddleware } from '#lib/paraglide/server';
 
 const handleParaglide: Handle = ({ event, resolve }) => paraglideMiddleware(event.request, ({ request, locale }) => {
-	event.request = request;
-
-	return resolve(event, {
+	return resolve({ ...event, request }, {
 		transformPageChunk: ({ html }) => html.replace('%paraglide.lang%', locale).replace('%paraglide.dir%', getTextDirection(locale))
 	});
 });


### PR DESCRIPTION
See https://github.com/opral/paraglide-js/issues/737 - this is necessary to adjust since the event object has readonly properties in SvelteKit 3
