### PR TITLE
fix: Install SvelteKit adapters from the `next` release channel when running `sv@next`

### DIFF
--- a/.changeset/tidy-adapters-listen.md
+++ b/.changeset/tidy-adapters-listen.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+Install SvelteKit adapters from the `next` release channel when running `sv@next`

--- a/packages/sv/src/addons/sveltekit-adapter.ts
+++ b/packages/sv/src/addons/sveltekit-adapter.ts
@@ -8,6 +8,7 @@ import {
 	pnpm,
 	svelteConfig
 } from '@sveltejs/sv-utils';
+import pkg from '../../package.json' with { type: 'json' };
 import { defineAddon, defineAddonOptions } from '../core/config.ts';
 
 const adapters = [
@@ -73,7 +74,7 @@ export default defineAddon({
 			})
 		);
 
-		sv.devDependency(adapter.package, adapter.version);
+		sv.devDependency(adapter.package, pkg.version.includes('-next.') ? 'next' : adapter.version);
 
 		svelteConfig.edit({ sv, cwd }, ({ ast, override, js }) => {
 			// finds any existing adapter's import declaration

--- a/packages/sv/src/addons/tests/sveltekit-adapter/test.ts
+++ b/packages/sv/src/addons/tests/sveltekit-adapter/test.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { expect } from 'vitest';
+import pkg from '../../../../package.json' with { type: 'json' };
 import sveltekitAdapter from '../../sveltekit-adapter.ts';
 import { setupTest } from '../_setup/suite.ts';
 
@@ -27,6 +28,16 @@ const { test, testCases } = setupTest(
 
 test.concurrent.for(testCases)('adapter $kind.type $variant', (testCase, { ...ctx }) => {
 	const cwd = ctx.cwd(testCase);
+	const packageJson = JSON.parse(readFileSync(join(cwd, 'package.json'), 'utf8'));
+	const adapterPackage = Object.keys(packageJson.devDependencies).find((dependency) =>
+		dependency.startsWith('@sveltejs/adapter-')
+	);
+	expect(adapterPackage).toBeDefined();
+	if (pkg.version.includes('-next.')) {
+		expect(packageJson.devDependencies[adapterPackage!]).toBe('next');
+	} else {
+		expect(packageJson.devDependencies[adapterPackage!]).not.toBe('next');
+	}
 
 	// config lives in vite.config.ts (ts) or vite.config.js (js)
 	const viteConfig = ['vite.config.ts', 'vite.config.js']

--- a/packages/sv/src/cli/tests/snapshots/create-experimental/package.json
+++ b/packages/sv/src/cli/tests/snapshots/create-experimental/package.json
@@ -19,7 +19,7 @@
 	},
 	"devDependencies": {
 		"@libsql/client": "^0.17.3",
-		"@sveltejs/adapter-cloudflare": "^7.2.8",
+		"@sveltejs/adapter-cloudflare": "next",
 		"@sveltejs/kit": "^3.0.0-next.0",
 		"@sveltejs/vite-plugin-svelte": "^7.2.0",
 		"auth": "^1.6.24",

--- a/packages/sv/src/cli/tests/snapshots/create-with-all-addons/package.json
+++ b/packages/sv/src/cli/tests/snapshots/create-with-all-addons/package.json
@@ -26,7 +26,7 @@
 		"@inlang/paraglide-js": "^2.18.2",
 		"@libsql/client": "^0.17.3",
 		"@playwright/test": "^1.60.0",
-		"@sveltejs/adapter-node": "^5.5.4",
+		"@sveltejs/adapter-node": "next",
 		"@sveltejs/kit": "^3.0.0-next.0",
 		"@sveltejs/vite-plugin-svelte": "^7.2.0",
 		"@tailwindcss/forms": "^0.5.11",


### PR DESCRIPTION
Closes #1256

### Description

This is what my clanker came up with. Maybe it would be better to just update the hardcoded list of versions in `sveltekit-adapter.ts` on this branch, I don't know. Thoughts?

### Checklist

- Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)
- Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable)
- Allow maintainers to edit this PR
- I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)
