### PR TITLE
fix(create): add generated config includes

### DIFF
--- a/.changeset/quiet-tools-include.md
+++ b/.changeset/quiet-tools-include.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix(create): include project source and Vite config files in generated TypeScript and JavaScript configs

--- a/packages/sv/src/cli/tests/snapshots/create-experimental/tsconfig.json
+++ b/packages/sv/src/cli/tests/snapshots/create-experimental/tsconfig.json
@@ -8,6 +8,7 @@
 	},
 	"include": [
 		"src",
+		"vite.config.ts",
 		"drizzle.config.ts"
 	]
 }

--- a/packages/sv/src/cli/tests/snapshots/create-only/tsconfig.json
+++ b/packages/sv/src/cli/tests/snapshots/create-only/tsconfig.json
@@ -2,7 +2,6 @@
 	"extends": "$app/tsconfig",
 	"compilerOptions": {
 		"strict": true
-	}
-	// To make changes to top-level options such as include and exclude, we recommend extending
-	// the generated config; see https://svelte.dev/docs/kit/configuration#typescript
+	},
+	"include": ["src", "vite.config.ts"]
 }

--- a/packages/sv/src/cli/tests/snapshots/create-with-all-addons/tsconfig.json
+++ b/packages/sv/src/cli/tests/snapshots/create-with-all-addons/tsconfig.json
@@ -5,6 +5,7 @@
 	},
 	"include": [
 		"src",
+		"vite.config.ts",
 		"drizzle.config.ts"
 	]
 }

--- a/packages/sv/src/create/shared/+checkjs/jsconfig.json
+++ b/packages/sv/src/create/shared/+checkjs/jsconfig.json
@@ -2,7 +2,6 @@
 	"extends": "$app/tsconfig",
 	"compilerOptions": {
 		"strict": true
-	}
-	// If you want to overwrite includes/excludes, make sure to copy over the relevant includes/excludes
-	// from the referenced tsconfig.json - TypeScript does not merge them in
+	},
+	"include": ["src", "vite.config.ts"]
 }

--- a/packages/sv/src/create/shared/+library+typescript/tsconfig.json
+++ b/packages/sv/src/create/shared/+library+typescript/tsconfig.json
@@ -2,5 +2,6 @@
 	"extends": "$app/tsconfig",
 	"compilerOptions": {
 		"strict": true
-	}
+	},
+	"include": ["src", "vite.config.ts"]
 }

--- a/packages/sv/src/create/shared/+library-typescript-checkjs/jsconfig.json
+++ b/packages/sv/src/create/shared/+library-typescript-checkjs/jsconfig.json
@@ -2,5 +2,6 @@
 	"extends": "$app/tsconfig",
 	"compilerOptions": {
 		"strict": true
-	}
+	},
+	"include": ["src", "vite.config.ts"]
 }

--- a/packages/sv/src/create/shared/+none/jsconfig.json
+++ b/packages/sv/src/create/shared/+none/jsconfig.json
@@ -2,7 +2,6 @@
 	"extends": "$app/tsconfig",
 	"compilerOptions": {
 		"strict": true
-	}
-	// If you want to overwrite includes/excludes, make sure to copy over the relevant includes/excludes
-	// from the referenced tsconfig.json - TypeScript does not merge them in
+	},
+	"include": ["src", "vite.config.ts"]
 }

--- a/packages/sv/src/create/shared/+typescript/tsconfig.json
+++ b/packages/sv/src/create/shared/+typescript/tsconfig.json
@@ -2,7 +2,6 @@
 	"extends": "$app/tsconfig",
 	"compilerOptions": {
 		"strict": true
-	}
-	// To make changes to top-level options such as include and exclude, we recommend extending
-	// the generated config; see https://svelte.dev/docs/kit/configuration#typescript
+	},
+	"include": ["src", "vite.config.ts"]
 }


### PR DESCRIPTION
Closes #1282

### Description

SvelteKit's generated `$app/tsconfig` no longer supplies top-level include entries, which can cause newly created projects to check unrelated files such as `node_modules`.

This adds explicit `src` and `vite.config.ts` includes to generated TypeScript and JavaScript project configs, removes obsolete inheritance guidance, and preserves additional files appended by add-ons such as `drizzle.config.ts`.

### Checklist

- Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)
- Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable)
- Allow maintainers to edit this PR
- I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)