### PR TITLE
fix(sv-utils): bump esrap to 2.3.6 to fix type dropping during migrations

### DIFF
--- a/.changeset/wide-meals-bake.md
+++ b/.changeset/wide-meals-bake.md
@@ -2,5 +2,5 @@
 "@sveltejs/sv-utils": patch
 ---
 
-bump esrap to 2.3.6 to preserve generic type arguments and annotations during sveltekit-3 migrations
+fix: bump esrap to 2.3.6 to preserve generic type arguments and annotations during sveltekit-3 migrations
   

--- a/.changeset/wide-meals-bake.md
+++ b/.changeset/wide-meals-bake.md
@@ -1,0 +1,6 @@
+---
+"@sveltejs/sv-utils": patch
+---
+
+bump esrap to 2.3.6 to preserve generic type arguments and annotations during sveltekit-3 migrations
+  

--- a/packages/sv-utils/package.json
+++ b/packages/sv-utils/package.json
@@ -32,7 +32,7 @@
 		"decircular": "^1.0.0",
 		"dedent": "^1.7.2",
 		"diff": "^9.0.0",
-		"esrap": "^2.3.3",
+		"esrap": "^2.3.6",
 		"package-manager-detector": "^1.8.0",
 		"silver-fleece": "^1.2.1",
 		"smol-toml": "^1.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,8 +123,8 @@ importers:
         specifier: ^9.0.0
         version: 9.0.0
       esrap:
-        specifier: ^2.3.3
-        version: 2.3.3(@typescript-eslint/types@8.67.0)
+        specifier: ^2.3.6
+        version: 2.3.6(@typescript-eslint/types@8.67.0)
       package-manager-detector:
         specifier: ^1.8.0
         version: 1.8.0
@@ -1243,6 +1243,14 @@ packages:
 
   esrap@2.3.3:
     resolution: {integrity: sha512-OETBYYsX6L8btUkOyi8AcdtlfpsyNO9nCmP92U/Cxm07epHeLo5we1ck6z0HsbB/jxWlfmEBF9oobZKqSBWD4Q==}
+    peerDependencies:
+      '@typescript-eslint/types': ^8.2.0
+    peerDependenciesMeta:
+      '@typescript-eslint/types':
+        optional: true
+
+  esrap@2.3.6:
+    resolution: {integrity: sha512-yc0OC12UjPqLoc+fe+v5GNs4TOjAigUw3sTikfC+xeBPGUw7gDRz3DtYaqEhxyMVJojcSWJw7jT0QWR+CbuE/A==}
     peerDependencies:
       '@typescript-eslint/types': ^8.2.0
     peerDependenciesMeta:
@@ -3012,6 +3020,12 @@ snapshots:
       estraverse: 5.3.0
 
   esrap@2.3.3(@typescript-eslint/types@8.67.0):
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+    optionalDependencies:
+      '@typescript-eslint/types': 8.67.0
+
+  esrap@2.3.6(@typescript-eslint/types@8.67.0):
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
     optionalDependencies:


### PR DESCRIPTION
### Description

Bumps `esrap` to `^2.3.6`, which fixed certain type annotations and arguments from being dropped: https://github.com/sveltejs/esrap/pull/179

#### Example
**Original source code:**
```ts
const results = await db.select({
  name: clients.firstName,
  score: sql<number>`phc.similarity(${clients.firstName}, ${searchTermPhrase}::text)`
});
```

**Previous vs new output**
```diff
  const results = await db.select({
    name: clients.firstName,
-   score: sql`phc.similarity(${clients.firstName}, ${searchTermPhrase}::text)`
+   score: sql<number>`phc.similarity(${clients.firstName}, ${searchTermPhrase}::text)`
  });
```

### Checklist

- Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)
- Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable)
- Allow maintainers to edit this PR
- I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)
