### PR TITLE
fix: ignore unknown style languages when parsing Svelte code

### DIFF
--- a/.changeset/lemon-trains-travel.md
+++ b/.changeset/lemon-trains-travel.md
@@ -1,0 +1,6 @@
+---
+'@sveltejs/sv-utils': patch
+'sv': patch
+---
+
+fix: ignore unknown style languages when parsing Svelte code

--- a/packages/sv-utils/src/tests/transforms.ts
+++ b/packages/sv-utils/src/tests/transforms.ts
@@ -95,6 +95,24 @@ describe('transforms', () => {
 			expect(result).toContain('world');
 		});
 
+		it('preserves styles with a lang attribute', () => {
+			const style = '\n\t.foo { color: red; } // SCSS comment\n';
+			const input = `<style lang="scss">${style}</style>\n\n<p>hello</p>`;
+			const result = transforms.svelte(({ ast }) => {
+				const node = ast.fragment.nodes.find((node) => node.type === 'RegularElement');
+				if (node?.type === 'RegularElement') {
+					const textNode = node.fragment.nodes[0];
+					if (textNode.type === 'Text') {
+						textNode.data = 'world';
+					}
+				}
+			})(input);
+
+			expect(result).toMatch(/<style\s+lang="scss"/);
+			expect(result).toContain(style);
+			expect(result).toContain('<p>world</p>');
+		});
+
 		it('abort: returns fals if transform is cacelled', () => {
 			const input = '<p>hello</p>';
 			expect(transforms.svelte(() => false)(input)).toBe(false);

--- a/packages/sv-utils/src/tooling/parsers.ts
+++ b/packages/sv-utils/src/tooling/parsers.ts
@@ -27,6 +27,9 @@ type ParseBase = {
 	generateCode(): string;
 };
 
+const STYLE_TAG_REGEX = /(<style\b([^>]*)>)([\s\S]*?)<\/style\s*>/gi;
+const LANG_ATTRIBUTE_REGEX = /(?:^|\s)lang(?:\s|=|$)/;
+
 export function parseScript(source: string): {
 	ast: utils.AstTypes.Program;
 	comments: utils.Comments;
@@ -70,9 +73,30 @@ export function parseYaml(source: string): { data: YamlDocument } & ParseBase {
 }
 
 export function parseSvelte(source: string): { ast: utils.SvelteAst.Root } & ParseBase {
-	const ast = utils.parseSvelte(source);
+	// Handle `<style lang="...">` blocks by replacing them with a safe placeholder,
+	// so that the Svelte parser doesn't throw errors on unknown languages.
+	const styles: string[] = [];
+	const sourceWithSafeStyles = source.replace(
+		STYLE_TAG_REGEX,
+		(match, openingTag: string, attributes: string, content: string) => {
+			if (!LANG_ATTRIBUTE_REGEX.test(attributes)) return match;
 
-	const generateCode = () => utils.serializeSvelte(ast, source);
+			styles.push(content);
+			return `${openingTag}/* */</style>`;
+		}
+	);
+	const ast = utils.parseSvelte(sourceWithSafeStyles);
+
+	const generateCode = () => {
+		let code = utils.serializeSvelte(ast, source);
+		let styleIndex = 0;
+		code = code.replace(STYLE_TAG_REGEX, (match, openingTag: string, attributes: string) => {
+			if (!LANG_ATTRIBUTE_REGEX.test(attributes) || styleIndex === styles.length) return match;
+			return `${openingTag}${styles[styleIndex++]}</style>`;
+		});
+
+		return code;
+	};
 
 	return {
 		ast,


### PR DESCRIPTION
Fixes #1263
