### PR TITLE
fix: transform `$lib` to relative path in style tags

### DIFF
--- a/.changeset/seven-facts-remain.md
+++ b/.changeset/seven-facts-remain.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix: transform `$lib` to relative path in style tags

--- a/packages/sv/src/migrate/migrations/sveltekit-3/tasks/lib-alias.ts
+++ b/packages/sv/src/migrate/migrations/sveltekit-3/tasks/lib-alias.ts
@@ -27,7 +27,10 @@ export default defineMigrationTask({
 				where: (content) => content.includes('$lib')
 			},
 			(content, file) => {
-				let styleLibPath = path.posix.relative(path.posix.dirname(file), directory.lib);
+				let styleLibPath = path.posix.relative(
+					path.posix.dirname(file.replaceAll('\\', '/')),
+					directory.lib.replaceAll('\\', '/')
+				);
 				if (!styleLibPath.startsWith('.')) styleLibPath = `./${styleLibPath}`;
 
 				const rewritten = content

--- a/packages/sv/src/migrate/migrations/sveltekit-3/tasks/lib-alias.ts
+++ b/packages/sv/src/migrate/migrations/sveltekit-3/tasks/lib-alias.ts
@@ -1,8 +1,10 @@
 import { transforms } from '@sveltejs/sv-utils';
 import fs from 'node:fs';
+import path from 'node:path';
 import { defineMigrationTask } from '../../../index.ts';
 
 const LIB_ALIAS = /(?<=['"`])\$lib(\/(.+)['"`]|['"`])/g;
+const STYLE_TAG = /(<style\b[^>]*>)([\s\S]*?)(<\/style\s*>)/gi;
 
 function libSubpathImports(libDir: string): Record<string, string> {
 	return { '#lib': `./${libDir}/index.js`, '#lib/*': `./${libDir}/*` };
@@ -24,20 +26,29 @@ export default defineMigrationTask({
 				include: `${directory.src}/**/*.{svelte,svelte.ts,svelte.js,ts,js,svx,md}`,
 				where: (content) => content.includes('$lib')
 			},
-			(content) => {
-				const rewritten = content.replace(LIB_ALIAS, (match, _, import_path) => {
-					match = match.replace('$lib', '#lib');
-					// Add explicit file extensions
-					if (import_path && !import_path.endsWith('.js') && !import_path.endsWith('.ts')) {
-						for (const ending of ['.js', '.ts', '/index.js', '/index.ts']) {
-							if (fs.existsSync(`${cwd}/${directory.lib}/${import_path}${ending}`)) {
-								// By default TS wants .js file endings even if it's actually a .ts file
-								return match.slice(0, -1) + ending.replace('.ts', '.js') + match.slice(-1);
+			(content, file) => {
+				let styleLibPath = path.posix.relative(path.posix.dirname(file), directory.lib);
+				if (!styleLibPath.startsWith('.')) styleLibPath = `./${styleLibPath}`;
+
+				const rewritten = content
+					.replace(
+						STYLE_TAG,
+						(_, open, css: string, close) =>
+							`${open}${css.replace(LIB_ALIAS, (match) => match.replace('$lib', styleLibPath))}${close}`
+					)
+					.replace(LIB_ALIAS, (match, _, import_path) => {
+						match = match.replace('$lib', '#lib');
+						// Add explicit file extensions
+						if (import_path && !import_path.endsWith('.js') && !import_path.endsWith('.ts')) {
+							for (const ending of ['.js', '.ts', '/index.js', '/index.ts']) {
+								if (fs.existsSync(`${cwd}/${directory.lib}/${import_path}${ending}`)) {
+									// By default TS wants .js file endings even if it's actually a .ts file
+									return match.slice(0, -1) + ending.replace('.ts', '.js') + match.slice(-1);
+								}
 							}
 						}
-					}
-					return match;
-				});
+						return match;
+					});
 				return rewritten === content ? false : rewritten;
 			}
 		);

--- a/packages/sv/src/migrate/migrations/sveltekit-3/tests/lib-alias/src/routes/+page.snapshot.svelte
+++ b/packages/sv/src/migrate/migrations/sveltekit-3/tests/lib-alias/src/routes/+page.snapshot.svelte
@@ -8,3 +8,9 @@
 </script>
 
 <svelte:component this={component} />
+
+<style>
+	div {
+		background-image: url("../lib/example.jpg");
+	}
+</style>

--- a/packages/sv/src/migrate/migrations/sveltekit-3/tests/lib-alias/src/routes/+page.svelte
+++ b/packages/sv/src/migrate/migrations/sveltekit-3/tests/lib-alias/src/routes/+page.svelte
@@ -8,3 +8,9 @@
 </script>
 
 <svelte:component this={component} />
+
+<style>
+	div {
+		background-image: url("$lib/example.jpg");
+	}
+</style>


### PR DESCRIPTION
Fixes #1267

Sadly Vite doesn't handle this, I assume because the hash has meaning in URLs.
