### PR TITLE
fix(drizzle): bump better-sqlite3 types to v9

### DIFF
--- a/.changeset/bright-dragons-smile.md
+++ b/.changeset/bright-dragons-smile.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix(drizzle): bump `@types/better-sqlite3` to v9

--- a/packages/sv/src/addons/drizzle.ts
+++ b/packages/sv/src/addons/drizzle.ts
@@ -124,7 +124,7 @@ export default defineAddon({
 		if (options.sqlite === 'better-sqlite3') {
 			// not a devDependency due to bundling issues
 			sv.dependency('better-sqlite3', '^13.0.2');
-			sv.devDependency('@types/better-sqlite3', '^7.6.13');
+			sv.devDependency('@types/better-sqlite3', '^9.6.0');
 		}
 
 		if (options.sqlite === 'libsql' || options.sqlite === 'turso')


### PR DESCRIPTION
Closes #1253

## What changed

- bump the generated `@types/better-sqlite3` dependency from v7 to v9 for the Drizzle `better-sqlite3` setup
- add a patch changeset for `sv`

DefinitelyTyped now publishes the existing declarations under the v9 package line. There are no declaration API changes, but generated projects were still pinned to the older v7 line.

## Validation

- `pnpm --filter sv check`
- Prettier check for the changed files
- confirmed generated Drizzle projects resolve `@types/better-sqlite3@9.6.0`

The full Drizzle integration suite reached dependency installation, but pnpm stopped because the existing `better-sqlite3` native build script is not approved in the generated test workspace.
