### PR TITLE
fix: use Changesets v2 PR number output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,9 +45,9 @@ jobs:
           NPM_CONFIG_PROVENANCE: true
 
       - name: Require addon integration tests on Changesets PR
-        if: steps.changesets.outputs.pullRequestNumber != ''
+        if: steps.changesets.outputs['pr-number'] != ''
         run: >-
-          gh pr edit "${{ steps.changesets.outputs.pullRequestNumber }}"
+          gh pr edit "${{ steps.changesets.outputs['pr-number'] }}"
           --add-label needs-addon-integration-tests
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Fix the release workflow to read the Changesets Action v2 `pr-number` output when labeling the generated release PR.

Changesets Action v2 renamed the previous `pullRequestNumber` output. Because the workflow still referenced the old name, the value was empty and the label step was skipped.

## Changes

- update the step condition to use `steps.changesets.outputs['pr-number']`
- pass the same output to `gh pr edit`

## Scope

This PR only corrects the Changesets output reference. It does not change token selection or workflow-trigger behavior.

Seee https://github.com/sveltejs/cli/pull/1223/changes for original implementation and https://github.com/sveltejs/cli/pull/1287 for unlabeled release pr