### PR TITLE
fix(sv): caching bugs

### DIFF
--- a/packages/sv/src/core/fetch-packages.ts
+++ b/packages/sv/src/core/fetch-packages.ts
@@ -90,17 +90,16 @@ type DownloadOptions = { path?: string; pkg: PackageJSON };
  */
 export async function downloadPackage(options: DownloadOptions): Promise<AddonDefinition> {
 	const { pkg } = options;
+
+	// contents is written to `sv/node_modules/pkg-name`
+	// so that we can dynamically import the package via `import(pkg-name)`
 	const dest = path.join(NODE_MODULES, pkg.name.split('/').join(path.sep));
 
-	// ensures that a new symlink/copy/extract always starts from a clean slate,
-	// so a stale `file:` symlink is never written through by the tarball extraction
+	// prevent old symlinks and caches from causing a stale install
 	fs.rmSync(dest, { recursive: true, force: true });
 
-	// The package lives in a local directory,
-	// so we link it into the cache instead of downloading a tarball
 	if (options.path) {
-		// we'll create a symlink so that we can dynamically import the package via `import(pkg-name)`
-		// On Windows, symlinks require admin privileges, so we fall back to copying if symlink fails
+		// local add-on (i.e. `file:...`)
 
 		// `symlinkSync` doesn't recursively create directories to the `destination` path,
 		// so we'll need to create them before creating the symlink
@@ -109,23 +108,23 @@ export async function downloadPackage(options: DownloadOptions): Promise<AddonDe
 			fs.mkdirSync(dir, { recursive: true });
 		}
 
-		// Try to create a symlink, but fall back to copying on Windows if it fails with EPERM
 		try {
 			fs.symlinkSync(options.path, dest, 'dir');
 		} catch (error) {
-			// On Windows, symlinks may fail with EPERM if admin privileges aren't available
-			// In that case, fall back to copying the directory
+			// Windows requires admin privileges for symlinks
 			if (
 				platform() === 'win32' &&
 				common.isNodeError(error) &&
 				(error.code === 'EPERM' || error.code === 'EACCES')
 			) {
+				// fall back to copying the directory
 				copyDirectorySync(options.path, dest);
 			} else {
 				throw error;
 			}
 		}
 	} else {
+		// npm add-on (i.e. @supacool)
 		const tarballUrl = pkg.dist?.tarball;
 		if (!tarballUrl) {
 			throw new Error(`Invalid add-on package: '${pkg.name}' is missing 'dist.tarball'`);
@@ -134,13 +133,11 @@ export async function downloadPackage(options: DownloadOptions): Promise<AddonDe
 		const data = await fetch(tarballUrl);
 		if (!data.body) throw new Error(`Unexpected response: '${tarballUrl}' responded with no body`);
 
-		// extracts the package's contents from the tarball and writes the files to `sv/node_modules/pkg-name`
-		// so that we can dynamically import the package via `import(pkg-name)`
 		await pipeline(
 			data.body,
 			createGunzip(),
 			// file paths from the tarball will always have a `package/` prefix,
-			// so we'll need to replace it with the name of the package
+			// so we'll need to strip that out
 			unpackTar(dest, { strip: 1 })
 		);
 	}

--- a/packages/sv/src/core/fetch-packages.ts
+++ b/packages/sv/src/core/fetch-packages.ts
@@ -125,27 +125,25 @@ export async function downloadPackage(options: DownloadOptions): Promise<AddonDe
 				throw error;
 			}
 		}
+	} else {
+		const tarballUrl = pkg.dist?.tarball;
+		if (!tarballUrl) {
+			throw new Error(`Invalid add-on package: '${pkg.name}' is missing 'dist.tarball'`);
+		}
 
-		return await importAddonCode(pkg.name, pkg.version, pkg.exports);
+		const data = await fetch(tarballUrl);
+		if (!data.body) throw new Error(`Unexpected response: '${tarballUrl}' responded with no body`);
+
+		// extracts the package's contents from the tarball and writes the files to `sv/node_modules/pkg-name`
+		// so that we can dynamically import the package via `import(pkg-name)`
+		await pipeline(
+			data.body,
+			createGunzip(),
+			// file paths from the tarball will always have a `package/` prefix,
+			// so we'll need to replace it with the name of the package
+			unpackTar(dest, { strip: 1 })
+		);
 	}
-
-	const tarballUrl = pkg.dist?.tarball;
-	if (!tarballUrl) {
-		throw new Error(`Invalid add-on package: '${pkg.name}' is missing 'dist.tarball'`);
-	}
-
-	const data = await fetch(tarballUrl);
-	if (!data.body) throw new Error(`Unexpected response: '${tarballUrl}' responded with no body`);
-
-	// extracts the package's contents from the tarball and writes the files to `sv/node_modules/pkg-name`
-	// so that we can dynamically import the package via `import(pkg-name)`
-	await pipeline(
-		data.body,
-		createGunzip(),
-		// file paths from the tarball will always have a `package/` prefix,
-		// so we'll need to replace it with the name of the package
-		unpackTar(dest, { strip: 1 })
-	);
 
 	return await importAddonCode(pkg.name, pkg.version, pkg.exports);
 }

--- a/packages/sv/src/core/fetch-packages.ts
+++ b/packages/sv/src/core/fetch-packages.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { pipeline } from 'node:stream/promises';
 import { createGunzip } from 'node:zlib';
 import { color, coerceVersion, downloadJson } from '@sveltejs/sv-utils';
+import * as packageJson from 'empathic/package';
 import { unpackTar } from 'modern-tar/fs';
 import * as v from 'valibot';
 import pkg from '../../package.json' with { type: 'json' };
@@ -11,8 +12,10 @@ import * as common from './common.ts';
 import { PackageJSONSchema, type PackageJSON } from './common.ts';
 import type { AddonDefinition, AddonReference } from './config.ts';
 
-// path to the `node_modules` directory of `sv`
-const NODE_MODULES = path.resolve(import.meta.dirname, '..', '..', 'node_modules');
+const packageJsonPath = packageJson.up({ cwd: import.meta.dirname });
+if (!packageJsonPath) throw Error('This should not happen');
+/** path to the `node_modules` directory of `sv` */
+const NODE_MODULES = path.join(path.dirname(packageJsonPath), 'node_modules');
 
 type PackageBlocklist = { npm_names: string[] };
 
@@ -87,15 +90,17 @@ type DownloadOptions = { path?: string; pkg: PackageJSON };
  */
 export async function downloadPackage(options: DownloadOptions): Promise<AddonDefinition> {
 	const { pkg } = options;
+	const dest = path.join(NODE_MODULES, pkg.name.split('/').join(path.sep));
+
+	// ensures that a new symlink/copy/extract always starts from a clean slate,
+	// so a stale `file:` symlink is never written through by the tarball extraction
+	fs.rmSync(dest, { recursive: true, force: true });
+
+	// The package lives in a local directory,
+	// so we link it into the cache instead of downloading a tarball
 	if (options.path) {
 		// we'll create a symlink so that we can dynamically import the package via `import(pkg-name)`
 		// On Windows, symlinks require admin privileges, so we fall back to copying if symlink fails
-		const dest = path.join(NODE_MODULES, pkg.name.split('/').join(path.sep));
-
-		// ensures that a new symlink/copy is always created
-		if (fs.existsSync(dest)) {
-			fs.rmSync(dest, { recursive: true });
-		}
 
 		// `symlinkSync` doesn't recursively create directories to the `destination` path,
 		// so we'll need to create them before creating the symlink
@@ -139,7 +144,7 @@ export async function downloadPackage(options: DownloadOptions): Promise<AddonDe
 		createGunzip(),
 		// file paths from the tarball will always have a `package/` prefix,
 		// so we'll need to replace it with the name of the package
-		unpackTar(path.join(NODE_MODULES, pkg.name), { strip: 1 })
+		unpackTar(dest, { strip: 1 })
 	);
 
 	return await importAddonCode(pkg.name, pkg.version, pkg.exports);

--- a/packages/sv/src/core/tests/fetch-packages.ts
+++ b/packages/sv/src/core/tests/fetch-packages.ts
@@ -1,8 +1,12 @@
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
+import { buffer } from 'node:stream/consumers';
 import { fileURLToPath } from 'node:url';
-import { afterAll, describe, expect, it } from 'vitest';
-import { hasSvExport, importAddonCode } from '../fetch-packages.ts';
+import { gzipSync } from 'node:zlib';
+import { packTar } from 'modern-tar/fs';
+import { afterAll, describe, expect, it, vi } from 'vitest';
+import { downloadPackage, hasSvExport, importAddonCode } from '../fetch-packages.ts';
 
 // add-ons are imported by bare specifier, so fixtures have to live where `sv` resolves from
 const NODE_MODULES = fileURLToPath(new URL('../../../node_modules', import.meta.url));
@@ -152,5 +156,43 @@ describe('importAddonCode', () => {
 		await expect(importAddonCode(name, '1.0.0', exports)).rejects.toThrow(
 			expect.objectContaining({ message: expect.not.stringMatching(/-\s*\n/) })
 		);
+	});
+});
+
+describe('downloadPackage', () => {
+	it('replaces a stale `file:` symlink instead of writing through it', async () => {
+		const name = `${PREFIX}${counter++}`;
+		const localDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sv-addon-local-'));
+		const marker = path.join(localDir, 'local-only.txt');
+		fs.writeFileSync(marker, 'do not clobber me');
+		// simulate the symlink left behind by a previous `sv add file:...`
+		fs.symlinkSync(localDir, path.join(NODE_MODULES, name), 'dir');
+
+		const pkgJson = JSON.stringify({
+			name,
+			version: '2.0.0',
+			type: 'module',
+			exports: './index.mjs'
+		});
+		const tarball = await buffer(
+			packTar([
+				{ type: 'content', content: pkgJson, target: 'package/package.json' },
+				{ type: 'content', content: ADDON, target: 'package/index.mjs' }
+			])
+		);
+		vi.stubGlobal('fetch', () => Promise.resolve(new Response(gzipSync(tarball))));
+
+		try {
+			const details = await downloadPackage({
+				pkg: { name, version: '2.0.0', dist: { tarball: `https://registry.test/${name}` } }
+			});
+			expect(details).toMatchObject({ id: 'fixture' });
+			// the symlink must have been replaced by the extracted package, not followed into `localDir`
+			expect(fs.lstatSync(path.join(NODE_MODULES, name)).isSymbolicLink()).toBe(false);
+			expect(fs.readFileSync(marker, 'utf8')).toBe('do not clobber me');
+		} finally {
+			vi.unstubAllGlobals();
+			fs.rmSync(localDir, { recursive: true, force: true });
+		}
 	});
 });


### PR DESCRIPTION
Closes #1312

### Description

Does not address the concurrency issue.

### Checklist

- Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)
- Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable)
- Allow maintainers to edit this PR
- I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved add-on installation so local and npm packages use a consistent destination.
  * Existing destinations are now replaced cleanly before installation.
  * Local packages continue to use symlinks, with a fallback for Windows permission errors.
  * npm packages are downloaded and unpacked correctly before being added.
  * Prevented stale local links from affecting package installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->