### PR TITLE
fix(create): use next adapter-auto version in templates

### DIFF
--- a/.changeset/silly-moons-create.md
+++ b/.changeset/silly-moons-create.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+fix(create): use SvelteKit 3 adapter versions in templates so new projects without an explicit adapter don't install the old `@sveltejs/adapter-auto`

--- a/packages/sv/src/cli/tests/snapshots/create-only/package.json
+++ b/packages/sv/src/cli/tests/snapshots/create-only/package.json
@@ -12,7 +12,7 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
 	},
 	"devDependencies": {
-		"@sveltejs/adapter-auto": "^7.0.1",
+		"@sveltejs/adapter-auto": "^8.0.0-next.3",
 		"@sveltejs/kit": "^3.0.0-next.0",
 		"@sveltejs/vite-plugin-svelte": "^7.2.0",
 		"svelte": "^5.56.7",

--- a/packages/sv/src/create/templates/demo/package.template.json
+++ b/packages/sv/src/create/templates/demo/package.template.json
@@ -12,7 +12,7 @@
 	"devDependencies": {
 		"@fontsource/fira-mono": "^5.2.7",
 		"@neoconfetti/svelte": "^2.2.2",
-		"@sveltejs/adapter-auto": "^7.0.1",
+		"@sveltejs/adapter-auto": "^8.0.0-next.3",
 		"@sveltejs/kit": "^3.0.0-next.0",
 		"@sveltejs/vite-plugin-svelte": "^7.2.0",
 		"svelte": "^5.56.7",

--- a/packages/sv/src/create/templates/library/package.template.json
+++ b/packages/sv/src/create/templates/library/package.template.json
@@ -23,7 +23,7 @@
 		"svelte": "^5.0.0"
 	},
 	"devDependencies": {
-		"@sveltejs/adapter-auto": "^7.0.1",
+		"@sveltejs/adapter-auto": "^8.0.0-next.3",
 		"@sveltejs/kit": "^3.0.0-next.0",
 		"@sveltejs/package": "^2.5.8",
 		"@sveltejs/vite-plugin-svelte": "^7.2.0",

--- a/packages/sv/src/create/templates/minimal/package.template.json
+++ b/packages/sv/src/create/templates/minimal/package.template.json
@@ -10,7 +10,7 @@
 		"prepare": "svelte-kit sync || echo ''"
 	},
 	"devDependencies": {
-		"@sveltejs/adapter-auto": "^7.0.1",
+		"@sveltejs/adapter-auto": "^8.0.0-next.3",
 		"@sveltejs/kit": "^3.0.0-next.0",
 		"@sveltejs/vite-plugin-svelte": "^7.2.0",
 		"svelte": "^5.56.7",


### PR DESCRIPTION
## Description

Fixes #1256

When running `sv@next create` **without** selecting an adapter, the generated project installed `@sveltejs/adapter-auto@^7.0.1` (the SvelteKit 2 version) alongside `@sveltejs/kit@^3.0.0-next.0`. PR #1258 fixed the versions used by the `sveltekit-adapter` add-on (when an adapter is explicitly selected), but the create templates themselves still pinned the old adapter.

This bumps `@sveltejs/adapter-auto` to `^8.0.0-next.3` (matching the add-on's version) in the `minimal`, `demo`, and `library` templates, and updates the `create-only` snapshot accordingly.

## Changes

- `packages/sv/src/create/templates/minimal/package.template.json`
- `packages/sv/src/create/templates/demo/package.template.json`
- `packages/sv/src/create/templates/library/package.template.json`
- `packages/sv/src/cli/tests/snapshots/create-only/package.json`
- changeset

## Validation

- `pnpm build` produces templates with `^8.0.0-next.3`
- `vitest run --project cli tests/cli.ts -t "create-only"` passes (generated project contains `@sveltejs/adapter-auto@^8.0.0-next.3`)
- `vitest run --project cli` / `--project create` / `--project addons tests/sveltekit-adapter/test.ts` pass (remaining addon-suite failures are pre-existing, caused by missing Playwright browsers in this environment)