### PR TITLE
fix(ci): restore template repo update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,6 @@ jobs:
 
       - name: Update Template Repo
         if: steps.changesets.outputs.published == 'true'
-        run: pnpm -F @sveltejs/create update-template-repo
+        run: pnpm -F sv update-template-repo
         env:
           UPDATE_TEMPLATE_SSH_KEY: ${{ secrets.UPDATE_TEMPLATE_SSH_KEY }}

--- a/.github/workflows/update-template-repo.yml
+++ b/.github/workflows/update-template-repo.yml
@@ -27,6 +27,6 @@ jobs:
         run: pnpm build
 
       - name: Run template update script
-        run: pnpm -F @sveltejs/create update-template-repo
+        run: pnpm -F sv update-template-repo
         env:
           UPDATE_TEMPLATE_SSH_KEY: ${{ secrets.UPDATE_TEMPLATE_SSH_KEY }}

--- a/packages/sv/package.json
+++ b/packages/sv/package.json
@@ -13,7 +13,8 @@
 	"scripts": {
 		"check": "tsgo",
 		"format": "pnpm lint --write",
-		"lint": "prettier --check . --config ../../prettier.config.js --ignore-path ../../.gitignore --ignore-path .gitignore --ignore-path ../../.prettierignore"
+		"lint": "prettier --check . --config ../../prettier.config.js --ignore-path ../../.gitignore --ignore-path .gitignore --ignore-path ../../.prettierignore",
+		"update-template-repo": "./src/create/scripts/update-template-repo.sh"
 	},
 	"files": [
 		"dist"

--- a/packages/sv/src/create/scripts/update-template-repo-contents.js
+++ b/packages/sv/src/create/scripts/update-template-repo-contents.js
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { create } from '../index.ts';
+import { create } from 'sv';
 
 const repo = /** @type {string} */ (process.argv[2]);
 
@@ -13,7 +13,8 @@ fs.readdirSync(repo).forEach((file) => {
 	}
 });
 
-create(repo, {
+create({
+	cwd: repo,
 	name: 'kit-template-default',
 	template: 'demo',
 	types: 'checkjs'

--- a/packages/sv/src/create/scripts/update-template-repo.sh
+++ b/packages/sv/src/create/scripts/update-template-repo.sh
@@ -15,7 +15,7 @@ get_sv_version() {
 
 VERSION=$(get_sv_version)
 DIR=$(get_abs_filename $(dirname "$0"))
-TMP=$(get_abs_filename "$DIR/../node_modules/.tmp")
+TMP=$(get_abs_filename "$DIR/../../../node_modules/.tmp")
 
 mkdir -p $TMP
 cd $TMP


### PR DESCRIPTION
Closes #

### Description

Since #838 the `@sveltejs/create` package no longer exists, so `pnpm -F @sveltejs/create update-template-repo` silently matched nothing (exit 0) and [kit-template-default](https://github.com/sveltejs/kit-template-default) stopped being updated on release.

- workflows now run `pnpm -F sv update-template-repo`, and `sv` gets that script back
- `update-template-repo-contents.js`: import `create` from `sv` (built output, the `../index.ts` import wasn't runnable) and use the current object signature
- fix the tmp dir path after the folder move

### Checklist

- Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)
- Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable)
- Allow maintainers to edit this PR
- I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)