### PR TITLE
chore(sv): replace `tiny-glob` with `fs.readdirSync`

### DIFF
--- a/.changeset/shaggy-dragons-thank.md
+++ b/.changeset/shaggy-dragons-thank.md
@@ -1,0 +1,5 @@
+---
+"sv": patch
+---
+
+chore(sv): replace `tiny-glob` with `fs.readdirSync`

--- a/packages/sv/package.json
+++ b/packages/sv/package.json
@@ -52,7 +52,6 @@
 		"ps-tree": "^1.2.0",
 		"sucrase": "^3.35.1",
 		"svelte": "^5.56.9",
-		"tiny-glob": "^0.2.9",
 		"tinyexec": "^1.2.4",
 		"valibot": "^1.4.1"
 	}

--- a/packages/sv/src/create/scripts/build-templates.js
+++ b/packages/sv/src/create/scripts/build-templates.js
@@ -5,7 +5,6 @@ import path from 'node:path';
 import parser from 'gitignore-parser';
 import { format } from 'oxfmt';
 import { transform } from 'sucrase';
-import glob from 'tiny-glob/sync.js';
 import oxfmtConfig from '../../../../../oxfmt.config.ts';
 
 /** @import { File, LanguageType } from '../index.ts' */
@@ -85,7 +84,11 @@ async function generate_templates(dist, shared) {
 			none: []
 		};
 
-		const files = glob('**/*', { cwd, filesOnly: true, dot: true });
+		const files = fs
+			.readdirSync(cwd, { recursive: true, withFileTypes: true })
+			.filter((entry) => entry.isFile())
+			.map(({ parentPath, name }) => path.join(path.relative(cwd, parentPath), name))
+			.sort();
 		for (const name of files) {
 			// the package.template.json thing is a bit annoying — basically we want
 			// to be able to develop and deploy the app from here, but have a different
@@ -249,7 +252,11 @@ async function generate_shared(dist) {
 	/** @type {Array<{ name: string, include: string[], exclude: string[], contents: string }>} */
 	const files = [];
 
-	const globbed = glob('**/*', { cwd, filesOnly: true, dot: true });
+	const globbed = fs
+		.readdirSync(cwd, { recursive: true, withFileTypes: true })
+		.filter((entry) => entry.isFile())
+		.map(({ parentPath, name }) => path.join(path.relative(cwd, parentPath), name))
+		.sort();
 	for (const file of globbed) {
 		const contents = fs.readFileSync(path.join(cwd, file), 'utf8');
 
@@ -357,7 +364,11 @@ function generate_vite_template(dist) {
 
 	for (const { src, lang } of variants) {
 		const srcDir = path.join(createVitePath, src);
-		const files = glob('**/*', { cwd: srcDir, filesOnly: true, dot: true });
+		const files = fs
+			.readdirSync(srcDir, { recursive: true, withFileTypes: true })
+			.filter((entry) => entry.isFile())
+			.map(({ parentPath, name }) => path.join(path.relative(srcDir, parentPath), name))
+			.sort();
 
 		for (const name of files) {
 			const srcPath = path.join(srcDir, name);

--- a/packages/sv/src/migrate/migrations/tests.spec.ts
+++ b/packages/sv/src/migrate/migrations/tests.spec.ts
@@ -25,9 +25,7 @@ for (const migrationDirectory of migrationDirectories) {
 				const cwd = path.join(baseDir, migrationDirectory, testsDirectoryName, testName);
 
 				// cleanup old test run by deleting old actual files
-				const oldActualFiles = fs.globSync('**/*.actual.*', {
-					cwd
-				});
+				const oldActualFiles = fs.globSync('**/*.actual.*', { cwd });
 				for (const oldActualFile of oldActualFiles) {
 					fs.rmSync(path.join(cwd, oldActualFile));
 				}
@@ -67,9 +65,7 @@ for (const migrationDirectory of migrationDirectories) {
 					throw new Error('No files were modified by the migration.');
 				}
 
-				const remainingSnapshotFiles = fs.globSync('**/*.snapshot.*', {
-					cwd
-				});
+				const remainingSnapshotFiles = fs.globSync('**/*.snapshot.*', { cwd });
 
 				// compare modified files against snapshots
 				for (const file of modifiedFiles) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,9 +98,6 @@ importers:
       svelte:
         specifier: ^5.56.9
         version: 5.56.9(@typescript-eslint/types@8.67.0)
-      tiny-glob:
-        specifier: ^0.2.9
-        version: 0.2.9
       tinyexec:
         specifier: ^1.2.4
         version: 1.3.0
@@ -1364,9 +1361,6 @@ packages:
     resolution: {integrity: sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==}
     engines: {node: '>=18'}
 
-  globalyzer@0.1.0:
-    resolution: {integrity: sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==}
-
   globrex@0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
 
@@ -1803,9 +1797,6 @@ packages:
 
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
-
-  tiny-glob@0.2.9:
-    resolution: {integrity: sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -3121,8 +3112,6 @@ snapshots:
 
   globals@17.6.0: {}
 
-  globalyzer@0.1.0: {}
-
   globrex@0.1.2: {}
 
   graceful-fs@4.2.11: {}
@@ -3552,11 +3541,6 @@ snapshots:
       any-promise: 1.3.0
 
   through@2.3.8: {}
-
-  tiny-glob@0.2.9:
-    dependencies:
-      globalyzer: 0.1.0
-      globrex: 0.1.2
 
   tinybench@2.9.0: {}
 


### PR DESCRIPTION
Closes #

### Description

Removes a `devDependency`.

### Checklist

- Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)
- Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable)
- Allow maintainers to edit this PR
- I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved template discovery during builds, including nested template files.
  * Maintained consistent ordering of discovered templates.

* **Chores**
  * Removed an unnecessary development dependency.
  * Simplified internal file-matching configuration without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->