### PR TITLE
docs(create): document `--no-download-check` option

### DIFF
--- a/.changeset/tidy-spiders-smile.md
+++ b/.changeset/tidy-spiders-smile.md
@@ -1,5 +1,0 @@
----
-'sv': patch
----
-
-docs(create): document the `--no-download-check` option

--- a/.changeset/tidy-spiders-smile.md
+++ b/.changeset/tidy-spiders-smile.md
@@ -1,0 +1,5 @@
+---
+'sv': patch
+---
+
+docs(create): document the `--no-download-check` option

--- a/documentation/docs/20-commands/10-sv-create.md
+++ b/documentation/docs/20-commands/10-sv-create.md
@@ -57,6 +57,13 @@ npx sv create --add eslint prettier [path]
 
 Run the command without the interactive add-ons prompt
 
+### `--no-download-check`
+
+Do not warn about downloads from community add-ons.
+
+> [!NOTE]
+> Svelte maintainers have not reviewed community add-ons for malicious code! Use at your discretion.
+
 ### `--addon-name <name>`
 
 Specify the package name when creating an addon template. Accepts `@<org>/<pkg>` or `<pkg>`. When omitted, you will be prompted for the name.


### PR DESCRIPTION
The `sv create` command supports `--no-download-check`, but its command documentation omitted the option even though the corresponding `sv add` documentation includes it. Document the flag and its security caveat, and add an `sv` patch changeset.

Closes #1309

Validation: `pnpm lint`
