### PR TITLE
Community add-on API is now official

### DIFF
--- a/.changeset/sixty-lions-smoke.md
+++ b/.changeset/sixty-lions-smoke.md
@@ -1,0 +1,5 @@
+---
+'sv': minor
+---
+
+cli: community add-on API is now official (no longer experimental), and the `addon` template is selectable in `sv create`. Go and build with it!

--- a/documentation/docs/20-commands/10-sv-create.md
+++ b/documentation/docs/20-commands/10-sv-create.md
@@ -29,8 +29,7 @@ Which project template to use:
 - `minimal` — barebones scaffolding for your new app
 - `demo` — showcase app with a word guessing game that works without JavaScript
 - `library` — template for a Svelte library, set up with `svelte-package`
-  <!-- TODO: JYC: Uncomment this when the addon template is ready -->
-  <!-- - `addon` — template for a community add-on, ready to be tested & published -->
+- `addon` — template for a community add-on, ready to be tested & published
 
 ### `--types <option>`
 

--- a/documentation/docs/20-commands/20-sv-add.md
+++ b/documentation/docs/20-commands/20-sv-add.md
@@ -65,9 +65,6 @@ Do not prompt to install dependencies.
 ## Community add-ons
 
 > [!NOTE]
-> Community add-ons are currently **experimental**. The API may change. Don't use them in production yet!
-
-> [!NOTE]
 > Svelte maintainers have not reviewed community add-ons for malicious code!
 
 Community add-ons are npm packages published by the community. Look out for add-ons from your favourite libraries and tools. _(soon)_ Many developers are building `sv` add-ons to make their integrations a one-liner. You can find them on [npmx](https://www.npmx.dev/search?q=keyword:sv-add) by searching for the keyword: `sv-add`.

--- a/documentation/docs/30-add-ons/99-community.md
+++ b/documentation/docs/30-add-ons/99-community.md
@@ -2,9 +2,6 @@
 title: [create your own]
 ---
 
-> [!NOTE]
-> Community add-ons are currently **experimental**. The API may change. Don't use them in production yet!
-
 This guide covers how to create, test, and publish community add-ons for the Svelte CLI.
 
 ## Quick start

--- a/documentation/docs/50-api/20-sv-utils.md
+++ b/documentation/docs/50-api/20-sv-utils.md
@@ -2,9 +2,6 @@
 title: sv-utils
 ---
 
-> [!NOTE]
-> `@sveltejs/sv-utils` is currently **experimental**. The API may change.
-
 `@sveltejs/sv-utils` is an add-on utility for parsing, transforming, and generating code..
 
 ```sh

--- a/packages/sv/src/cli/create.ts
+++ b/packages/sv/src/cli/create.ts
@@ -221,12 +221,9 @@ export async function createProject(cwd: ProjectPath, options: Options) {
 				// always use the minimal template for playground projects
 				if (options.fromPlayground) return Promise.resolve<TemplateType>('minimal');
 
-				// TODO JYC:
-				// Don't allow the addon template right now to be displayed in the select list
-				const availableTemplates = templates.filter((t) => t.name !== 'addon');
-				// Later, we will not allow the addon template to be added via the CLI when "--add" is used
-				// const availableTemplates =
-				// 	options.add.length > 0 ? templates.filter((t) => t.name !== 'addon') : templates;
+				// the addon template is incompatible with "--add"
+				const availableTemplates =
+					options.add.length > 0 ? templates.filter((t) => t.name !== 'addon') : templates;
 
 				return p.select<TemplateType>({
 					message: 'Which template would you like?',


### PR DESCRIPTION
### Description

community add-on API is now official (no longer experimental), and the `addon` template is selectable in `sv create`. 
Go and build with it!

### Checklist

- Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)
- Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable)
- Allow maintainers to edit this PR
- I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)
