### PR TITLE
feat(create): make the npm org optional for the `addon` template

### DIFF
--- a/.changeset/olive-hounds-repeat.md
+++ b/.changeset/olive-hounds-repeat.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+feat(create): make the npm org optional for the `addon` template

--- a/documentation/docs/30-add-ons/99-community.md
+++ b/documentation/docs/30-add-ons/99-community.md
@@ -177,18 +177,15 @@ Your add-on must have `sv` as a peer dependency and **no** `dependencies` in `pa
 
 ### Package names
 
-Packages must be published under an npm org:
+Any npm package name works:
 
 ```sh
-# ✓ GOOD
 npx sv add @my-org/sv
 npx sv add @my-org/core
-
-# ✗ BAD
 npx sv add my-lib
 ```
 
-If your package is published with the `sv` scope, it can be omitted. The following all resolves to the same package:
+Publishing under an org is recommended, because naming the package `sv` within it lets users install it by typing the org alone. If your package is published with the `sv` scope, it can be omitted. The following all resolves to the same package:
 
 ```sh
 npx sv add @my-org

--- a/packages/sv/src/cli/create.ts
+++ b/packages/sv/src/cli/create.ts
@@ -273,13 +273,13 @@ export async function createProject(cwd: ProjectPath, options: Options) {
 	let projectName = parentDirName.startsWith('@') ? `${parentDirName}/${basename}` : basename;
 
 	if (template === 'addon' && !projectName.startsWith('@')) {
-		// At this stage, we don't support un-scoped add-ons
-		// FYI: a demo exists for `npx sv add my-cool-addon`
+		// publishing as `@my-org/sv` is what lets users install with just `sv add @my-org`
 		const org = await p.text({
-			message: `Community add-ons must be published under an npm org. Enter the name of your npm org:`,
+			message: `npm org for your add-on? Leave empty to publish as ${color.command(basename)}:`,
 			placeholder: '  @my-org',
+			defaultValue: '',
 			validate: (value) => {
-				if (!value) return 'Organization name is required';
+				if (!value) return;
 				if (!value.startsWith('@')) return 'Must start with @';
 				if (value.includes('/')) return 'Just the org, not the full package name';
 			}
@@ -288,7 +288,7 @@ export async function createProject(cwd: ProjectPath, options: Options) {
 			p.cancel('Operation cancelled.');
 			process.exit(0);
 		}
-		projectName = `${org}/${basename}`;
+		if (org) projectName = `${org}/${basename}`;
 	}
 
 	if (template === 'addon' && options.add.length > 0) {


### PR DESCRIPTION
Closes #1101.

The org prompt in `sv create --template addon` now accepts an empty answer and scaffolds an unscoped package. Publishing under an org stays the recommendation, since naming the package `sv` within it is what enables the `sv add @my-org` shorthand.

Also corrects the `### Package names` docs. They marked `npx sv add my-lib` as invalid, but `sv add` has parsed unscoped specifiers since the feature shipped and has never had a scope check. Two add-ons published today under the `sv-add` keyword are unscoped (`sveltekit-temporal`, `svforge`) and install fine.

For context on how the docs drifted: the requirement was only ever enforced in `create` (added in 618f1ad, relaxed to a prompt by #1031), while the docs stated it globally. A later docs refactor (#1161) then turned the hedged "unscoped packages are not supported yet" note into a hard `✗ BAD npx sv add my-lib` example, pointing at the one command that never enforced it.

Note that the prompt still blocks in non-interactive runs; that is pre-existing and left alone here.