### PR TITLE
fix(create): use selected pm in library `build` command

### DIFF
--- a/.changeset/soft-wombats-clean.md
+++ b/.changeset/soft-wombats-clean.md
@@ -1,0 +1,5 @@
+---
+"sv": patch
+---
+
+fix(create): use selected pm in library `build` command

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ Closes #
 
 ### Checklist
 
-- Update [snapshots](../CONTRIBUTING.md#update-snapshots) (if applicable)
-- Add a [changeset](../CONTRIBUTING.md#generating-changelogs) (if applicable)
+- Update [snapshots](https://github.com/sveltejs/cli/blob/main/CONTRIBUTING.md#update-snapshots) (if applicable)
+- Add a [changeset](https://github.com/sveltejs/cli/blob/main/CONTRIBUTING.md#generating-changelogs) (if applicable)
 - Allow maintainers to edit this PR
 - I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)

--- a/packages/sv/src/cli/create.ts
+++ b/packages/sv/src/cli/create.ts
@@ -352,6 +352,10 @@ export async function createProject(cwd: ProjectPath, options: Options) {
 
 	if (packageManager) {
 		workspace.packageManager = packageManager;
+
+		if (template === 'library') {
+			common.updateLibraryBuild(projectPath, packageManager);
+		}
 	}
 
 	let argsFormattedAddons: string[] = [];

--- a/packages/sv/src/core/common.ts
+++ b/packages/sv/src/core/common.ts
@@ -293,6 +293,17 @@ export function updateReadme(projectPath: string, command: string) {
 	fs.writeFileSync(readmePath, content);
 }
 
+export function updateLibraryBuild(projectPath: string, packageManager: AgentName): void {
+	const pkgPath = path.join(projectPath, 'package.json');
+	const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+
+	if (pkg.scripts?.build && typeof pkg.scripts.build === 'string') {
+		const prepackCmd = resolveCommandArray(packageManager, 'run', ['prepack']).join(' ');
+		pkg.scripts.build = pkg.scripts.build.replace('npm run prepack', prepackCmd);
+		fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, '\t') + '\n');
+	}
+}
+
 export function errorAndExit(message: string) {
 	const [firstLine, ...restLines] = message.split('\n');
 


### PR DESCRIPTION
Closes #1316

### Description

A quick fix until I rewrite the create command.

### Checklist

- Update [snapshots](./CONTRIBUTING.md#update-snapshots) (if applicable)
- Add a [changeset](./CONTRIBUTING.md#generating-changelogs) (if applicable)
- Allow maintainers to edit this PR
- I care about what I'm doing, no matter the tool I use (Notepad, Sublime, VSCode, AI...)
