### PR TITLE
fix(migrate): allow `@sveltejs/kit` to be a dependency

### DIFF
--- a/.changeset/fair-games-tickle.md
+++ b/.changeset/fair-games-tickle.md
@@ -1,0 +1,5 @@
+---
+"sv": patch
+---
+
+fix(migrate): allow `@sveltejs/kit` to be a dependency when migrating

--- a/packages/sv/src/migrate/migrations/app-state/index.ts
+++ b/packages/sv/src/migrate/migrations/app-state/index.ts
@@ -8,9 +8,9 @@ export default defineMigration({
 	setup: ({ pkg }) => {
 		const kitPackageName = '@sveltejs/kit';
 
-		if (!pkg.devDependencies?.[kitPackageName])
+		if (!pkg.devDependencies?.[kitPackageName] && !pkg.dependencies?.[kitPackageName])
 			throw new Error(
-				`${color.command(kitPackageName)} is not a devDependency in package.json - this doesn't look like a SvelteKit project.\n` +
+				`${color.command(kitPackageName)} is not in package.json - this doesn't look like a SvelteKit project.\n` +
 					`Point to one with ${color.command('--cwd <path>')}, or see ${color.command('sv migrate --help')}.`
 			);
 	},

--- a/packages/sv/src/migrate/migrations/sveltekit-3/index.ts
+++ b/packages/sv/src/migrate/migrations/sveltekit-3/index.ts
@@ -20,13 +20,14 @@ export default defineMigration({
 	setup: ({ pkg, requires }) => {
 		const kitPackageName = '@sveltejs/kit';
 
-		if (!pkg.devDependencies?.[kitPackageName])
+		const kitDep = pkg.devDependencies?.[kitPackageName] ?? pkg.dependencies?.[kitPackageName];
+		if (!kitDep)
 			throw new Error(
-				`${color.command(kitPackageName)} is not a devDependency in package.json - this doesn't look like a SvelteKit project.\n` +
+				`${color.command(kitPackageName)} is not in package.json - this doesn't look like a SvelteKit project.\n` +
 					`Point to one with ${color.command('--cwd <path>')}, or see ${color.command('sv migrate --help')}.`
 			);
 
-		const kitVersion = coerceVersion(pkg.devDependencies[kitPackageName]);
+		const kitVersion = coerceVersion(kitDep);
 		if (kitVersion.major && kitVersion.major < 2) {
 			requires('sveltekit-2');
 		}


### PR DESCRIPTION
Closes #1270

### Description

A migration is not the right place to police this.

<!-- Please describe what your PR does -->

### Checklist

- Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)
- Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable)
- Allow maintainers to edit this PR
- I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)
